### PR TITLE
Change context_code and context_source arrows to left side + peek code

### DIFF
--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -29,7 +29,7 @@ the order with which contexts will be displayed.
 gef➤ gef config context.layout
 ```
 
-There are currently 6 panes that can be displayed:
+There are currently 6 sections that can be displayed:
 
    * `regs`
    * `stack`
@@ -38,20 +38,20 @@ There are currently 6 panes that can be displayed:
    * `threads`
    * `trace`
 
-To prevent one pane to be displayed, simply use the `context.layout` setting,
-and prepend the pane name with `-` or `!`, such as:
+To prevent one section to be displayed, simply use the `context.layout` setting,
+and prepend the section name with `-` or just omit it.
 
 ```
 gef➤ gef config context.layout "regs stack code -source -threads -trace"
 ```
-Will not display the `source`, `threads`, and `trace` panes.
+Will not display the `source`, `threads`, and `trace` sections.
 
 
 ### Redirecting context output to another tty/file ###
 
 By default, the `gef` context will be displayed on the current TTY. This can be
 overridden by setting `context.redirect` variable to have the context sent to
-another pane.
+another section.
 
 To do so, select the TTY/file/socket/etc. you want the context redirected to
 with `gef config`.
@@ -68,7 +68,7 @@ gef➤ gef config context.redirect /dev/pts/0
 ```
 
 Enjoy:
