### PR TITLE
Fix bad format string in heap dump 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,22 +8,23 @@ and reverse-engineers, to
 provides additional features to GDB using the Python API to assist during the
 process of dynamic analysis and exploit development.
 
-`GEF` fully relies on GDB API and other Linux specific source of information
-(such as `/proc/pid`). As a consequence, some of the features might not work on
-custom or harden systems such as GrSec.
-It has full support for Python2 and Python3 indifferently (as more and more
-distro start pushing `gdb` compiled with Python3 support).
+`GEF` fully relies on GDB API and other Linux-specific sources of information
+(such as `/proc/<pid>`). As a consequence, some of the features might not work on
+custom or hardened systems such as GrSec.
+
+It has full support for both Python2 and Python3 indifferently (as more and more
+distros start pushing `gdb` compiled with Python3 support).
 
 ![gef-context](https://i.imgur.com/Fl8yuiO.png)
 
 *Some* of `GEF` features include:
 
   * **One** single GDB script.
-  * **No** dependencies, `GEF` is battery-included and is litterally installable
+  * **No** dependencies, `GEF` is battery-included and is literally installable
     within 5 seconds.
   * Provides more than **50** commands to drastically change your experience in
     GDB.
-  * Works indifferently on Python 2 or 3 engine.
+  * Works consistently on both Python2 and Python3.
   * Built around an architecture abstraction layer, so all commands work in any
     GDB-supported architecture (x86-32/64, ARMv5/6/7, AARCH64, SPARC, MIPS,
     PowerPC, etc.).
@@ -34,7 +35,8 @@ distro start pushing `gdb` compiled with Python3 support).
 ### Install ###
 
 Simply make sure you have [GDB 7.x+](https://www.gnu.org/s/gdb).
-``` bash
+
+```bash
 # via the install script
 $ wget -q -O- https://github.com/hugsy/gef/raw/master/gef.sh | sh
 
@@ -44,17 +46,21 @@ $ echo source ~/.gdbinit-gef.py >> ~/.gdbinit
 ```
 
 Then just start playing (for local files):
+
 ```bash
 $ gdb -q /path/to/my/bin
 gef➤  gef help
 ```
 
 Or (for remote debugging):
+
 ```bash
 remote:~ $ gdbserver 0.0.0.0:1234 /path/to/file
 Running as PID: 666
 ```
+
 And:
+
 ```bash
 local:~ $ gdb -q
 gef➤  gef-remote -t your.ip.address:1234 -p 666
@@ -62,13 +68,10 @@ gef➤  gef-remote -t your.ip.address:1234 -p 666
 
 ### Update ###
 
-If your host/VM is connected to Internet, you can update `gef` easily to the latest version (even without `git` installed)
-```bash
-$ python /path/to/gef.py --update
-Updated
-```
+If your host/VM is connected to the Internet, you can update `gef` easily to the latest version (even without `git` installed). with `python /path/to/gef.py --update`
 
-For example,
+For example:
+
 ```bash
 $ python ~/.gdbinit-gef.py --update
 Updated
@@ -173,33 +176,32 @@ $ pip[23] install ropgadget ropper capstone
 
 ## But why not PEDA? ##
 
-Yes ! Why not ?! [PEDA](https://github.com/longld/peda) is a fantastic tool to
-do the same, but is **only** to be used for x86-32 or x86-64. Whereas
-`GEF` supports all the architecture supported by `GDB` (currently x86, ARM,
-AARCH64, MIPS, PowerPC, SPARC) but is designed to integrate new architectures
-very easily as well!
-
+Yes! Why not?! [PEDA](https://github.com/longld/peda) is a fantastic tool to
+do the same, but **only** works for x86-32 or x86-64x whereas `GEF` supports
+all the architecture supported by `GDB` (currently x86, ARM, AARCH64, MIPS,
+PowerPC, SPARC) but is designed to integrate new architectures very easily as
+well!
 
 
 ## Bugs & Feedbacks ##
 
-To discuss `gef`, `gdb`, exploitation or other topic, feel free to join the
-channel `##gef` on Freenode IRC network. You can also to me (`hugsy`) via the
+To discuss `gef`, `gdb`, exploitation or other topics, feel free to join the
+`##gef` channel on the Freenode IRC network. You can also to me (`hugsy`) via the
 channel. For those who do not have an IRC client (like `weechat` or `irssi`),
 simply [click here](https://webchat.freenode.net/?channels=##gef).
 
 For bugs or feature requests, just
-go [here](https://github.com/hugsy/gef/issues) and provide thorough description
+go [here](https://github.com/hugsy/gef/issues) and provide a thorough description
 if you want help.
 
 
 ## Contribution ##
 
-`gef` was created and maintained by
-myself, [`@_hugsy_`](https://twitter.com/_hugsy_), but kept fresh thanks to [all
+`gef` was created and maintained by myself,
+[`@_hugsy_`](https://twitter.com/_hugsy_), but kept fresh thanks to [all
 the contributors](https://github.com/hugsy/gef/graphs/contributors).
 
-Or if you just like the tool, feel free to drop a simple *Thanks* on IRC,
+Or if you just like the tool, feel free to drop a simple *"thanks"* on IRC,
 Twitter or other, it is **always** very appreciated.
 
 
@@ -213,15 +215,15 @@ better.
 
 The rule is simple, provide a (substantial) contribution to `GEF`, such as:
 
-   1. Submitting a Pull-Request for a new feature/command
-   1. Submitting a Pull-Request for a new architecture support
-   1. Or sending a relevant issue request (like a bug, crash, or else)
+   1. Submitting a Pull-Request for a new feature/command.
+   1. Submitting a Pull-Request for a new architecture support.
+   1. Or sending a relevant issue request (like a bug, crash, or else).
 
 Poke me on the IRC `##gef` channel about it, and next time we meet in person
 (like at a conference), I'll be happy to pay you a beer.
 
-I do also accept beers if you think that the tool is cool :wink:
+I do also accept beers if you think that the tool is cool! :wink:
 
 Cheers :beers:
 
-# Happy hacking #
+# Happy Hacking #

--- a/gef.py
+++ b/gef.py
@@ -478,14 +478,14 @@ class GlibcArena:
 
     def fastbin(self, i):
         addr = self.deref_as_long(self.fastbinsY[i])
-        if addr == 0x00:
+        if addr == 0:
             return None
-        return GlibcChunk(addr+2*self.__arch)
+        return GlibcChunk(addr + 2*self.__arch)
 
     def bin(self, i):
         idx = i * 2
         fd = self.deref_as_long(self.bins[idx])
-        bw = self.deref_as_long(self.bins[idx+1])
+        bw = self.deref_as_long(self.bins[idx + 1])
         return (fd, bw)
 
     def get_next(self):
@@ -517,7 +517,7 @@ class GlibcArena:
 
 
 class GlibcChunk:
-    """ Glibc chunk class.
+    """Glibc chunk class.
     Ref:  https://sploitfun.wordpress.com/2015/02/10/understanding-glibc-malloc/"""
 
     def __init__(self, addr, from_base=False):
@@ -542,7 +542,7 @@ class GlibcChunk:
     def get_usable_size(self):
         # https://github.com/sploitfun/lsploits/blob/master/glibc/malloc/malloc.c#L4537
         cursz = self.get_chunk_size()
-        if cursz == 0x00: return cursz
+        if cursz == 0: return cursz
         if self.has_M_bit(): return cursz - 2*self.arch
         return cursz - self.arch
 
@@ -694,10 +694,10 @@ def _xlog(m, stream, cr=True):
         gdb.flush()
     return 0
 
-def err(msg, cr=True):   return _xlog(Color.colorify("[!]", attrs="bold red")+" "+msg, gdb.STDERR, cr)
-def warn(msg, cr=True):  return _xlog(Color.colorify("[*]", attrs="bold yellow")+" "+msg, gdb.STDLOG, cr)
-def ok(msg, cr=True):    return _xlog(Color.colorify("[+]", attrs="bold green")+" "+msg, gdb.STDLOG, cr)
-def info(msg, cr=True):  return _xlog(Color.colorify("[+]", attrs="bold blue")+" "+msg, gdb.STDLOG, cr)
+def err(msg, cr=True):   return _xlog("{} {}".format(Color.colorify("[!]", attrs="bold red"), msg), gdb.STDERR, cr)
+def warn(msg, cr=True):  return _xlog("{} {}".format(Color.colorify("[*]", attrs="bold yellow"), msg), gdb.STDLOG, cr)
+def ok(msg, cr=True):    return _xlog("{} {}".format(Color.colorify("[+]", attrs="bold green"), msg), gdb.STDLOG, cr)
+def info(msg, cr=True):  return _xlog("{} {}".format(Color.colorify("[+]", attrs="bold blue"), msg), gdb.STDLOG, cr)
 
 def show_exception():
     exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -4040,11 +4040,11 @@ class GlibcHeapBinsCommand(GenericCommand):
         return
 
     @staticmethod
-    def pprint_bin(arena_addr, bin_idx):
+    def pprint_bin(arena_addr, index):
         arena = GlibcArena(arena_addr)
-        fw, bk = arena.bin(bin_idx)
+        fw, bk = arena.bin(index)
 
-        ok("Found base for bin({:d}): fw={:#x}, bk={:#x}".format(bin_idx, fw, bk))
+        ok("Found base for bin({:d}): fw={:#x}, bk={:#x}".format(index, fw, bk))
         if bk == fw and ((int(arena)&~0xFFFF) == (bk&~0xFFFF)):
             ok("Empty")
             return

--- a/gef.py
+++ b/gef.py
@@ -4081,26 +4081,26 @@ class GlibcHeapFastbinsYCommand(GenericCommand):
 
         print(titlify("Fastbins for arena {:#x}".format(int(arena))))
         for i in range(10):
-            m = "Fastbin[{:d}] ".format(i)
+            print("Fastbin[{:d}] ".format(i), end="")
             # https://github.com/sploitfun/lsploits/blob/master/glibc/malloc/malloc.c#L1680
             chunk = arena.fastbin(i)
 
             while True:
                 if chunk is None:
-                    m+= "0x00"
+                    print("0x00", end="")
                     break
 
+                print("{:s}  {:s}  ".format(right_arrow, str(chunk)), end="")
                 try:
-                    m+= "{:s}  {:s}  ".format(right_arrow, str(chunk))
                     next_chunk = chunk.get_fwd_ptr()
-                    if next_chunk == 0x00:
+                    if next_chunk == 0:
                         break
 
                     chunk = GlibcChunk(next_chunk, from_base=True)
                 except gdb.MemoryError:
                     break
+            print()
 
-            print(m)
         return
 
 class GlibcHeapUnsortedBinsCommand(GenericCommand):

--- a/gef.py
+++ b/gef.py
@@ -3984,7 +3984,7 @@ class GlibcHeapArenaCommand(GenericCommand):
             return
 
         while True:
-            print("{:s}".format(arena,))
+            print("{}".format(arena))
             arena = arena.get_next()
             if arena is None:
                 break
@@ -4036,7 +4036,7 @@ class GlibcHeapBinsCommand(GenericCommand):
             self.usage()
             return
 
-        gdb.execute("heap bins {:s}".format(bin_t))
+        gdb.execute("heap bins {}".format(bin_t))
         return
 
     @staticmethod
@@ -4064,7 +4064,7 @@ class GlibcHeapFastbinsYCommand(GenericCommand):
     See https://github.com/sploitfun/lsploits/blob/master/glibc/malloc/malloc.c#L1123"""
 
     _cmdline_ = "heap bins fast"
-    _syntax_  = "{:s} [ARENA_LOCATION]".format(_cmdline_)
+    _syntax_  = "{:s} [ARENA_ADDRESS]".format(_cmdline_)
 
     def __init__(self):
         super(GlibcHeapFastbinsYCommand, self).__init__(complete=gdb.COMPLETE_LOCATION, prefix=False)
@@ -4073,15 +4073,15 @@ class GlibcHeapFastbinsYCommand(GenericCommand):
     @if_gdb_running
     def do_invoke(self, argv):
         main_arena = GlibcHeapCommand.get_main_arena()
-        arena = GlibcArena('*'+argv[0]) if len(argv)==1 else main_arena
+        arena = GlibcArena("*{:s}".format(argv[0])) if len(argv)==1 else main_arena
 
         if arena is None:
             err("Invalid Glibc arena")
             return
 
-        print(titlify("Information on FastBins of arena {:#x}".format(int(arena))))
+        print(titlify("Fastbins for arena {:#x}".format(int(arena))))
         for i in range(10):
-            m = "Fastbin[{:d}] ".format(i,)
+            m = "Fastbin[{:d}] ".format(i)
             # https://github.com/sploitfun/lsploits/blob/master/glibc/malloc/malloc.c#L1680
             chunk = arena.fastbin(i)
 
@@ -4108,7 +4108,7 @@ class GlibcHeapUnsortedBinsCommand(GenericCommand):
     See: https://github.com/sploitfun/lsploits/blob/master/glibc/malloc/malloc.c#L1689"""
 
     _cmdline_ = "heap bins unsorted"
-    _syntax_  = "{:s} [ARENA_LOCATION]".format(_cmdline_)
+    _syntax_  = "{:s} [ARENA_ADDRESS]".format(_cmdline_)
 
     def __init__(self):
         super(GlibcHeapUnsortedBinsCommand, self).__init__(complete=gdb.COMPLETE_LOCATION, prefix=False)
@@ -4120,16 +4120,16 @@ class GlibcHeapUnsortedBinsCommand(GenericCommand):
             err("Incorrect Glibc arenas")
             return
 
-        arena_addr = "*{:#x}".format(int(argv[0], 16)) if len(argv)==1 else "main_arena"
-        print(titlify("Information on Unsorted Bin of arena '{:s}'".format(arena_addr)))
+        arena_addr = "*{:s}".format(argv[0]) if len(argv)==1 else "main_arena"
+        print(titlify("Unsorted Bin for arena '{:s}'".format(arena_addr)))
         GlibcHeapBinsCommand.pprint_bin(arena_addr, 0)
         return
 
 class GlibcHeapSmallBinsCommand(GenericCommand):
-    """Convience command for viewing small bins"""
+    """Convenience command for viewing small bins."""
 
     _cmdline_ = "heap bins small"
-    _syntax_  = "{:s} [ARENA_LOCATION]".format(_cmdline_)
+    _syntax_  = "{:s} [ARENA_ADDRESS]".format(_cmdline_)
 
     def __init__(self):
         super(GlibcHeapSmallBinsCommand, self).__init__(complete=gdb.COMPLETE_LOCATION, prefix=False)
@@ -4141,17 +4141,17 @@ class GlibcHeapSmallBinsCommand(GenericCommand):
             err("Incorrect Glibc arenas")
             return
 
-        arena_addr = "*{:#x}".format(int(argv[0],16)) if len(argv)==1 else "main_arena"
-        print(titlify("Information on Small Bins of arena '{:s}'".format(arena_addr)))
+        arena_addr = "*{:s}".format(argv[0]) if len(argv)==1 else "main_arena"
+        print(titlify("Small Bins for arena '{:s}'".format(arena_addr)))
         for i in range(1, 64):
             GlibcHeapBinsCommand.pprint_bin(arena_addr, i)
         return
 
 class GlibcHeapLargeBinsCommand(GenericCommand):
-    """Convience command for viewing large bins"""
+    """Convenience command for viewing large bins."""
 
     _cmdline_ = "heap bins large"
-    _syntax_  = "{:s} [ARENA_LOCATION]".format(_cmdline_)
+    _syntax_  = "{:s} [ARENA_ADDRESS]".format(_cmdline_)
 
     def __init__(self):
         super(GlibcHeapLargeBinsCommand, self).__init__(complete=gdb.COMPLETE_LOCATION, prefix=False)
@@ -4163,8 +4163,8 @@ class GlibcHeapLargeBinsCommand(GenericCommand):
             err("Incorrect Glibc arenas")
             return
 
-        arena_addr = "*{:#x}".format(int(argv[0],16)) if len(argv)==1 else "main_arena"
-        print(titlify("Information on Large Bins of arena '{:s}'".format(arena_addr)))
+        arena_addr = "*{:s}".format(argv[0]) if len(argv)==1 else "main_arena"
+        print(titlify("Large Bins for arena '{:s}'".format(arena_addr)))
         for i in range(64, 127):
             GlibcHeapBinsCommand.pprint_bin(arena_addr, i)
         return


### PR DESCRIPTION
### Description ###
* Fixes a bug on python3 gdb when printing heap arenas.
* Fixes other format strings that were converting a string to an int only to convert it to a string again.
* Fixes a few typos.
* Improves (imo) some wording in the comments, prints, and README.
* Should have some speed improvements (untested).

### Related Issue ###

https://github.com/hugsy/gef/issues/97

