### PR TITLE
added support for remotely specifiying debugee and re-running targets

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -251,7 +251,10 @@ process execution, display the reason for trigger and the associated context.
 
 ## `gef-remote` debugging ##
 
-It is possible to use `gef` in a remote debugging environment.
+It is possible to use `gef` in a remote debugging environment. Required files
+will be automatically downloaded and cached in a temporary directory (`/tmp/gef` on most
+Unix systems). Remember to manually delete the cache if you change the target file or
+`gef` will use the outdated version.
 
 
 ### With a local copy ###
@@ -288,8 +291,7 @@ It is possible to use `gdb` internal functions to copy our targeted binary.
 
 In the following of our previous, if we want to debug `uname`, run `gdb` and
 connect to our `gdbserver`. To be able to locate the right process in the `/proc`
-structure, the command `gef-remote` requires 1 argument, `-t` to provide the
-target host and port.
+structure, the command `gef-remote` requires 1 argument, the target host and port.
 The option `-p` must be provided and indicate the process PID on the remote
 host, only if the extended mode (`-E`) is being used.
 

--- a/gef.py
+++ b/gef.py
@@ -1505,7 +1505,7 @@ def get_process_maps():
         pid = get_pid()
         proc = "/proc/%d/maps" % pid
 
-        f = open_file(proc, use_cache=True)
+        f = open_file(proc, use_cache=False)
         while True:
             line = f.readline()
             if len(line) == 0:

--- a/gef.py
+++ b/gef.py
@@ -1431,15 +1431,58 @@ def get_sp():
 
 
 def get_pid():
-    if "gef-remote.pid" in __config__.keys():
-        return __config__.get("gef-remote.pid")[0]
     return get_frame().pid
 
 
 def get_filepath():
-    if "gef-remote.filename" in __config__.keys():
-        return __config__.get("gef-remote.filename")[0]
-    return gdb.current_progspace().filename
+    filename = gdb.current_progspace().filename
+
+    if is_remote_debug():
+
+        # if no filename specified, try downloading target from /proc
+        if filename == None:
+            pid = get_frame().pid
+
+            if pid > 0:
+                return download_file("/proc/%d/exe" % pid, use_cache=True)
+            else:
+                return None
+
+        # if target is remote file, download
+        elif filename.startswith("target:"):
+            return download_file(filename[len("target:"):], use_cache=True)
+        else:
+            return filename
+    else:
+        return filename
+
+
+def download_file(target, use_cache=False):
+    """Download filename `target` inside the mirror tree in /tmp"""
+    try:
+        local_root = '{0:s}/gef'.format(tempfile.gettempdir())
+        local_path = local_root + '/' + os.path.dirname( target )
+        local_name = local_path + '/' + os.path.basename( target )
+        if use_cache and os.path.isfile(local_name):
+            return local_name
+        gef_makedirs(local_path)
+        gdb.execute("remote get {0:s} {1:s}".format(target, local_name))
+    except Exception as e:
+        err(str(e))
+        local_name = None
+    return local_name
+
+
+def open_file(path, use_cache=False):
+    """Attempt to open the given file, if remote debugging is active, download
+    it first to the mirror in /tmp/"""
+    if is_remote_debug():
+        lpath = download_file(path, use_cache)
+        if not lpath:
+            raise IOError("cannot open remote path %s" % path)
+        return open(lpath)
+    else:
+        return open(path)
 
 
 def get_filename():
@@ -1460,8 +1503,9 @@ def get_process_maps():
 
     try:
         pid = get_pid()
-        proc = __config__.get("gef-remote.proc_directory")[0]
-        f = open('%s/%d/maps' % (proc, pid))
+        proc = "/proc/%d/maps" % pid
+
+        f = open_file(proc, use_cache=True)
         while True:
             line = f.readline()
             if len(line) == 0:
@@ -1920,9 +1964,10 @@ def endian_str():
         return "<" # LE
     return ">" # BE
 
+
 @memoize
 def is_remote_debug():
-    return "gef-remote.target" in __config__.keys()
+    return "remote" in gdb.execute("maintenance print target-stack", to_string=True)
 
 
 def de_bruijn(alphabet, n):
