### PR TITLE
Fix table formatting in commands.md

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,28 +22,15 @@ improving it.
 |fd                        | Enumerate file descriptors opened by process.|
 |format-string-helper      | Exploitable format-string helper: this command will set up specific breakpoints at well-known dangerous functions (printf, snprintf, etc.), and check if the pointer holding the format string is writable, and  susceptible to format string attacks if an attacker can control its content. (alias: fmtstr-helper)|
 |gef-alias                 | GEF defined aliases|
-|gef-remote                | gef wrapper for the `target remote` command. This command will automatically|
-                             download the target binary in the local temporary directory (defaut /tmp) and then
-                             source it. Additionally, it will fetch all the /proc/PID/maps and loads all its
-                             information.|
+|gef-remote                | gef wrapper for the `target remote` command. This command will automatically download the target binary in the local temporary directory (defaut /tmp) and then source it. Additionally, it will fetch all the /proc/PID/maps and loads all its information.|
 |heap                      | Base command to get information about the Glibc heap structure.|
 |hexdump                   | Display arranged hexdump (according to architecture endianness) of memory range.|
 |hijack-fd                 | ChangeFdCommand: redirect file descriptor during runtime.|
-|ida-interact              | IDA Interact: set of commands to interact with IDA via a XML RPC service
-                             deployed via the IDA script `ida_gef.py`. It should be noted that this command
-                             can also be used to interact with Binary Ninja (using the script `binja_gef.py`)
-                             using the same interface. (alias: binaryninja-interact, bn, binja)|
+|ida-interact              | IDA Interact: set of commands to interact with IDA via a XML RPC service deployed via the IDA script `ida_gef.py`. It should be noted that this command can also be used to interact with Binary Ninja (using the script `binja_gef.py`) using the same interface. (alias: binaryninja-interact, bn, binja)|
 |ksymaddr                  | Solve kernel symbols from kallsyms table.|
 |nop                       | Patch the instruction pointed by parameters with NOP. If the return option is specified, it will set the return register to the specific value.|
-|pattern                   | This command will create or search a De Bruijn cyclic pattern to facilitate
-                             determining the offset in memory. The algorithm used is the same as the one
-                             used by pwntools, and can therefore be used in conjunction.|
-|pcustom                   | Dump user defined structure.
-                             This command attempts to reproduce WinDBG awesome `dt` command for GDB and allows
-                             to apply structures (from symbols or custom) directly to an address.
-                             Custom structures can be defined in pure Python using ctypes, and should be stored
-                             in a specific directory, whose path must be stored in the `pcustom.struct_path`
-                             configuration setting. (alias: dt)|
+|pattern                   | This command will create or search a De Bruijn cyclic pattern to facilitate determining the offset in memory. The algorithm used is the same as the one used by pwntools, and can therefore be used in conjunction.|
+|pcustom                   | Dump user defined structure. This command attempts to reproduce WinDBG awesome `dt` command for GDB and allows to apply structures (from symbols or custom) directly to an address. Custom structures can be defined in pure Python using ctypes, and should be stored in a specific directory, whose path must be stored in the `pcustom.struct_path` configuration setting. (alias: dt)|
 |pid                       | ProcessIdCommand: print the process id of the process being debugged.|
 |process-search            | List and filter process. (alias: ps)|
 |registers                 | Display full details on one, many or all registers value from current architecture.|
@@ -55,9 +42,7 @@ improving it.
 |set-permission            | Change a page permission. By default, it will change it to RWX. (alias: mprotect)|
 |shellcode                 | ShellcodeCommand uses @JonathanSalwan simple-yet-awesome shellcode API to download shellcodes.|
 |trace-run                 | Create a runtime trace of all instructions executed from $pc to LOCATION specified.|
-|unicorn-emulate           | Use Unicorn-Engine to emulate the behavior of the binary, without affecting the GDB runtime.
-                             By default the command will emulate only the next instruction, but location and number of instruction can be
-                             changed via arguments to the command line. By default, it will emulate the next instruction from current PC. (alias: emulate)|
+|unicorn-emulate           | Use Unicorn-Engine to emulate the behavior of the binary, without affecting the GDB runtime. By default the command will emulate only the next instruction, but location and number of instruction can be changed via arguments to the command line. By default, it will emulate the next instruction from current PC. (alias: emulate)|
 |vmmap                     | Display virtual memory mapping|
 |xfiles                    | Shows all libraries (and sections) loaded by binary (Truth is out there).|
 |xinfo                     | Get virtual section information for specific address|


### PR DESCRIPTION
Fixed the broken table in `commands.md` caused by having line breaks on some rows. Unfortunately this lead to some pretty long lines in places which makes the Markdown fairly ugly but I couldn't find a workaround for this. At least the table is readable now :)

Relates to: https://github.com/hugsy/gef/issues/86