### PR TITLE
Fix FormatStringBreakpoint on x86_32

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2921,7 +2921,7 @@ class FormatStringBreakpoint(gdb.Breakpoint):
         msg = []
         if is_x86_32():
             sp = current_arch.sp
-            sz =  current_arch.instruction_length
+            sz =  get_memory_alignment()
             val = sp + (self.num_args * sz) + sz
             ptr = read_int_from_memory(val)
             addr = lookup_address(ptr)

--- a/gef.py
+++ b/gef.py
@@ -1923,11 +1923,11 @@ def read_int_from_memory(addr):
     return struct.unpack(fmt, mem)[0]
 
 
-def read_cstring_from_memory(address, max_length=GEF_MAX_STRING_LENGTH):
+def read_cstring_from_memory(address, max_length=GEF_MAX_STRING_LENGTH, encoding='unicode_escape'):
     """Return a C-string from memory."""
     char_t = cached_lookup_type("char")
     char_ptr = char_t.pointer()
-    res = gdb.Value(address).cast(char_ptr).string().strip()
+    res = gdb.Value(address).cast(char_ptr).string(encoding=encoding).strip()
     res2 = res.replace('\n','\\n').replace('\r','\\r').replace('\t','\\t')
 
     if max_length and len(res) > max_length:


### PR DESCRIPTION
## Fix FormatStringBreakpoint on x86_32 ##

### Description ###
<!--- Describe technically what your patch does. -->
Fixes:
* current_arch.instruction_length is None for x86 so FormatStringBreakpoint throws an exception.
    `Python Exception <class 'TypeError'> unsupported operand type(s) for *: 'int' and 'NoneType':`
* read_cstring_from_memory (specifically GDB Value.string()) would throw UnicodeDecodeError if string was not properly formatted, e.g. "aaa\xcc".
    `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcc in position 3: unexpected end of data`


### Motivation and Context ###

<!--- Why is this change required? What problem does it solve? -->
<!--- Why is this patch will make a better world? -->
I ran into both of these issues while trying to use format-string-helper on a 32-bit binary. First the current_arch.instruction_length issue appeared, and then UnicodeDecodeError.

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark:       | rock'n roll            |
| x86-64       | :heavy_check_mark:      |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: | Who uses SPARC anyway? |

### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
