### PR TITLE
Bugfix: Invalid size printed because of checking wrong argument

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7768,7 +7768,7 @@ class PatternSearchCommand(GenericCommand):
             return
 
         if argc==2:
-            if not argv[0].isdigit():
+            if not argv[1].isdigit():
                 err("Invalid size")
                 return
             size = long(argv[1])


### PR DESCRIPTION
## Bugfix: pattern offset checks wrong argument for size (pattern offset) ##

### Description ###
Bugfix: The wrong argument is checked if it is a digit if a size is provided with the pattern offset command


### Motivation and Context ###
Bugfix



### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read and agree to the **CONTRIBUTING** document.
