### PR TITLE
also look for 1 byte wide instructions in gdb_get_nth_previous_instruction_address

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1080,7 +1080,7 @@ def gdb_get_nth_previous_instruction_address(addr, n):
 
     # we try to find a good set of previous instructions by "guessing" disassembling backwards
     # the 15 comes from the longest instruction valid size
-    for i in range(15*n, 1, -1):
+    for i in range(15*n, 0, -1):
         try:
             insns = list(gdb_disassemble(addr-i, end_pc=next_insn_addr))
         except gdb.MemoryError:


### PR DESCRIPTION
## gdb_get_nth_previous_instruction_address fix ##
Fixes a bug where 1 byte wide instructions are not shown in the code context when `context.nb_lines_code == 1`:

![bug](https://user-images.githubusercontent.com/214637/33011249-aeeff13a-cddd-11e7-8a7b-c4884a038267.png)
note the missing line with `clc` before the current instruction (this is after a `stepi`)

### Description ###
The range of addresses used as start point for instruction disassembly in `gdb_get_nth_previous_instruction_address` had a lower limit of 2 because the second argument to `range` is exclusive.


### Motivation and Context ###

<!--- Why is this change required? What problem does it solve? -->
<!--- Why is this patch will make a better world? -->


### How Has This Been Tested? ###
x86-64


### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
