### PR TITLE
Fixed small issue with one of the pop mnemonics operand checks

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1393,7 +1393,7 @@ class ARM(Architecture):
         branch_mnemos = {"bl", "bx"}
         write_mnemos = {"ldr", "add"}
         if insn.mnemonic in pop_mnemos:
-            return insn.operands[-1] == " pc}"
+            return insn.operands[-1] == "pc"
         if insn.mnemonic in branch_mnemos:
             return insn.operands[-1] == "lr"
         if insn.mnemonic in write_mnemos:


### PR DESCRIPTION
## Fixed small issue with one of the pop mnemonics operand checks ##

### Description ###

Fixes small typo introduced in commit hugsy/gef@d0d266a2b7f855db5256ea7cd1d5dea2bb29baf4


### Related Issue ###

No issue created (too small of a fix and on a feature dev branch not used by many)


### Motivation and Context ###

Fixes invalid detection of return operations in the case of **pop** operations with **pc** as the last operand for **ARM** architecture


### How Has This Been Tested? ###

Has this patch been tested on (example)

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | does not apply |
| x86-64       | :heavy_multiplication_x: | does not apply |
| ARM          | :heavy_check_mark:       |                        |
| AARCH64  | :heavy_check_mark:       | is inherited from ARM |
| MIPS         | :heavy_multiplication_x: | does not apply |
| POWERPC | :heavy_multiplication_x: | does not apply |
| SPARC       | :heavy_multiplication_x: | does not apply |


### Screenshots (if applicable) ###

<!--- Screenshots make everything better. -->


### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
