### PR TITLE
Fix `pie breakpoint` bug when using on running process

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3460,6 +3460,15 @@ class PieBreakpointCommand(GenericCommand):
             bp_expr = tmp_bp_expr
             self.set_pie_breakpoint(lambda base: "b {}".format(bp_expr), bp_expr)
 
+        # When the process is already on, set real breakpoints immediately
+        if is_alive():
+            vmmap = get_process_maps()
+            base_address = [x.page_start for x in vmmap if x.path == get_filepath()][0]
+
+            for bp, bp_ins in __pie_breakpoints__.items():
+                bp_ins.instantiate(base_address)
+            
+
     @staticmethod
     def set_pie_breakpoint(set_func, addr):
         global __pie_counter__, __pie_breakpoints__


### PR DESCRIPTION
Fix `pie breakpoint` bug when using on running process. Currently when using `pie breakpoint` on running process, no real breakpoint will be set until next `pie run` or `pie attach`.

## Descriptive title of your patch ##
Fix `pie breakpoint` bug when using on running process
### Description ###
<!--- Describe technically what your patch does. -->
Fix the bug by adding breakpoint set code when alive process is detected when using `pie breakpoing`

### Related Issue ###

Nope.


### Motivation and Context ###

<!--- Why is this change required? What problem does it solve? -->
<!--- Why is this patch will make a better world? -->
Bug repair

### How Has This Been Tested? ###

Has this patch been tested on (example)

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x:       |             |
| x86-64       | :heavy_check_mark: | rock'n roll                       |
| ARM          | :heavy_multiplication_x:       |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x:       |                        |
| POWERPC      | :heavy_multiplication_x:       |                        |
| SPARC        | :heavy_multiplication_x: | Who uses SPARC anyway? |


### Screenshots (if applicable) ###

<!--- Screenshots make everything better. -->


### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
