### PR TITLE
Add ability to pass args to 'pie run' command

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3519,7 +3519,7 @@ class PieRunCommand(GenericCommand):
         # get base address
         gdb.execute("set stop-on-solib-events 1")
         disable_context()
-        gdb.execute("run")
+        gdb.execute("run {}".format(" ".join(argv)))
         enable_context()
         gdb.execute("set stop-on-solib-events 0")
         vmmap = get_process_maps()


### PR DESCRIPTION
## Pass args to `pie run` ##

### Description/Motivation/Screenshots ###
Intuitively you would expect `pie run a b c` to be essentially the same
as `run a b c`. However, previously `pie run a b c` would discard
arguments and execute `run`. This commit changes that behavior so that
arguments are passed to `pie run`.

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark:  |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
- [ ] I have tagged the PR as appropriate (e.g. bug fix).
