### PR TITLE
Add rudimentary memory context view and mem watch command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,6 +27,7 @@ improve it.
 |hijack-fd                 | ChangeFdCommand: redirect file descriptor during runtime.|
 |ida-interact              | IDA Interact: set of commands to interact with IDA via a XML RPC service deployed via the IDA script `ida_gef.py`. It should be noted that this command can also be used to interact with Binary Ninja (using the script `binja_gef.py`) using the same interface. (alias: binaryninja-interact, bn, binja)|
 |ksymaddr                  | Solve kernel symbols from kallsyms table.|
+|memory                    | Add memory watches to the context view.|
 |nop                       | Patch the instruction pointed by parameters with NOP. If the return option is specified, it will set the return register to the specific value.|
 |patch                     | Write specified values to the specified address.|
 |pattern                   | This command will create or search a De Bruijn cyclic pattern to facilitate determining the offset in memory. The algorithm used is the same as the one used by pwntools, and can therefore be used in conjunction.|

--- a/docs/commands/memory.md
+++ b/docs/commands/memory.md
@@ -1,0 +1,18 @@
+## Command memory ##
+
+As long as the 'memory' section is enabled in your context layout (which it is by default), you can register addresses, lengths, and grouping size.
+
+![memory watch](http://i.imgur.com/NXYwSwW.png)
+
+### Adding a watch
+`memory watch <ADDRESS> [SIZE] [(qword|dword|word|byte)]`
+
+### Removing a watch
+`memory unwatch <ADDRESS>`
+
+### Listing watches
+`memory list`
+
+### Clearing watches
+`memory clear`
+

--- a/gef.py
+++ b/gef.py
@@ -5932,7 +5932,8 @@ class ContextCommand(GenericCommand):
         self.add_setting("nb_lines_code", 5, "Number of instruction before and after $pc")
         self.add_setting("ignore_registers", "", "Space-separated list of registers not to display (e.g. '$cs $ds $gs')")
         self.add_setting("clear_screen", False, "Clear the screen before printing the context")
-        self.add_setting("layout", "regs stack code source threads trace extra", "Change the order/display of the context")
+        self.add_setting("layout", "regs stack code source memory threads trace extra",
+                         "Change the order/presence of the context sections")
         self.add_setting("redirect", "", "Redirect the context information to another TTY")
 
         if "capstone" in list(sys.modules.keys()):


### PR DESCRIPTION
`memory watch ADDRESS [SIZE] [GROUPING]`
`memory unwatch ADDRESS`
`memory list`
`memory clear`

Can be added to your context layout.

```
──────────────────────────────────────────────────────────────────────────────[ stack ]────
0x00007fffffffe560│+0x38: 0x00007fffffffe7a9  →  "USER=vagrant"
────────────────────────────────────────────────────────────────────[ memory:0x620000 ]────
0x0000000000620000     00 00 00 00 00 00 00 00 01 10 02 00 00 00 00 00     ................
0x0000000000620010     0c 24 ad fb 00 00 00 00 00 00 00 00 00 00 00 00     .$..............
0x0000000000620020     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00     ................
0x0000000000620030     00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00     ................
──────────────────────────────────────────────────────────────[ memory:0x7fffffffe528 ]────
0x00007fffffffe528     c9 49 40 00 00 00 00 00 38 e5 ff ff ff 7f 00 00     .I@.....8.......
0x00007fffffffe538     1c 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00     ................
0x00007fffffffe548     90 e7 ff ff ff 7f 00 00 00 00 00 00 00 00 00 00     ................
0x00007fffffffe558     98 e7 ff ff ff 7f 00 00 a9 e7 ff ff ff 7f 00 00     ................
```

Improvements:

1. Size should be total size, not number of units (e.g. size 0x10 with dword prints 6 dwords not 4).
2. ~~There's nothing splitting different watches.~~
3. ~~No way to list watches.~~
4. ~~No way to clear watches.~~
5. Right now I just throw the dict of addresses to watch into the global scope. We should tuck this away somewhere.
6. Doesn't evaluate expressions.
7. Will print the hex dump errors for each watch address that can't be read from.
8. ~~No docs~~