### PR TITLE
A few changes

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -5753,17 +5753,17 @@ class ContextCommand(GenericCommand):
                 continue
 
             if i < line_num:
-                print(Color.grayify("{:4d}\t {:s}".format(i + 1, lines[i],)))
+                print(Color.grayify("   {:4d}\t {:s}".format(i + 1, lines[i],)))
 
             if i == line_num:
                 extra_info = self.get_pc_context_info(pc, lines[i])
                 if extra_info:
                     print(extra_info)
-                print(Color.colorify("{:4d}\t {:s} \t\t {:s} $pc\t".format(i + 1, lines[i], left_arrow,), attrs="bold red"))
+                print(Color.colorify("{}{:4d}\t {:s}".format(right_arrow, i + 1, lines[i]), attrs="bold red"))
 
             if i > line_num:
                 try:
-                    print("{:4d}\t {:s}".format(i + 1, lines[i],))
+                    print("   {:4d}\t {:s}".format(i + 1, lines[i],))
                 except IndexError:
                     break
         return
@@ -5796,7 +5796,7 @@ class ContextCommand(GenericCommand):
                 current_block = current_block.superblock
 
             if m:
-                return "\t // " + ", ".join(["{:s}={:s}".format(Color.yellowify(a),b) for a, b in m.items()])
+                return "\t\t// " + ", ".join(["{:s}={:s}".format(Color.yellowify(a),b) for a, b in m.items()])
         except Exception:
             pass
         return ""

--- a/gef.py
+++ b/gef.py
@@ -235,7 +235,6 @@ else:
             def cache_clear(self, caller=None):
                 """Clear a cache."""
                 if caller in self._caches_dict:
-                    del self._caches_dict[caller]
                     self._caches_dict[caller] = collections.OrderedDict()
                 return
 
@@ -440,7 +439,7 @@ class Section:
     def __init__(self, *args, **kwargs):
         attrs = ["page_start", "page_end", "offset", "permission", "inode", "path"]
         for attr in attrs:
-            value = kwargs[attr] if attr in kwargs else None
+            value = kwargs.get(attr)
             setattr(self, attr, value)
         return
 

--- a/gef.py
+++ b/gef.py
@@ -5697,10 +5697,10 @@ class ContextCommand(GenericCommand):
                 text = str(insn)
 
                 if insn.address < pc:
-                    line += Color.grayify(text)
+                    line += Color.grayify("   {}".format(text))
 
                 elif insn.address == pc:
-                    line += Color.colorify("{:s}  {:s}$pc".format(text, left_arrow), attrs="bold red")
+                    line += Color.colorify("{:s}{:s}".format(right_arrow, text), attrs="bold red")
 
                     if current_arch.is_conditional_branch(insn):
                         is_taken, reason = current_arch.is_branch_taken(insn)
@@ -5712,7 +5712,7 @@ class ContextCommand(GenericCommand):
                             line += Color.colorify("\tNOT taken {:s}".format(reason), attrs="bold red")
 
                 else:
-                    line += text
+                    line += "   {}".format(text)
 
                 print("".join(line))
 
@@ -5720,7 +5720,7 @@ class ContextCommand(GenericCommand):
                     target = insn.operands[-1].split()[0]
                     target = int(target, 16)
                     for i, insn in enumerate(gef_disassemble(target, nb_insn, from_top=True)):
-                        text= "{}  {}".format (down_arrow if i==0 else " ", str(insn))
+                        text= "   {}  {}".format (down_arrow if i==0 else " ", str(insn))
                         print(text)
                     break
 

--- a/gef.py
+++ b/gef.py
@@ -5520,6 +5520,7 @@ class ContextCommand(GenericCommand):
         self.add_setting("enable", True, "Enable/disable printing the context when breaking")
         self.add_setting("show_stack_raw", False, "Show the stack pane as raw hexdump (no dereference)")
         self.add_setting("show_registers_raw", True, "Show the registers pane with raw values (no dereference)")
+        self.add_setting("peek_calls", False, "Peek into calls")
         self.add_setting("nb_lines_stack", 8, "Number of line in the stack pane")
         self.add_setting("nb_lines_backtrace", 10, "Number of line in the backtrace pane")
         self.add_setting("nb_lines_code", 5, "Number of instruction before and after $pc")