@@ -3245,21 +3290,21 @@ class RemoteCommand(GenericCommand):
 
     def __init__(self):
         super(RemoteCommand, self).__init__(prefix=False)
-        self.add_setting("proc_directory", "/proc")
+        self.handler_connected = False
         return
 
     def do_invoke(self, argv):
         target = None
         rpid = -1
         update_solib = False
-        download_all_libs = False
+        self.download_all_libs = False
         download_lib = None
         is_extended_remote = False
         opts, args = getopt.getopt(argv, "p:UD:AEh")
         for o,a in opts:
             if   o == "-U":   update_solib = True
             elif o == "-D":   download_lib = a
-            elif o == "-A":   download_all_libs = True
+            elif o == "-A":   self.download_all_libs = True
             elif o == "-E":   is_extended_remote = True
             elif o == "-p":   rpid = int(a)
             elif o == "-h":
@@ -3273,6 +3318,11 @@ class RemoteCommand(GenericCommand):
         if is_extended_remote and rpid < 0:
             err("A PID must be provided (-p <PID>) when using remote-extended mode")
             return
+
+        # lazily install handler on first use
+        if not self.handler_connected:
+            gdb.events.new_objfile.connect(self.new_objfile_handler)
+            self.handler_connected = True
 
         target = args[0]
 
@@ -3296,12 +3346,12 @@ class RemoteCommand(GenericCommand):
             warn("No remote session active.")
             return
 
-        if download_all_libs == True:
+        if self.download_all_libs == True:
             vmmap = get_process_maps()
             success = 0
             for sect in vmmap:
                 if sect.path.startswith("/"):
-                    _file = self.download_file(rpid, sect.path)
+                    _file = download_file(sect.path)
                     if _file is None:
                         err("Failed to download %s" % sect.path)
                     else:
@@ -3310,7 +3360,7 @@ class RemoteCommand(GenericCommand):
             ok("Downloaded %d files" % success)
 
         elif download_lib is not None:
-            _file = self.download_file(rpid, download_lib)
+            _file = download_file(download_lib)
             if _file is None:
                 err("Failed to download remote file")
                 return
@@ -3322,6 +3372,17 @@ class RemoteCommand(GenericCommand):
 
         return
 
+    def new_objfile_handler(self, event):
+        """Hook that handles new_objfile events, will update remote environment accordingly"""
+        if not is_remote_debug():
+            return
+
+        # download newly loaded libraries
+        if self.download_all_libs and event.new_objfile.filename.startswith("target:"):
+            lib = event.new_objfile.filename[len("target:"):]
+            llib = download_file(lib, use_cache=True)
+            if llib:
+                ok("Download success: %s %s %s" % (lib, right_arrow(), llib))
 
     def setup_remote_environment(self, pid, update_solib=False):
         """Clone the remote environment locally in the temporary directory.
@@ -3342,17 +3403,13 @@ class RemoteCommand(GenericCommand):
             err("Source binary is not readable")
             return
 
-        directory  = '%s/gef/%d' % (tempfile.gettempdir(), pid)
+        directory  = '%s/gef' % (tempfile.gettempdir())
         gdb.execute("file %s" % infos["exe"])
 
         self.add_setting("root", directory)
-        self.add_setting("proc_directory", directory + '/proc')
-        self.add_setting("pid", pid)
-        self.add_setting("filename", infos["exe"])
 
-        ok("Remote information loaded, remember to clean '%s' when your session is over" % directory)
+        ok("Remote information loaded, remember to clean '%s' when your session is over" % tempfile.gettempdir())
         return
-
 
     def connect_target(self, target, is_extended_remote):
         """Connect to remote target and get symbols. To prevent `gef` from requesting information
@@ -3370,24 +3427,10 @@ class RemoteCommand(GenericCommand):
         return ret
 
 
