### PR TITLE
Cache get_info_files for big speedup!

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2259,6 +2259,7 @@ def get_info_sections():
     return
 
 
+@lru_cache()
 def get_info_files():
     """Retrieves all the files loaded by debuggee."""
     lines = gdb.execute("info files", to_string=True).splitlines()


### PR DESCRIPTION
The context command calls `get_info_files` 50+ times (Unless you're
showing regs raw, and who wants that?).

This appears to speed up the context command for me 25% on my linux
(x86_64) machine and 40% on my raspberry pi!