### PR TITLE
Issue #186: gef_get_auxiliary_values() assumes values are in hexadecimal

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2727,7 +2727,7 @@ def gef_get_auxiliary_values():
     for line in gdb.execute("info auxv", to_string=True).splitlines():
         tmp = line.split()
         _type = tmp[1]
-        res[_type] = int(tmp[-2], 16) if _type in ("AT_PLATFORM", "AT_EXECFN") else int(tmp[-1], 16)
+        res[_type] = int(tmp[-2], base=0) if _type in ("AT_PLATFORM", "AT_EXECFN") else int(tmp[-1], base=0)
     return res
 
 


### PR DESCRIPTION
## Fix issue #186: [capstone-disassemble] MemoryError: Cannot access memory at address XXX

### Description ###

`gef_get_auxiliary_values()` parses the values returned by "info auxv"
as hexadecimal, which is wrong. This patch uses `base=0` to infer the
correct base depending on the prefix ("0x" for hex, otherwise decimal)

### Related Issue ###

#186 

### How Has This Been Tested? ###

Tested on my laptop, with gdb 8.0.1 and python 3.6.

`base=0` also works on python 2.7

### Types of changes ###

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
