### PR TITLE
Fix autocompleter problem

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -82,6 +82,7 @@ import termios
 import time
 import traceback
 import types
+import readline
 
 
 PYTHON_MAJOR = sys.version_info[0]
@@ -5597,7 +5598,10 @@ class RopperCommand(GenericCommand):
             argv.append("-I")
             argv.append("{:#x}".format(sect.page_start))
 
+        # ropper set up own autocompleter after which gdb/gef autocomplete don't work
+        old_completer = readline.get_completer()
         ropper.start(argv)
+        readline.set_completer(old_completer)
         return
 
 

--- a/gef.py
+++ b/gef.py
@@ -82,7 +82,6 @@ import termios
 import time
 import traceback
 import types
-import readline
 
 
 PYTHON_MAJOR = sys.version_info[0]
@@ -5598,6 +5597,7 @@ class RopperCommand(GenericCommand):
             argv.append("-I")
             argv.append("{:#x}".format(sect.page_start))
 
+        import readline
         # ropper set up own autocompleter after which gdb/gef autocomplete don't work
         old_completer_delims = readline.get_completer_delims()
         old_completer = readline.get_completer()

--- a/gef.py
+++ b/gef.py
@@ -5599,9 +5599,11 @@ class RopperCommand(GenericCommand):
             argv.append("{:#x}".format(sect.page_start))
 
         # ropper set up own autocompleter after which gdb/gef autocomplete don't work
+        old_completer_delims = readline.get_completer_delims()
         old_completer = readline.get_completer()
         ropper.start(argv)
         readline.set_completer(old_completer)
+        readline.set_completer_delims(old_completer_delims)
         return
 
 


### PR DESCRIPTION
## Autocompleter problem patch ##

### Description ###
<!--- Describe technically what your patch does. -->
After `ropper` call, autocomplete function stops working correctly. Instead of gef/gdb command it autocomplete python environment entitiy. This happens because `ropper` imports `rlcompleter` module, which set up own completer function in `readline` module. In my patch completer function (and completer delims) is backed up before `ropper` call and restored after it.

### How Has This Been Tested? ###

Has this patch been tested on (example)

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark:       |           |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x:        |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x:       |                        |
| POWERPC      | :heavy_multiplication_x:      |                        |
| SPARC        | :heavy_multiplication_x:  |  |



### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
