### PR TITLE
gef.py: don't touch SIGALRM

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7975,9 +7975,6 @@ if __name__  == "__main__":
             # we can safely ignore this
             pass
 
-        # SIGALRM will simply display a message, but gdb won't forward the signal to the process
-        gdb.execute("handle SIGALRM print nopass")
-
         # saving GDB indexes in GEF tempdir
         gef_makedirs(GEF_TEMP_DIR)
         gdb.execute("save gdb-index {}".format(GEF_TEMP_DIR))


### PR DESCRIPTION
## Don't Touch SIGALRM ##

### Description ###
Currently, `gef.py` sets the `SIGALRM` handling to **nopass**, which is fatal for applications that rely on `SIGALRM` handling. This patch removes this behaviour.

### Related Issue ###

no related issues


### Motivation and Context ###

In my case: I am using [RIOT](https://github.com/RIOT-OS/RIOT) (an OS for embedded hardware). RIOT is also able to run within a Unix process (native port), so that applications for embedded hardware can be quickly tested, before they are flashed on hardware. RIOT's native port makes use of `SIGALRM` to throw interrupts to emulate hardware timers. After installing `gef`, the native port hangs, because the `SIGALRM` is not passed to the application anymore. I can fix this issue by setting `handle SIGALRM nostop noprint pass` manually before debugging, but that's very inconvenient.

What was the motivation to set `SIGALRM` from within `gef.py` anyways? Maybe I am just missing the bigger picture here .. but is setting `SIGALRM` to **nopass** really necessary here?

### How Has This Been Tested? ###

Has this patch been tested on (example)

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark:       | rock'n roll            |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x:       |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x:       |                        |
| POWERPC      | :heavy_multiplication_x:       |                        |
| SPARC        | :heavy_multiplication_x: | Who uses SPARC anyway? |


### Screenshots (if applicable) ###

<!--- Screenshots make everything better. -->


### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read and agree to the **CONTRIBUTING** document.
