### PR TITLE
IndentationError: expected an indented block Fix

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -4943,13 +4943,13 @@ class ContextCommand(GenericCommand):
             return
 
         if not current_layout:
-        self.tty_rows, self.tty_columns = get_terminal_size()
-        layout_mapping = {"regs":  self.context_regs,
-                          "stack": self.context_stack,
-                          "code": self.context_code,
-                          "source": self.context_source,
-                          "trace": self.context_trace,
-                          "threads": self.context_threads}
+            self.tty_rows, self.tty_columns = get_terminal_size()
+            layout_mapping = {"regs":  self.context_regs,
+                            "stack": self.context_stack,
+                            "code": self.context_code,
+                            "source": self.context_source,
+                            "trace": self.context_trace,
+                            "threads": self.context_threads}
 
         redirect = self.get_setting("redirect")
         if redirect and os.access(redirect, os.W_OK):


### PR DESCRIPTION
Fixes indentation error at line 4946 which prevents gdb from loading the .gdbinit-gef.py script.
Love the project I use this all the time, I'll buy you beer if we meet up someday.
Cheers!

##IndentationError: expected an indented block Fix ##

### Description ###
Fixes indentation error at line 4946 which prevents gdb from loading the .gdbinit-gef.py script.


### Related Issue ###

https://github.com/hugsy/gef/issues/XX


### Motivation and Context ###

Fixes indentation error currently script does not launch with gdb 7.x
GDB will be able to launch the .gdbinit-gef.py making life hella awesome duh.


### How Has This Been Tested? ###

Has this patch been tested on:
Linux d3d53c 4.4.39-gentoo #1 SMP Mon Jan 16 17:26:37 AST 2017 x86_64 Intel(R) Core(TM) i7-6560U CPU @ 2.20GHz GenuineIntel GNU/Linux

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark:       | rock'n roll            |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_check_mark:       |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_check_mark:       |                        |
| POWERPC      | :heavy_check_mark:       |                        |
| SPARC        | :heavy_multiplication_x: | Who uses SPARC anyway? |


### Screenshots (if applicable) ###

![image](https://cloud.githubusercontent.com/assets/9785864/22129502/cb37fd0c-de7c-11e6-8983-04a7cedf8164.png)




### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
