### PR TITLE
[RFC]pie breakpoint support

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -32,6 +32,7 @@ improve it.
 |patch                     | Write specified values to the specified address.|
 |pattern                   | This command will create or search a De Bruijn cyclic pattern to facilitate determining the offset in memory. The algorithm used is the same as the one used by pwntools, and can therefore be used in conjunction.|
 |pcustom                   | Dump user defined structure. This command attempts to reproduce WinDBG awesome `dt` command for GDB and allows to apply structures (from symbols or custom) directly to an address. Custom structures can be defined in pure Python using ctypes, and should be stored in a specific directory, whose path must be stored in the `pcustom.struct_path` configuration setting. (alias: dt)|
+|pie                       | Base command to support PIE breakpoints. PIE breakpoints is that you can set to a PIE binary, and use pie series commands to attach or create a new process, and it will automatically set the real breakpoint when the binary is running.
 |process-search            | List and filter process. (alias: ps)|
 |process-status            | Extends the info given by GDB `info proc`, by giving an exhaustive description of the process status.|
 |registers                 | Display full details on one, many or all registers value from current architecture.|

--- a/docs/commands/pie.md
+++ b/docs/commands/pie.md
@@ -1,0 +1,82 @@
+## Command pie ##
+
+The `pie` command provides a useful way to set breakpoint to a PIE enabled binary.
+`pie` command then provides what we call "PIE breakpoint". A PIE breakpoint is just
+a virtual breakpoint which will be set to real breakpoint when the process is attaching.
+A PIE breakpoint's address is the offset from binary base address.
+
+Note that you need to use ENTIRE PIE COMMAND SERIES to support PIE breakpoint, especially the
+"attaching" commands provided by `pie` command, like `pie attach`, `pie run`, etc.
+
+Usage is just:
+```
+gef➤ pie <sub_commands>
+```
+
+
+### `pie breakpoint` command ###
+
+This command sets a new PIE breakpoint. It can be used like normal `breakpoint` command
+in gdb. The location is just the offset from the base address. Breakpoint will not be
+set immediately after this command. Instead, it will be set when you use `pie attach`,
+`pie run`, `pie remote` to actually attach to a process, so it can resolve the right base
+address.
+
+Usage:
+```
+gef➤ pie breakpoint <LOCATION>
+```
+
+### `pie info` command ###
+
+Since PIE breakpoint is not real breakpoint, this command provide a way to observe the
+state of all PIE breakpoints.
+
+This is just like `info breakpoint` in gdb.
+```
+gef➤  pie info
+VNum	Num	Addr
+1	N/A	0xdeadbeef
+```
+
+The VNum is the virtual number, which is the number of the PIE breakpoint. The Num is the
+number of the according real breakpoint number in gdb. Address is the PIE breakpoint's
+address.
+
+You can ignore VNum argument to get info of all PIE breakpoints.
+
+Usage:
+```
+gef➤  pie info [VNum]
+
+```
+
+
+### `pie delete` command ###
+
+This command deletes a PIE breakpoint given a VNum of that PIE breakpoint.
+
+Usage:
+```
+gef➤  pie delete <VNum>
+```
+
+
+### `pie attach` command ###
+
+The same as gdb's `attach` command. Always use this command instead of raw `attach` 
+if you have PIE breakpoint. This will set real breakpoint when attaching.
+
+The usage is just the same as `attach`.
+
+### `pie remote` command ###
+The same as gdb's `remote` command. Always use this command instead of raw `remote`
+if you have PIE breakpoint. This will set real breakpoint when attaching.
+
+The usage is just the same as `remote`.
+
+### `pie run` command ###
+The same as gdb's `run` command. Always use the command instead of raw `run` if you 
+have PIE breakpoint. This will set real breakpoint when attaching.
+
+The usage is just the same as `run`.


### PR DESCRIPTION
## PIE breakpoint support ##

### Description ###
This is what I've done to support PIE, this is actually pretty naive implementation.
Since PIE base address is known only when we start a program, then I implemented `pie run`, `pie attach`, `pie remote` to substitute original `run`, `attach` and `remote` commands. Then I can start a program and then decide its base address to set my real breakpoints. This is done by commands `pie breakpoint`.

I call those "virtual" breakpoint "PIE breakpoint". I have searched for some time but have no clue about how to do pre hook to something like starting a program. That is why I used such a method. 

### Related Issue ###

https://github.com/hugsy/gef/issues/183


### Motivation and Context ###

Currently gef has no complete PIE support, and every time I want a breakpoint of a PIE program I have to do `entry-break` and then find out base address to calculate real address and set such a breakpoint.

### How Has This Been Tested? ###

Has this patch been tested on (example)

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark:       | non-complete check            |
| x86-64       | :heavy_check_mark: |  non-complete check                      |
| ARM          | :heavy_multiplication_x:|                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: | Who uses SPARC anyway? |


### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
