### PR TITLE
context_code: Work up the hierarchy when dumping symbols

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -5559,7 +5559,9 @@ class ContextCommand(GenericCommand):
 
             if i == line_num:
                 extra_info = self.get_pc_context_info(pc, lines[i])
-                print(Color.colorify("{:4d}\t {:s} \t\t {:s} $pc\t".format(i + 1, lines[i], left_arrow,), attrs="bold red") + extra_info)
+                if extra_info:
+                    print(extra_info)
+                print(Color.colorify("{:4d}\t {:s} \t\t {:s} $pc\t".format(i + 1, lines[i], left_arrow,), attrs="bold red"))
 
             if i > line_num:
                 try:
@@ -5572,7 +5574,7 @@ class ContextCommand(GenericCommand):
         try:
             current_block = gdb.block_for_pc(pc)
             if not current_block.is_valid(): return ""
-            m = []
+            m = collections.OrderedDict()
             for sym in current_block:
                 if not sym.is_function and sym.name in line:
                     key = sym.name
@@ -5590,12 +5592,11 @@ class ContextCommand(GenericCommand):
                     else:
                         continue
 
-                    found = any([k == key for k, v in m])
-                    if not found:
-                        m.append((key, val))
+                    if key not in m:
+                        m[key] = val
 
             if m:
-                return "; " + ", ".join(["{:s}={:s}".format(Color.yellowify(a),b) for a, b in m])
+                return "\t // " + ", ".join(["{:s}={:s}".format(Color.yellowify(a),b) for a, b in m.items()])
         except Exception:
             pass
         return ""

--- a/gef.py
+++ b/gef.py
@@ -5577,8 +5577,8 @@ class ContextCommand(GenericCommand):
             m = collections.OrderedDict()
             while current_block and not current_block.is_static:
                 for sym in current_block:
-                    if not sym.is_function and sym.name in line:
-                        symbol = sym.name
+                    symbol = sym.name
+                    if not sym.is_function and re.search(r"\W{}\W".format(symbol), line):
                         val = gdb.parse_and_eval(symbol)
                         if val.type.code in (gdb.TYPE_CODE_PTR, gdb.TYPE_CODE_ARRAY):
                             addr = long(val.address)


### PR DESCRIPTION

Instead of only looking in the current block for symbols, work up to the static block. This way, you can dump more information.

```bash
─────────────────────────────────[ source:array.c+11 ]────
   7            memset(ar, '\x00', 20);
   8            memset(ar, '\x00', 20);
   9
  10            for (int i = 0; i < 20; i++)
         // i=0x0, ar=0x00007fffffffe490  →  0x00
  11                    printf("%02x ", ar[i]);                   ←  $pc
  12            printf("\n");
  13     }
```

without:
```bash
────────────────────────────────[ source:array.c+11 ]────
   7            memset(ar, '\x00', 20);
   8            memset(ar, '\x00', 20);
   9
  10            for (int i = 0; i < 20; i++)
  11                    printf("%02x ", ar[i]);                   ←  $pc        ; i=0x0
  12            printf("\n");
  13     }
```