### PR TITLE
Fix version handling to work with '-' in version number

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -201,7 +201,7 @@ GEF_TEMP_DIR                           = os.path.join(tempfile.gettempdir(), "ge
 GEF_MAX_STRING_LENGTH                  = 50
 
 GDB_MIN_VERSION                         = (7, 7)
-GDB_VERSION_MAJOR, GDB_VERSION_MINOR    = [int(_) for _ in gdb.VERSION.replace("Fedora ","").replace("-",".").split(".")[:2]]
+GDB_VERSION_MAJOR, GDB_VERSION_MINOR    = [int(_) for _ in re.search(r"(\d+)[^\d]+(\d+)", gdb.VERSION).groups()]
 GDB_VERSION                             = (GDB_VERSION_MAJOR, GDB_VERSION_MINOR)
 
 current_elf  = None

--- a/gef.py
+++ b/gef.py
@@ -201,7 +201,7 @@ GEF_TEMP_DIR                           = os.path.join(tempfile.gettempdir(), "ge
 GEF_MAX_STRING_LENGTH                  = 50
 
 GDB_MIN_VERSION                         = (7, 7)
-GDB_VERSION_MAJOR, GDB_VERSION_MINOR    = [int(_) for _ in gdb.VERSION.replace("Fedora ","").split(".")[:2]]
+GDB_VERSION_MAJOR, GDB_VERSION_MINOR    = [int(_) for _ in gdb.VERSION.replace("Fedora ","").replace("-",".").split(".")[:2]]
 GDB_VERSION                             = (GDB_VERSION_MAJOR, GDB_VERSION_MINOR)
 
 current_elf  = None


### PR DESCRIPTION
## Verison handling can handle '-' in gdb version number ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
Just replaces '-' by '.' in the version number to make it to integers again. This is sufficient as only major and minor version numbers are used. 
<!-- Why is this change required? What problem does it solve? -->
It makes gef installable if gdb version contains a '-', which was the case after I upgraded to Fedora 28.
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark: |   |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
- [ ] I have tagged the PR as appropriate (e.g. bug fix). NOT POSSIBLE
