### PR TITLE
edit-flags: Add toggle feature

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -461,7 +461,7 @@ register flags.
 
 One or many arguments can be provided, following the syntax below:
 ```
-gef> flags [+|-|~]FLAGNAME ([+|-|~]FLAGNAME...)
+gef> flags [(+|-|~)FLAGNAME ...]
 ```
 Where `FLAGNAME` is the name of the flag (case insensitive), and `+|-|~` indicates
 the action on wether to set, unset, or toggle the flag.

--- a/docs/features.md
+++ b/docs/features.md
@@ -461,10 +461,10 @@ register flags.
 
 One or many arguments can be provided, following the syntax below:
 ```
-gef> flags [+|-]FLAGNAME ([+|-]FLAGNAME...)
+gef> flags [+|-|~]FLAGNAME ([+|-|~]FLAGNAME...)
 ```
-Where `FLAGNAME` is the name of the flag (case insensitive), and `+|-` indicates
-the action on wether to set the flag or not.
+Where `FLAGNAME` is the name of the flag (case insensitive), and `+|-|~` indicates
+the action on wether to set, unset, or toggle the flag.
 
 For instance, on x86 architecture, if we don't want to take a conditional jump
 (`jz` condition), but we want to have the Carry flag set, simply go with:

--- a/gef.py
+++ b/gef.py
@@ -2745,7 +2745,7 @@ class FlagsCommand(GenericCommand):
     """Edit flags in a human friendly wait"""
 
     _cmdline_ = "edit-flags"
-    _syntax_  = "%s [+|-]FLAGNAME ([+|-]FLAGNAME)*" % _cmdline_
+    _syntax_  = "%s [+|-|~]FLAGNAME ([+|-|~]FLAGNAME)*" % _cmdline_
     _aliases_ = ["flags", ]
 
     def __init__(self):
@@ -2760,7 +2760,7 @@ class FlagsCommand(GenericCommand):
             action = flag[0]
             name = flag[1:].lower()
 
-            if action not in ('+', '-'):
+            if action not in ('+', '-', '~'):
                 err("Invalid action for flag '%s'" % flag)
                 continue
 
@@ -2776,8 +2776,10 @@ class FlagsCommand(GenericCommand):
             old_flag = get_register_ex( flag_register() )
             if action=='+':
                 new_flags = old_flag | (1<<off)
-            else:
+            elif action=='-':
                 new_flags = old_flag & ~(1<<off)
+            else:
+                new_flags = old_flag ^ (1<<off)
 
             gdb.execute("set (%s) = %#x" % (flag_register(), new_flags))
 

--- a/gef.py
+++ b/gef.py
@@ -2742,10 +2742,10 @@ class SearchPatternCommand(GenericCommand):
 
 
 class FlagsCommand(GenericCommand):
-    """Edit flags in a human friendly wait"""
+    """Edit flags in a human friendly way"""
 
     _cmdline_ = "edit-flags"
-    _syntax_  = "%s [+|-|~]FLAGNAME ([+|-|~]FLAGNAME)*" % _cmdline_
+    _syntax_  = "%s [(+|-|~)FLAGNAME ...]" % _cmdline_
     _aliases_ = ["flags", ]
 
     def __init__(self):


### PR DESCRIPTION
This adds a new option to `edit-flags` so you can toggle instead of just set or unset.

This is handy, for example, if you want to alternate which branch you take every time you hit it

```bash
b <x>
commands 1
edit-flags ~ZERO
end
```