### PR TITLE
scripts: Add install script for gef-extras

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -140,8 +140,11 @@ repository where anyone can freely submit their own commands to extend GDB via
 GEF's API.
 
 To benefit from it:
-
 ```bash
+# via the install script
+$ wget -q -O- https://github.com/hugsy/gef/raw/master/scripts/gef-extras.sh | sh
+
+# manually
 # clone the repo
 $ https://github.com/hugsy/gef-extras.git
 # specify gef to load this directory

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/hugsy/gef-extras.git $HOME/gef-extras
+gdb -q -ex 'gef config gef.extra_plugins_dir "'$HOME'/gef-extras/scripts"' -ex 'gef config pcustom.struct_path '$HOME'/gef-extras/structs' -ex 'gef save' -ex quit


### PR DESCRIPTION
## Add install script for gef-extras ##

### Description ###

Add an install script for gef-extras, nothing special, just automating the more than 1 instructions needed if anyone wants to do it easily.

It clones the `gef-extras` repo to `$HOME`, then setting `gef.extra_plugins_dir` and `pcustom.struct_path`.

### Related Issue ###

https://github.com/hugsy/gef/issues/252


### Motivation and Context ###

One line installation for gef-extras just like gef itself!
<!--- Why is this change required? What problem does it solve? -->
<!--- Why is this patch will make a better world? -->


### How Has This Been Tested? ###
No testing required.


### Screenshots (if applicable) ###

![](https://ibin.co/w800/3xkWzZ0JCGqy.png)
<!--- Screenshots make everything better. -->


### Types of changes ###

<!--- Put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist ###

<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read and agree to the **CONTRIBUTING** document.
