### PR TITLE
Small fix to int(operand[1]) error for tbz/tbnz check in is_branch_taken

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1484,33 +1484,15 @@ class AARCH64(ARM):
                 if op==0: taken, reason = True, "{}==0".format(reg)
                 else: taken, reason = False, "{}!=0".format(reg)
             elif mnemo=="tbnz":
-                # maybe a bit overkill
-                if is_debug(): warn("type(operands[1]) = {}".format(type(operands[1])))
-                op1 = operands[1]
-                if is_debug(): warn("op1 = '{}'".format(op1))
-                if not isinstance(op1, str):
-                    if is_debug(): warn("isinstance(op1, str) == False")
-                    op1 = str(op1)
-                op1 = op1.strip()
-                if is_debug(): warn("op1.strip() = '{}'".format(op1))
-                op1.lstrip("#")
-                if is_debug(): warn("op1.lstrip('#') = '{}'".format(op1))
-                i = int(op1)
+                # operands[1] has one or more white spaces in front, then a #, then the number
+                # so we need to eliminate them
+                i = int(operands[1].strip().lstrip("#"))
                 if (op & 1<<i) != 0: taken, reason = True, "{}&1<<{}!=0".format(reg,i)
                 else: taken, reason = False, "{}&1<<{}==0".format(reg,i)
             elif mnemo=="tbz":
-                # maybe a bit overkill
-                if is_debug(): warn("type(operands[1]) = {}".format(type(operands[1])))
-                op1 = operands[1]
-                if is_debug(): warn("op1 = '{}'".format(op1))
-                if not isinstance(op1, str):
-                    if is_debug(): warn("isinstance(op1, str) == False")
-                    op1 = str(op1)
-                op1 = op1.strip()
-                if is_debug(): warn("op1.strip() = '{}'".format(op1))
-                op1.lstrip("#")
-                if is_debug(): warn("op1.lstrip('#') = '{}'".format(op1))
-                i = int(op1)
+                # operands[1] has one or more white spaces in front, then a #, then the number
+                # so we need to eliminate them
+                i = int(operands[1].strip().lstrip("#"))
                 if (op & 1<<i) == 0: taken, reason = True, "{}&1<<{}==0".format(reg,i)
                 else: taken, reason = False, "{}&1<<{}!=0".format(reg,i)
 

--- a/gef.py
+++ b/gef.py
@@ -1484,11 +1484,23 @@ class AARCH64(ARM):
                 if op==0: taken, reason = True, "{}==0".format(reg)
                 else: taken, reason = False, "{}!=0".format(reg)
             elif mnemo=="tbnz":
-                i = int(operands[1])
+                # maybe a bit overkill
+                op1 = operands[1]
+                if not isinstance(op1, basestring):
+                    op1 = str(op1)
+                op1 = op1.strip()
+                op1.lstrip("#")
+                i = int(op1)
                 if (op & 1<<i) != 0: taken, reason = True, "{}&1<<{}!=0".format(reg,i)
                 else: taken, reason = False, "{}&1<<{}==0".format(reg,i)
             elif mnemo=="tbz":
-                i = int(operands[1])
+                # maybe a bit overkill
+                op1 = operands[1]
+                if not isinstance(op1, basestring):
+                    op1 = str(op1)
+                op1 = op1.strip()
+                op1.lstrip("#")
+                i = int(op1)
                 if (op & 1<<i) == 0: taken, reason = True, "{}&1<<{}==0".format(reg,i)
                 else: taken, reason = False, "{}&1<<{}!=0".format(reg,i)
 

--- a/gef.py
+++ b/gef.py
@@ -1486,20 +1486,28 @@ class AARCH64(ARM):
             elif mnemo=="tbnz":
                 # maybe a bit overkill
                 op1 = operands[1]
+                if is_debug(): warn("op1 = '{}'".format(op1))
                 if not isinstance(op1, str):
