### PR TITLE
Minor improvements to stack displaying

### DIFF
--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -62,6 +62,34 @@ hexdump version of 0x40 byte of the stack. This command makes it convenient for
 tracking the evolution of arbitrary locations in memory. Tracked locations can
 be removed one by one using `memory unwatch`, or altogether with `memory reset`.
 
+To have the stack displayed with the largest stack addresses on top (i.e., grow the
+stack downward), enable the following setting:
+```
+gef➤ gef config context.grow_stack_down True
+```
+
+To always display the saved instruction pointer in the stack view, enable the following:
+```
+gef➤ gef config context.show_saved_ip True
+```
+
+If the saved instruction pointer is not within the portion of the stack being displayed,
+then a section is created that includes the saved ip and depending on the architecture
+the frame pointer.  Since not all the addresses can be displayed, the missing addresses
+are squished into an ellipsis.
+```
+0x00007fffffffc9e8│+0x00: 0x00007ffff7a2d830  →  <__main+240> mov edi, eax    ← savedip
+0x00007fffffffc9e0│+0x00: 0x00000000004008c0  →  <__init+0> push r15    ← $rbp
+. . . (440 bytes skipped)
+0x00007fffffffc7e8│+0x38: 0x0000000000000000
+0x00007fffffffc7e0│+0x30: 0x0000000000000026 ("&"?)
+0x00007fffffffc7d8│+0x28: 0x0000000001958ac0
+0x00007fffffffc7d0│+0x20: 0x00007ffff7ffa2b0  →  0x5f6f7364765f5f00
+0x00007fffffffc7c8│+0x18: 0x00007fff00000000
+0x00007fffffffc7c0│+0x10: 0x00007fffffffc950  →  0x0000000000000000
+0x00007fffffffc7b8│+0x08: 0x0000000000000000
+0x00007fffffffc7b0│+0x00: 0x00007fffffffc7e4  →  0x0000000000000000      ← $rsp
+```
 
 ### Redirecting context output to another tty/file ###
 


### PR DESCRIPTION
## Minor improvements to the stack display ##

### Description ###
<!--- Describe technically what your patch does. -->
  - Added the option context.grow_stack_down, when enabled the stack will grow down, which pushes new items to bottom.
  - Added the option context.show_saved_ip, when enabled the context shows the saved ip and the ebp, it puts ... (XX btyes) between the frame pointer and where the stack display begins.
  - Changed stack alias and dereference function so that it would work with or without the L prefix in the input to dereference.
  - Added savedip label to regs array so that it'd be labeled when available
  - Added function get_saved_ip(), which uses the 'info frame' to find the saved instruction pointer address.

### Related Issue ###
None

### Motivation and Context ###
Thanks for all your work creating such a great tool!  I have been using the changes below in my own version of gef.  Since I have found them helpful, I thought others might as well, so I decided to share them.
Basically, I added 2 options for displaying stack info when using context and dereference function, which are disabled by default.  Changing the direction of the stack is useful for myself and others because we were taught and think about the stack as getting smaller as it goes down the screen.  The second improvement just includes the saved instruction pointer, base pointer, and a placeholder for the distance between the EBP and the top of the stack that is displayed.  

If you accept these changes, I'm hopeful they will bring about world peas.  

Thanks!
### How Has This Been Tested? ###

This patch has only been test on x86 platforms.  

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark:       |                        |
| x86-64       | :heavy_check_mark:       |                        |
| ARM          | :heavy_check_mark:       |                        |
| AARCH64      | :heavy_check_mark:       |                        |
| MIPS         | :heavy_check_mark:       |                        |
| POWERPC      | :heavy_check_mark:       |                        |
| SPARC        | :heavy_multiplication_x: | Who uses SPARC anyway? |



### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [X ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X ] I have read and agree to the **CONTRIBUTING** document.
