### PR TITLE
fix wrong error handling when no main_arena found

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -587,6 +587,8 @@ class GlibcArena:
     def __init__(self, addr=None):
         arena = gdb.parse_and_eval(addr)
         malloc_state_t = cached_lookup_type("struct malloc_state")
+        if malloc_state_t is None:
+            raise gdb.error
         self.__arena = arena.cast(malloc_state_t)
         self.__addr = long(arena.address)
         return
@@ -5262,7 +5264,7 @@ class GlibcHeapUnsortedBinsCommand(GenericCommand):
     @only_if_gdb_running
     def do_invoke(self, argv):
         if get_main_arena() is None:
-            err("Incorrect Glibc arenas")
+            err("Incorrect Glibc arenas or arenas not found")
             return
 
         arena_addr = "*{:s}".format(argv[0]) if len(argv) == 1 else "main_arena"
@@ -5286,7 +5288,7 @@ class GlibcHeapSmallBinsCommand(GenericCommand):
     @only_if_gdb_running
     def do_invoke(self, argv):
         if get_main_arena() is None:
-            err("Incorrect Glibc arenas")
+            err("Incorrect Glibc arenas or arenas not found")
             return
 
         arena_addr = "*{:s}".format(argv[0]) if len(argv) == 1 else "main_arena"
@@ -5315,7 +5317,7 @@ class GlibcHeapLargeBinsCommand(GenericCommand):
     @only_if_gdb_running
     def do_invoke(self, argv):
         if get_main_arena() is None:
-            err("Incorrect Glibc arenas")
+            err("Incorrect Glibc arenas or arenas not found")
             return
 
         arena_addr = "*{:s}".format(argv[0]) if len(argv) == 1 else "main_arena"


### PR DESCRIPTION
	modified:   gef.py

## Descriptive title of your patch ##

### Description ###
Just some minor changes to heap command when no symbols found.
the get_main_arena function wants to handle a gdb.error when no symbols(especially malloc_state_t) found, but the GlibcArena class just gives back a None which will cause further calling on None object used as malloc_state_t and caues unwanted exception.

And also did some changes to the error messages since when that happens, it may also be no symbols found instead of incorrect glibc arenas only.

### Types of changes ###

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
