### PR TITLE
Improve hexdump function and commands that use it

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -915,7 +915,7 @@ def hexdump(source, length=0x10, separator=".", show_raw=False, base=0, fmt='byt
         "word": ("H", 2),
         "byte": ("B", 1),
     }
-    type = formats[fmt][0]
+    typecode = formats[fmt][0]
     chunk = formats[fmt][1]
 
     result = []
@@ -923,15 +923,15 @@ def hexdump(source, length=0x10, separator=".", show_raw=False, base=0, fmt='byt
         s = source[i:i + length]
 
         if PYTHON_MAJOR == 3:
-            line = array.array(type, s)
+            line = array.array(typecode, s)
             text = "".join([chr(c) if 0x20 <= c < 0x7F else separator for c in s])
         else:
-            if type == 'Q': # python2 doesn't support qwords in arrays :(
+            if typecode == 'Q': # python2 doesn't support qwords in arrays :(
                 line = []
                 for j in range(0, length, 8):
                     line.append(struct.unpack("<Q", line[j:j+8]))
             else:
-                line = array.array(type, s)
+                line = array.array(typecode, s)
             text = "".join([c if 0x20 <= ord(c) < 0x7F else separator for c in s])
 
         hexa = " ".join(["{0:0{1}x}".format(c, chunk*2) for c in line])

--- a/gef.py
+++ b/gef.py
@@ -6391,11 +6391,11 @@ class MemoryCommand(GenericCommand):
         if len(argv) < 1:
             self.usage()
             return
-        cmd, opt = argv[0], argv[1:]
+        cmd, argv = argv[0], argv[1:]
         if cmd == "watch":
-            self.watch(opt)
+            self.watch(argv)
         elif cmd == "unwatch":
-            self.unwatch(int(opt[0], 0))
+            self.unwatch(to_unsigned_long(gdb.parse_and_eval(argv[0])))
         elif cmd == "clear":
             self.clear()
         elif cmd == "list":
@@ -6404,15 +6404,17 @@ class MemoryCommand(GenericCommand):
             self.usage()
             return
 
-    def watch(self, opt):
-        address, opt = int(opt[0], 0), opt[1:]
-        if opt:
-            size, opt = int(opt[0], 0), opt[1:]
+    def watch(self, argv):
+        address = to_unsigned_long(gdb.parse_and_eval(argv[0]))
+        argv = argv[1:]
+        if argv:
+            size = to_unsigned_long(gdb.parse_and_eval(argv[0]))
+            argv = argv[1:]
         else:
             size = 0x10
 
-        if opt:
-            group = opt[0].lower()
+        if argv:
+            group = argv[0].lower()
             if group not in {"qword", "dword", "word", "byte"}:
                 warn("Unexpected grouping")
                 self.usage()

--- a/gef.py
+++ b/gef.py
@@ -6928,9 +6928,7 @@ class XorMemoryCommand(GenericCommand):
         return
 
     def do_invoke(self, argv):
-        if len(argv) == 0:
-            err("Missing subcommand <display|patch>")
-            self.usage()
+        self.usage()
         return
 
 @register_command
@@ -6944,7 +6942,7 @@ class XorMemoryDisplayCommand(GenericCommand):
 
     @only_if_gdb_running
     def do_invoke(self, argv):
-        if len(argv) not in (3, 4):
+        if len(argv) != 3:
             self.usage()
             return
 

--- a/gef.py
+++ b/gef.py
@@ -6420,6 +6420,11 @@ class MemoryCommand(GenericCommand):
                 self.usage()
         else:
             group = "byte"
+            if current_arch:
+                if current_arch.ptrsize == 4:
+                    group = "dword"
+                elif current_arch.ptrsize == 8:
+                    group = "qword"
 
         watches[address] = (size, group)
 

--- a/gef.py
+++ b/gef.py
@@ -6481,10 +6481,14 @@ class HexdumpCommand(GenericCommand):
             for arg in argv[1:]:
                 arg = arg.lower()
                 if arg.startswith("l"):
-                    if arg[1:].isdigit():
-                        read_len = long(arg[1:])
-                        continue
-                elif arg == "up":
+                    arg = arg[1:]
+                try:
+                    read_len = long(arg, 0)
+                    continue
+                except ValueError:
+                    pass
+
+                if arg == "up":
                     up_to_down = True
                     continue
                 elif arg == "down":


### PR DESCRIPTION
1. Allow hexdump to group by variable amounts (e.g. word, dword, qword)
2. Remove the special handling in the hexdump _command_ for non-byte sizes
3. Evaluate simple expressions in memory command.
4. Don't require L in front of size arg of hexdump
5. Allow size to be specified in hex in size arg of hexdump
6. Fix usage cases in xor-memory command.

Still needs to be tested on python2! specifically: `hexdump qword`