### PR TITLE
Issue #185: Improve error message if -a or -m is missing

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -5929,6 +5929,12 @@ class AssembleCommand(GenericCommand):
                 mode_s = "32"
                 endian_s = "little"
                 arch, mode = get_keystone_arch(arch=arch_s, mode=mode_s, endian=False)
+        elif not arch_s:
+            err("An architecture (-a) must be provided")
+            return
+        elif not mode_s:
+            err("A mode (-m) must be provided")
+            return
         else:
             arch, mode = get_keystone_arch(arch=arch_s, mode=mode_s, endian=big_endian)
             endian_s = "big" if big_endian else "little"


### PR DESCRIPTION
## Improve error message in asm command ##

### Description ###

This prints a nice error message if -a or -m is missing when running the `assemble` command


### Related Issue ###

#185 


### Motivation and Context ###

This is way better than showing an ugly python exception.


### How Has This Been Tested? ###

Yes, works on my laptop. Anyway, it's 4 lines of python.

### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document. ← There is no such file :D
