### PR TITLE
Use max() to avoid zero or negative numbers

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8150,7 +8150,7 @@ class GefHelpCommand(gdb.Command):
         doc = class_name.__doc__ if hasattr(class_name, "__doc__") else ""
         doc = "\n                         ".join(doc.split("\n"))
         aliases = "(alias: {:s})".format(", ".join(class_name._aliases_)) if hasattr(class_name, "_aliases_") else ""
-        w = get_terminal_size()[1] - 29 - len(aliases)
+        w = max(1, get_terminal_size()[1] - 29 - len(aliases))  # use max() to avoid zero or negative numbers
         msg = "{cmd:<25s} -- {help:{w}s} {aliases:s}".format(cmd=cmd, help=Color.greenify(doc), w=w, aliases=aliases)
         self.docs.append(msg)
         return


### PR DESCRIPTION
Fixes #245
Headless servers have zero width screens. This was making the width calculation negative, which generated a illegal format string.