-    def download_file(self, pid, target):
-        """Download filename `target` inside the mirror tree in /tmp"""
-        try:
-            local_root = '{0:s}/gef/{1:d}'.format(tempfile.gettempdir(), pid)
-            local_path = local_root + '/' + os.path.dirname( target.replace("target:", "") )
-            local_name = local_path + '/' + os.path.basename( target )
-            gef_makedirs(local_path)
-            gdb.execute("remote get {0:s} {1:s}".format(target, local_name))
-        except Exception as e:
-            err(str(e))
-            local_name = None
-        return local_name
-
-
     def load_target_proc(self, pid, info):
         """Download one item from /proc/pid"""
         remote_name = "/proc/{:d}/{:s}".format(pid, info)
-        return self.download_file(pid, remote_name)
+        return download_file(remote_name)
 
 
     def refresh_shared_library_path(self):
@@ -4278,8 +4321,7 @@ class FileDescriptorCommand(GenericCommand):
             return
 
         pid = get_pid()
-        proc = __config__.get("gef-remote.proc_directory")[0]
-        path = "%s/%d/fd" % (proc, pid)
+        path = "/proc/%d/fd" % (pid)
 
         for fname in os.listdir(path):
             fullpath = path+"/"+fname


### PR DESCRIPTION
Hi, I've added a new option to gef-remote so you can tell the gdbserver which executable you want to run. Additionally this patch allows you to restart processes and specify arguments (when you are connected in extended-remote mode).

Example (server started with `gdbserver --multi 0.0.0.0:1337`):
```
gef➤  gef-remote -f /bin/ls 10.0.0.83:1337
[+] Connected to '10.0.0.83:1337'
Reading /bin/ls from remote target...
warning: File transfers from remote targets can be slow. Use "set sysroot" to access files locally instead.
Reading /bin/ls from remote target...
[+] Target is not running, waiting for start
gef➤  run "/proc"
`target:/bin/ls' has disappeared; keeping its symbols.
Starting program: target:/bin/ls "/proc"
Reading /lib/ld-linux.so.2 from remote target...
Reading /lib/ld-linux.so.2 from remote target...
Reading /lib/ld-2.11.2.so from remote target...
Reading /lib/.debug/ld-2.11.2.so from remote target...
[+] Targeting PID=3742
[+] Downloading remote information
[+] Remote information loaded, remember to clean '/tmp/gef/3742' when your session is over
Reading /lib/libselinux.so.1 from remote target...
Reading /lib/librt.so.1 from remote target...
Reading /lib/libacl.so.1 from remote target...
Reading /lib/libc.so.6 from remote target...
Reading /lib/libdl.so.2 from remote target...
Reading /lib/libpthread.so.0 from remote target...
Reading /lib/libattr.so.1 from remote target...
Reading /lib/librt-2.11.2.so from remote target...
Reading /lib/.debug/librt-2.11.2.so from remote target...
Reading /lib/libc-2.11.2.so from remote target...
Reading /lib/.debug/libc-2.11.2.so from remote target...
Reading /lib/libdl-2.11.2.so from remote target...
Reading /lib/.debug/libdl-2.11.2.so from remote target...
Reading /lib/libpthread-2.11.2.so from remote target...
Reading /lib/.debug/libpthread-2.11.2.so from remote target...
[Inferior 1 (process 3742) exited normally]
[*] No debugging session active
```

And (`gdbserver 0.0.0.0:1337 /bin/ls`):
```
gef➤  gef-remote -E 10.0.0.83:1337
warning: Could not load vsyscall page because no executable was specified
try using the "file" command first.
0xb7fe3850 in ?? ()
[+] Connected to '10.0.0.83:1337'
[+] Targeting PID=3747
[+] Downloading remote information
[+] Remote information loaded, remember to clean '/tmp/gef/3747' when your session is over
gef➤  r
Starting program:  
warning: Could not load vsyscall page because no executable was specified
try using the "file" command first.
[+] Targeting PID=3750
[+] Downloading remote information
[+] Remote information loaded, remember to clean '/tmp/gef/3750' when your session is over
[Inferior 1 (process 3750) exited normally]
[*] No debugging session active
```
This works by adding a hook to gdb that downloads the remote info each time "continue" is executed and the PID has changed since the last time.

One thing I had to change to make this work is that in extended-remote mode, `setup_remote_environment` no longer uses the `file` command on the local, downloaded file because then the next `run` would start  the local file instead of the remote one. I hope this doesn't break anything in the other commands.