-![gef-context-redirect-pane](https://i.imgur.com/sWlX37q.png)
+![gef-context-redirect-section](https://i.imgur.com/sWlX37q.png)
 
 
 To go back to normal, remove the value:
@@ -78,22 +78,22 @@ gef➤ gef config context.redirect ""
 
 ### Examples ###
 
-  * Display the code pane first, then register, and stack:
+  * Display the code section first, then register, and stack:
 ```
 gef➤ gef config context.layout "code regs stack -source -threads -trace"
 ```
 
-  * Stop showing the context panes when breaking:
+  * Stop showing the context sections when breaking:
 ```
 gef➤ gef config context.enable 0
 ```
 
-  * Clear the screen before showing the context panes when breaking:
+  * Clear the screen before showing the context sections when breaking:
 ```
 gef➤ gef config context.clear_screen 1
 ```
 
-  * Automatically dereference the registers in the `regs` pane (like `PEDA`):
+  * Automatically dereference the registers in the `regs` section (like `PEDA`):
 ```
 gef➤ gef config context.show_registers_raw 0
 ```

--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -97,3 +97,8 @@ gef➤ gef config context.clear_screen 1
 ```
 gef➤ gef config context.show_registers_raw 0
 ```
+
+  * Don't 'peek' into the start of functions that are called.
+```
+gef➤  gef config context.peek_calls False
+```

--- a/gef.py
+++ b/gef.py
@@ -5753,17 +5753,17 @@ class ContextCommand(GenericCommand):
                 continue
 
             if i < line_num:
-                print(Color.grayify("{:4d}\t {:s}".format(i + 1, lines[i],)))
+                print(Color.grayify("   {:4d}\t {:s}".format(i + 1, lines[i],)))
 
             if i == line_num:
                 extra_info = self.get_pc_context_info(pc, lines[i])
                 if extra_info:
                     print(extra_info)
-                print(Color.colorify("{:4d}\t {:s} \t\t {:s} $pc\t".format(i + 1, lines[i], left_arrow,), attrs="bold red"))
+                print(Color.colorify("{}{:4d}\t {:s}".format(right_arrow, i + 1, lines[i]), attrs="bold red"))
 
             if i > line_num:
                 try:
-                    print("{:4d}\t {:s}".format(i + 1, lines[i],))
+                    print("   {:4d}\t {:s}".format(i + 1, lines[i],))
                 except IndexError:
                     break
         return
@@ -5796,7 +5796,7 @@ class ContextCommand(GenericCommand):
                 current_block = current_block.superblock
 
             if m:
-                return "\t // " + ", ".join(["{:s}={:s}".format(Color.yellowify(a),b) for a, b in m.items()])
+                return "\t\t// " + ", ".join(["{:s}={:s}".format(Color.yellowify(a),b) for a, b in m.items()])
         except Exception:
             pass
         return ""

--- a/gef.py
+++ b/gef.py
@@ -1234,7 +1234,9 @@ class ARM(Architecture):
         return 2 if is_arm_thumb() else 4
 
     def is_call(self, insn):
-        return False
+        mnemo = insn.mnemo
+        call_mnemos = {"bl", "blx"}
+        return mnemo in call_mnemos
 
     def flag_register_to_human(self, val=None):
         # http://www.botskool.com/user-pages/tutorials/electronics/arm-7-tutorial-part-1

--- a/gef.py
+++ b/gef.py
@@ -235,7 +235,6 @@ else:
             def cache_clear(self, caller=None):
                 """Clear a cache."""
                 if caller in self._caches_dict:
-                    del self._caches_dict[caller]
                     self._caches_dict[caller] = collections.OrderedDict()
                 return
 
@@ -440,7 +439,7 @@ class Section:
     def __init__(self, *args, **kwargs):
         attrs = ["page_start", "page_end", "offset", "permission", "inode", "path"]
         for attr in attrs:
-            value = kwargs[attr] if attr in kwargs else None
+            value = kwargs.get(attr)
             setattr(self, attr, value)
         return
 

--- a/gef.py
+++ b/gef.py
@@ -94,6 +94,7 @@ if PYTHON_MAJOR == 2:
 
     # Compat Py2/3 hacks
     range = xrange
+    FileNotFoundError = IOError
 
     left_arrow = "<-"
     right_arrow = "->"
@@ -116,7 +117,6 @@ elif PYTHON_MAJOR == 3:
     # Compat Py2/3 hack
     long = int
     unicode = str
-    FileNotFoundError = IOError
 
     left_arrow = " \u2190 "
     right_arrow = " \u2192 "

--- a/gef.py
+++ b/gef.py
@@ -5568,10 +5568,19 @@ class ContextCommand(GenericCommand):
         if self.get_setting("clear_screen"):
             clear_screen(redirect)
 
-        for pane in current_layout:
-            if pane[0] in ("!", "-"):
+        do_warn = False  # Deprecating "!"
+        for section in current_layout:
+            # Deprecating "!" from the layout syntax
+            if section[0] == "!":
+                do_warn = True
                 continue
-            layout_mapping[pane]()
+            if section[0] == "-":
+                continue
+            layout_mapping[section]()
+
+        # Deprecating "!"
+        if do_warn:
+            warn("context.layout: '!' deprecated: Use '-' before sections to hide them.")
 
         self.context_title("")
 

--- a/gef.py
+++ b/gef.py
@@ -1349,12 +1349,12 @@ class AARCH64(ARM):
                 if (op & 1<<i) == 0: taken, reason = True, "{}&1<<{}==0".format(reg,i)
                 else: taken, reason = False, "{}&1<<{}!=0".format(reg,i)
 
-        if mnemo.endswith("eq"): taken, reason = val&(1<<flags["zero"]), "Z"
-        if mnemo.endswith("ne"): taken, reason = val&(1<<flags["zero"]) == 0, "!Z"
-        if mnemo.endswith("lt"): taken, reason = val&(1<<flags["negative"])!=val&(1<<flags["overflow"]), "N!=O"
-        if mnemo.endswith("le"): taken, reason = val&(1<<flags["zero"]) or val&(1<<flags["negative"])!=val&(1<<flags["overflow"]), "Z || N!=O"
-        if mnemo.endswith("gt"): taken, reason = val&(1<<flags["zero"]) == 0 and val&(1<<flags["negative"]) == val&(1<<flags["overflow"]), "!Z && N==O"
-        if mnemo.endswith("ge"): taken, reason = val&(1<<flags["negative"]) == val&(1<<flags["overflow"]), "N==O"
+        elif mnemo.endswith("eq"): taken, reason = val&(1<<flags["zero"]), "Z"
+        elif mnemo.endswith("ne"): taken, reason = val&(1<<flags["zero"]) == 0, "!Z"
+        elif mnemo.endswith("lt"): taken, reason = val&(1<<flags["negative"])!=val&(1<<flags["overflow"]), "N!=O"
+        elif mnemo.endswith("le"): taken, reason = val&(1<<flags["zero"]) or val&(1<<flags["negative"])!=val&(1<<flags["overflow"]), "Z || N!=O"
+        elif mnemo.endswith("gt"): taken, reason = val&(1<<flags["zero"]) == 0 and val&(1<<flags["negative"]) == val&(1<<flags["overflow"]), "!Z && N==O"
+        elif mnemo.endswith("ge"): taken, reason = val&(1<<flags["negative"]) == val&(1<<flags["overflow"]), "N==O"
         return taken, reason
 
 

--- a/gef.py
+++ b/gef.py
@@ -5697,10 +5697,10 @@ class ContextCommand(GenericCommand):
                 text = str(insn)
 
                 if insn.address < pc:
-                    line += Color.grayify(text)
+                    line += Color.grayify("   {}".format(text))
 
                 elif insn.address == pc:
-                    line += Color.colorify("{:s}  {:s}$pc".format(text, left_arrow), attrs="bold red")
+                    line += Color.colorify("{:s}{:s}".format(right_arrow, text), attrs="bold red")
 
                     if current_arch.is_conditional_branch(insn):
                         is_taken, reason = current_arch.is_branch_taken(insn)
@@ -5712,7 +5712,7 @@ class ContextCommand(GenericCommand):
                             line += Color.colorify("\tNOT taken {:s}".format(reason), attrs="bold red")
 
                 else:
-                    line += text
+                    line += "   {}".format(text)
 
                 print("".join(line))
 
@@ -5720,7 +5720,7 @@ class ContextCommand(GenericCommand):
                     target = insn.operands[-1].split()[0]
                     target = int(target, 16)
                     for i, insn in enumerate(gef_disassemble(target, nb_insn, from_top=True)):
-                        text= "{}  {}".format (down_arrow if i==0 else " ", str(insn))
+                        text= "   {}  {}".format (down_arrow if i==0 else " ", str(insn))
                         print(text)
                     break
 

--- a/gef.py
+++ b/gef.py
@@ -5738,7 +5738,12 @@ class ContextCommand(GenericCommand):
 
                 if is_taken:
                     target = insn.operands[-1].split()[0]
-                    target = int(target, 16)
+                    try:
+                        target = int(target, 16)
+                    except ValueError:
+                        # If the operand isn't an address right now we can't parse it
+                        is_taken = False
+                        continue
                     for i, insn in enumerate(gef_disassemble(target, nb_insn, from_top=True)):
                         text= "   {}  {}".format (down_arrow if i==0 else " ", str(insn))
                         print(text)

--- a/gef.py
+++ b/gef.py
@@ -1302,6 +1302,11 @@ class AARCH64(ARM):
     }
     function_parameters = ["$x0", "$x1", "$x2", "$x3"]
 
+    def is_call(self, insn):
+        mnemo = insn.mnemo
+        call_mnemos = {"bl", "blr"}
+        return mnemo in call_mnemos
+
     def flag_register_to_human(self, val=None):
         # http://events.linuxfoundation.org/sites/events/files/slides/KoreaLinuxForum-2014.pdf
         reg = self.flag_register

--- a/gef.py
+++ b/gef.py
@@ -5521,6 +5521,7 @@ class ContextCommand(GenericCommand):
         self.add_setting("enable", True, "Enable/disable printing the context when breaking")
         self.add_setting("show_stack_raw", False, "Show the stack pane as raw hexdump (no dereference)")
         self.add_setting("show_registers_raw", True, "Show the registers pane with raw values (no dereference)")
+        self.add_setting("peek_calls", False, "Peek into calls")
         self.add_setting("nb_lines_stack", 8, "Number of line in the stack pane")
         self.add_setting("nb_lines_backtrace", 10, "Number of line in the backtrace pane")
         self.add_setting("nb_lines_code", 5, "Number of instruction before and after $pc")
@@ -5717,6 +5718,8 @@ class ContextCommand(GenericCommand):
                         else:
                             reason = "[Reason: !({:s})]".format(reason) if reason else ""
                             line += Color.colorify("\tNOT taken {:s}".format(reason), attrs="bold red")
+                    elif current_arch.is_call(insn) and self.get_setting("peek_calls") == True:
+                        is_taken = True
 
                 else:
                     line += "   {}".format(text)

--- a/gef.py
+++ b/gef.py
@@ -1846,7 +1846,7 @@ def catch_generic_exception(f):
 
 
 def to_unsigned_long(v):
-    """Helper to cast a gdb.Value to unsigned long."""
+    """Cast a gdb.Value to unsigned long."""
     unsigned_long_t = cached_lookup_type("unsigned long")
     return long(v.cast(unsigned_long_t))
 
@@ -1856,7 +1856,10 @@ def get_register(regname):
     regname = regname.strip()
     try:
         value = gdb.parse_and_eval(regname)
-        return long(value)
+        if value.type.code == gdb.TYPE_CODE_INT:
+            return to_unsigned_long(value)
+        else:
+            return long(value)
     except gdb.error:
         value = gdb.selected_frame().read_register(regname)
         return long(value)

--- a/gef.py
+++ b/gef.py
@@ -980,12 +980,12 @@ def gdb_disassemble(start_pc, **kwargs):
 
     for insn in arch.disassemble(start_pc, **kwargs):
         address = insn["addr"]
-        asm = insn["asm"].rstrip()
-        if " " in asm:
-            mnemo, operands = asm.split(None, 1)
+        asm = insn["asm"].rstrip().split(None, 1)
+        if len(asm) > 1:
+            mnemo, operands = asm
             operands = operands.split(",")
         else:
-            mnemo, operands = asm, []
+            mnemo, operands = asm[0], []
 
         loc = gdb_get_location_from_symbol(address)
         location = "<{}+{}>".format(*loc) if loc else ""

--- a/gef.py
+++ b/gef.py
@@ -5585,7 +5585,8 @@ class ContextCommand(GenericCommand):
 
         # Deprecating "!"
         if do_warn:
-            warn("context.layout: '!' deprecated: Use '-' before sections to hide them.")
+            warn("context.layout: '!' deprecated: Use '-' before section names to hide them.")
+            warn("Please fix your config as '!' will not work in a future release")
 
         self.context_title("")
 

--- a/gef.py
+++ b/gef.py
@@ -5018,9 +5018,13 @@ class DetailRegistersCommand(GenericCommand):
                 print(line)
                 continue
 
-            addr = align_address(long(reg))
-            line += Color.boldify(format_address(addr))
-            addrs = DereferenceCommand.dereference_from(addr)
+            old_value = ContextCommand.old_registers.get(regname, 0)
+            new_value = align_address(long(reg))
+            if new_value == old_value:
+                line += Color.boldify(format_address(new_value))
+            else:
+                line += Color.colorify(format_address(new_value), attrs="bold red")
+            addrs = DereferenceCommand.dereference_from(new_value)
 
             if len(addrs) > 1:
                 sep = " {:s} ".format(right_arrow)
@@ -5631,7 +5635,7 @@ class ContextCommand(GenericCommand):
             except Exception:
                 new_value = 0
 
-            old_value = self.old_registers[reg] if reg in self.old_registers else 0x00
+            old_value = self.old_registers.get(reg, 0)
 
             line += "{:s}  ".format(Color.greenify(reg))
             if new_value_type_flag:
@@ -5899,12 +5903,13 @@ class ContextCommand(GenericCommand):
         return
 
 
-    def update_registers(self, event):
+    @classmethod
+    def update_registers(cls, event):
         for reg in current_arch.all_registers:
             try:
-                self.old_registers[reg] = get_register(reg)
+                cls.old_registers[reg] = get_register(reg)
             except Exception:
-                self.old_registers[reg] = 0
+                cls.old_registers[reg] = 0
         return
 
 

--- a/gef.py
+++ b/gef.py
@@ -5520,7 +5520,7 @@ class ContextCommand(GenericCommand):
         self.add_setting("enable", True, "Enable/disable printing the context when breaking")
         self.add_setting("show_stack_raw", False, "Show the stack pane as raw hexdump (no dereference)")
         self.add_setting("show_registers_raw", True, "Show the registers pane with raw values (no dereference)")
-        self.add_setting("peek_calls", False, "Peek into calls")
+        self.add_setting("peek_calls", True, "Peek into calls")
         self.add_setting("nb_lines_stack", 8, "Number of line in the stack pane")
         self.add_setting("nb_lines_backtrace", 10, "Number of line in the backtrace pane")
         self.add_setting("nb_lines_code", 5, "Number of instruction before and after $pc")


### PR DESCRIPTION
* is_hex: EAFP style check
* Minor cleanups
* Context: Add 'peek call' option

    ```
       0x8048d16    push 0x8049df0
     → 0x8048d1b    call 0x8049ed0
       ↳  0x8049ed0    push ebp
          0x8049ed1    mov eax, 0x0
    ```

* Registers: Highlight changed regs
* Cast registers to unsigned in get_register
    GDB types registers, meaning $esp and $eax, for example, can have the
    same value, but evaluate to different values (eax being negative, esp
    always unsigned). This casts the value to an unsigned.

    This fixes DereferenceCommand not showing when other registers point to
    an address.

    ```
    ─────────────────────────────────────[ stack ]────
    0xffffd600│+0x00: 0x08049df0  →  0x8049df0    lea ecx, [esp+0x4]         ← $esp
    0xffffd604│+0x04: 0x01   ← $eax  // Before this would never show
    ```

 * context_source: Put pc arrow on left
 * context_code: Put pc arrow on left
    ```
    ───────────────────────────────────[ code:i386 ]────
       0x8048d0a    push 0x804a5c0
       0x8048d0f    push 0x804a520
       0x8048d14    push ecx
       0x8048d15    push esi
       0x8048d16    push 0x8049df0
     → 0x8048d1b    call 0x8049ed0
    ```