+                    if is_debug(): warn("isinstance(op1, str) == False")
                     op1 = str(op1)
                 op1 = op1.strip()
+                if is_debug(): warn("op1.strip() = '{}'".format(op1))
                 op1.lstrip("#")
+                if is_debug(): warn("op1.lstrip('#') = '{}'".format(op1))
                 i = int(op1)
                 if (op & 1<<i) != 0: taken, reason = True, "{}&1<<{}!=0".format(reg,i)
                 else: taken, reason = False, "{}&1<<{}==0".format(reg,i)
             elif mnemo=="tbz":
                 # maybe a bit overkill
                 op1 = operands[1]
+                if is_debug(): warn("op1 = '{}'".format(op1))
                 if not isinstance(op1, str):
+                    if is_debug(): warn("isinstance(op1, str) == False")
                     op1 = str(op1)
                 op1 = op1.strip()
+                if is_debug(): warn("op1.strip() = '{}'".format(op1))
                 op1.lstrip("#")
+                if is_debug(): warn("op1.lstrip('#') = '{}'".format(op1))
                 i = int(op1)
                 if (op & 1<<i) == 0: taken, reason = True, "{}&1<<{}==0".format(reg,i)
                 else: taken, reason = False, "{}&1<<{}!=0".format(reg,i)

--- a/gef.py
+++ b/gef.py
@@ -1485,6 +1485,7 @@ class AARCH64(ARM):
                 else: taken, reason = False, "{}!=0".format(reg)
             elif mnemo=="tbnz":
                 # maybe a bit overkill
+                if is_debug(): warn("type(operands[1]) = {}".format(type(operands[1])))
                 op1 = operands[1]
                 if is_debug(): warn("op1 = '{}'".format(op1))
                 if not isinstance(op1, str):
@@ -1499,6 +1500,7 @@ class AARCH64(ARM):
                 else: taken, reason = False, "{}&1<<{}==0".format(reg,i)
             elif mnemo=="tbz":
                 # maybe a bit overkill
+                if is_debug(): warn("type(operands[1]) = {}".format(type(operands[1])))
                 op1 = operands[1]
                 if is_debug(): warn("op1 = '{}'".format(op1))
                 if not isinstance(op1, str):

--- a/gef.py
+++ b/gef.py
@@ -1486,7 +1486,7 @@ class AARCH64(ARM):
             elif mnemo=="tbnz":
                 # maybe a bit overkill
                 op1 = operands[1]
-                if not isinstance(op1, basestring):
+                if not isinstance(op1, str):
                     op1 = str(op1)
                 op1 = op1.strip()
                 op1.lstrip("#")
@@ -1496,7 +1496,7 @@ class AARCH64(ARM):
             elif mnemo=="tbz":
                 # maybe a bit overkill
                 op1 = operands[1]
-                if not isinstance(op1, basestring):
+                if not isinstance(op1, str):
                     op1 = str(op1)
                 op1 = op1.strip()
                 op1.lstrip("#")


### PR DESCRIPTION
## Small fix to int(operand[1]) error for tbz/tbnz check in is_branch_taken ##

### Description ###

Small fix in the way gef parses second argument 


### Related Issue ###

https://github.com/hugsy/gef/issues/211


### Motivation and Context ###

Fixes the bug


### How Has This Been Tested? ###

Has this patch been tested on (example)

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32        | :heavy_multiplication_x: | does not apply |
| x86-64        | :heavy_multiplication_x: | does not apply |
| ARM           | :heavy_multiplication_x: | does not apply |
| AARCH64   | :heavy_check_mark:        | Fix in AARCH64.is_branch_taken |
| MIPS          | :heavy_multiplication_x:  | does not apply |
| POWERPC  | :heavy_multiplication_x: | does not apply |
| SPARC        | :heavy_multiplication_x: | does not apply |


### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read and agree to the **CONTRIBUTING** document.
