### PR TITLE
Fixes prompt not to trigger SIGSEGV on Gentoo

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6248,9 +6248,9 @@ class GefMissingCommand(gdb.Command):
 def __gef_prompt__(current_prompt):
     prompt = "gef> " if PYTHON_MAJOR == 2 else "gef\u27a4  "
     if is_alive():
-        fmt_prompt = "\001\033[1;32m\002{0:s}\001\033[0m\002".format(prompt)
+        fmt_prompt = "\033[1;32m{0:s}\033[0m".format(prompt)
     else:
-        fmt_prompt = "\001\033[1;31m\002{0:s}\001\033[0m\002".format(prompt)
+        fmt_prompt = "\033[1;31m{0:s}\033[0m".format(prompt)
     return fmt_prompt
 
 


### PR DESCRIPTION
Prompt format string caused a segfault on Gentoo in readline (gdb 7.11.1, readline 6.3_p8-r2).
The result is that prompt looks exactly the same as on other systems, but it doesn't crash gdb on Gentoo.