### PR TITLE
Fix gef_disassemble for even nb_insn

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1133,17 +1133,13 @@ def gef_disassemble(addr, nb_insn, from_top=False):
     """Disassemble `nb_insn` instructions after `addr`. If `from_top` is False (default), it will
     also disassemble the `nb_insn` instructions before `addr`.
     Return an iterator of Instruction objects."""
-    if nb_insn & 1:
-        count = nb_insn + 1
-
     if not from_top:
-        start_addr = gdb_get_nth_previous_instruction_address(addr, count)
+        start_addr = gdb_get_nth_previous_instruction_address(addr, nb_insn+1)
         if start_addr > 0:
-            for insn in gdb_disassemble(start_addr, count=count):
-                if insn.address == addr: break
+            for insn in gdb_disassemble(start_addr, count=nb_insn):
                 yield insn
 
-    for insn in gdb_disassemble(addr, count=count):
+    for insn in gdb_disassemble(addr, count=nb_insn+1):
         yield insn
 
 

--- a/gef.py
+++ b/gef.py
@@ -1046,10 +1046,11 @@ def gdb_get_location_from_symbol(address):
 def gdb_disassemble(start_pc, **kwargs):
     """""Disassemble instructions starting from `start_pc` (Integer)
     Accepts the following optional named parameters:
-    - `end_pc` (Integer) to disassemble only instructions whose startaddress
+    - `end_pc` (Integer) to disassemble only instructions whose start address
                          fall in the closed memory address interval from
                          start_pc to end_pc.
     - `count` (Integer) to disassemble at most this number of instructions
+
     If `end_pc` and `count` are not provided, the function will behave as if
     `count=1`.
     Return an iterator of Instruction objects


### PR DESCRIPTION
## Fix failure when context.nb_lines_code is set to an even number  ##

### Description ###
Removes check for uneven nb_insn in gef_disassemble that is not needed.



### Motivation and Context ###
Setting context.nb_lines_code to an even number would lead to an error:
`Command 'context' failed to execute properly, reason: local variable 'count' referenced before assignment`

<!--- Why is this change required? What problem does it solve? -->
<!--- Why is this patch will make a better world? -->


### How Has This Been Tested? ###

Has this patch been tested on (example)

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | |
| x86-64       | :heavy_check_mark:  |          |
| ARM          | :heavy_multiplication_x:       |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x:       |                        |
| POWERPC      | :heavy_multiplication_x:       |                        |
| SPARC        | :heavy_multiplication_x: |  |

### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read and agree to the **CONTRIBUTING** document.  _(Unable to find)_