@@ -5716,6 +5717,8 @@ class ContextCommand(GenericCommand):
                         else:
                             reason = "[Reason: !({:s})]".format(reason) if reason else ""
                             line += Color.colorify("\tNOT taken {:s}".format(reason), attrs="bold red")
+                    elif current_arch.is_call(insn) and self.get_setting("peek_calls") == True:
+                        is_taken = True
 
                 else:
                     line += "   {}".format(text)

--- a/gef.py
+++ b/gef.py
@@ -2147,9 +2147,11 @@ def xor(data, key):
 
 def is_hex(pattern):
     """Return whether provided string is a hexadecimal value."""
-    if not pattern.startswith("0x") and not pattern.startswith("0X"):
+    try:
+        int(pattern, 16)
+    except ValueError:
         return False
-    return len(pattern)%2==0 and all(c in string.hexdigits for c in pattern[2:])
+    return True
 
 
 def ida_synchronize_handler(event):

--- a/gef.py
+++ b/gef.py
@@ -5017,9 +5017,13 @@ class DetailRegistersCommand(GenericCommand):
                 print(line)
                 continue
 
-            addr = align_address(long(reg))
-            line += Color.boldify(format_address(addr))
-            addrs = DereferenceCommand.dereference_from(addr)
+            old_value = ContextCommand.old_registers.get(regname, 0)
+            new_value = align_address(long(reg))
+            if new_value == old_value:
+                line += Color.boldify(format_address(new_value))
+            else:
+                line += Color.colorify(format_address(new_value), attrs="bold red")
+            addrs = DereferenceCommand.dereference_from(new_value)
 
             if len(addrs) > 1:
                 sep = " {:s} ".format(right_arrow)
@@ -5630,7 +5634,7 @@ class ContextCommand(GenericCommand):
             except Exception:
                 new_value = 0
 
-            old_value = self.old_registers[reg] if reg in self.old_registers else 0x00
+            old_value = self.old_registers.get(reg, 0)
 
             line += "{:s}  ".format(Color.greenify(reg))
             if new_value_type_flag:
@@ -5898,12 +5902,13 @@ class ContextCommand(GenericCommand):
         return
 
 
-    def update_registers(self, event):
+    @classmethod
+    def update_registers(cls, event):
         for reg in current_arch.all_registers:
             try:
-                self.old_registers[reg] = get_register(reg)
+                cls.old_registers[reg] = get_register(reg)
             except Exception:
-                self.old_registers[reg] = 0
+                cls.old_registers[reg] = 0
         return
 
 

--- a/gef.py
+++ b/gef.py
@@ -1846,7 +1846,7 @@ def catch_generic_exception(f):
 
 
 def to_unsigned_long(v):
-    """Helper to cast a gdb.Value to unsigned long."""
+    """Cast a gdb.Value to unsigned long."""
     unsigned_long_t = cached_lookup_type("unsigned long")
     return long(v.cast(unsigned_long_t))
 
@@ -1856,6 +1856,8 @@ def get_register(regname):
     regname = regname.strip()
     try:
         value = gdb.parse_and_eval(regname)
+        if value.type.code == gdb.TYPE_CODE_INT:
+           value = to_unsigned_long(value)
         return long(value)
     except gdb.error:
         value = gdb.selected_frame().read_register(regname)


### PR DESCRIPTION
1. Put the current PC arrow on the left
```
───────────────────────────────────[ code:i386 ]────
   0x8048d0a    push 0x804a5c0
   0x8048d0f    push 0x804a520
   0x8048d14    push ecx
   0x8048d15    push esi
   0x8048d16    push 0x8049df0
 → 0x8048d1b    call 0x8049ed0
```

2. Cast registers to unsigned in `get_register`.
- Registers are typed in GDB. eax and esp can both point to the stack, but gdb will consider one signed. This casts it to unsigned. This fixes `telescope` et. al so that it'll properly show other registers pointing to the stack

```
─────────────────────────────────────[ stack ]────
0xffffd600│+0x00: 0x08049df0  →  0x8049df0    lea ecx, [esp+0x4]         ← $esp
0xffffd604│+0x04: 0x01   ← $eax
```

3. Highlights changed registers EVEN in 'un raw' mode
4. Add "peek_code" option to context
```
   0x8048d16    push 0x8049df0
 → 0x8048d1b    call 0x8049ed0
   ↳  0x8049ed0    push ebp
      0x8049ed1    mov eax, 0x0
```