### PR TITLE
tests: Don't use mutable kwargs

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,7 +3,7 @@ import subprocess
 PATH_TO_DEFAULT_BINARY = "./tests/binaries/default.out"
 
 
-def gdb_run_command(cmd, before=[], after=[], target=PATH_TO_DEFAULT_BINARY):
+def gdb_run_command(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
     """Execute a command inside GDB. `before` and `after` are lists of commands to be executed
     before (resp. after) the command to test."""
     command = [
@@ -13,46 +13,55 @@ def gdb_run_command(cmd, before=[], after=[], target=PATH_TO_DEFAULT_BINARY):
         "-ex", "gef config gef.debug True"
     ]
 
-    if len(before):
-        for _ in before: command+= ["-ex", _]
+    if before:
+        for _ in before: command += ["-ex", _]
 
     command += ["-ex", cmd]
 
-    if len(after):
-        for _ in after: command+= ["-ex", _]
+    if after:
+        for _ in after: command += ["-ex", _]
 
-    command+= ["-ex", "quit", "--", target]
+    command += ["-ex", "quit", "--", target]
 
     lines = subprocess.check_output(command, stderr=subprocess.STDOUT).strip().splitlines()
     return b"\n".join(lines)
 
 
-def gdb_run_silent_command(cmd, before=[], after=[], target=PATH_TO_DEFAULT_BINARY):
+def gdb_run_silent_command(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
     """Disable the output and run entirely the `target` binary."""
+    if not before:
+        before = []
+
     before += ["gef config context.clear_screen False",
-               """gef config context.layout "-code -stack" """,
+               "gef config context.layout '-code -stack'",
                "run"]
     return gdb_run_command(cmd, before, after, target)
 
 
-def gdb_run_command_last_line(cmd, before=[], after=[], target=PATH_TO_DEFAULT_BINARY):
+def gdb_run_command_last_line(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
     """Execute a command in GDB, and return only the last line of its output."""
     return gdb_run_command(cmd, before, after, target).splitlines()[-1]
 
 
-def gdb_start_silent_command(cmd, before=[], after=[], target=PATH_TO_DEFAULT_BINARY):
+def gdb_start_silent_command(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
     """Execute a command in GDB by starting an execution context. This command disables the `context`
     and set a tbreak at the most convenient entry point."""
+    if not before:
+        before = []
+
     before += ["gef config context.clear_screen False",
-               """gef config context.layout "-code -stack" """,
+               "gef config context.layout '-code -stack'",
                "entry-break"]
     return gdb_run_command(cmd, before, after, target)
 
 
-def gdb_start_silent_command_last_line(cmd, before=[], after=[], target=PATH_TO_DEFAULT_BINARY):
+def gdb_start_silent_command_last_line(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
     """Execute `gdb_start_silent_command()` and return only the last line of its output."""
+    if not before:
+        before = []
+
     before += ["gef config context.clear_screen False",
-               """gef config context.layout "-code -stack" """,
+               "gef config context.layout '-code -stack'",
                "entry-break"]
     return gdb_start_silent_command(cmd, before, after, target).splitlines()[-1]
 


### PR DESCRIPTION
Since these functions mutate the argument, if they are called without
those args, the mutation applies to the list that is bound to the
function object itself. This means that subsequent calls to the function
without the arg will be _re-appending_ the same commands.
