### PR TITLE
Fix watch memory

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6352,8 +6352,11 @@ class ContextCommand(GenericCommand):
     def context_memory(self):
         for address, opt in sorted(watches.items()):
             self.context_title("memory:{:#x}".format(address))
-            mem = read_memory(address, opt[0])
-            print(hexdump(mem, base=address, fmt=opt[1]))
+            gdb.execute('hexdump {fmt:s} {address:d} {size:d}'.format(
+                address=address,
+                size=opt[0],
+                fmt=opt[1]
+            ))
 
     @classmethod
     def update_registers(cls, event):


### PR DESCRIPTION
## Fix `context` command if `memory watch` is enabled ##

### Description ###
<!--- Describe technically what your patch does. -->
This patch fix problem with `context` command if `memory watch` is enabled for some address (see screenshots). This problem appeared after commit https://github.com/hugsy/gef/commit/f3cfded314e5a28661c7ec749747e1d45d09d94e, in which there is a call of `hexdump` function with keyarg `fmt` in method `ContextCommand.context_memory`.

### Motivation and Context ###

<!--- Why is this change required? What problem does it solve? -->
This patch fix bug in `context` command.
<!--- Why is this patch will make a better world? -->


### How Has This Been Tested? ###

Has this patch been tested on (example)

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark:       |            |
| x86-64       |:heavy_check_mark: |                        |
| ARM          |  :heavy_multiplication_x:      |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         |  :heavy_multiplication_x:       |                        |
| POWERPC      |  :heavy_multiplication_x:       |                        |
| SPARC        |  :heavy_multiplication_x:|  |


### Screenshots (if applicable) ###

<!--- Screenshots make everything better. -->
![gef](https://user-images.githubusercontent.com/7187402/31771406-79b17a58-b4f5-11e7-882d-3ef10593817a.png)


### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would causx existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
