### PR TITLE
Fix get_filepath when inferior has no name

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2019,8 +2019,14 @@ def get_filepath():
         else:
             return filename
     else:
+        if filename is not None:
+            return filename
+        # inferior probably did not have name,
+        # extract cmdline from info proc
+        tmp = gdb.execute("info proc", to_string=True)
+        tmp = [x for x in tmp.split("\n") if x.startswith("cmdline")][0]
+        filename = tmp.split("'")[1]
         return filename
-
 
 @lru_cache()
 def get_filename():


### PR DESCRIPTION
## Fix get_filepath() when the inferior does not have a name ##

The get_filepath() method used to work on the assumption that the inferior in gdb would always have a name which can be false. In that case a NoneType was returned and later dereferenced resulting in an error.

### Description ###

The patch fixes this by checking in the else branch if filename is None and if yes, uses 'info proc' to retrieve the cmdline

### Related Issue ###

None

### Motivation and Context ###

Resolves execution error in case of inferior not having a name


### How Has This Been Tested? ###

This patch was only tested on a x86_64 machine specifically on a 64bits process (firefox) as I ran into the situation inadvertently.

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | No       |          |
| x86-64       | Yes |                        |
| ARM          | No      |                        |
| AARCH64      | No |                        |
| MIPS         | No       |                        |
| POWERPC      | No      |                        |
| SPARC        | No | Who uses SPARC anyway? |


### Screenshots (if applicable) ###

<!--- Screenshots make everything better. -->


### Types of changes ###

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read and agree to the **CONTRIBUTING** document.
