### PR TITLE
unicorn docs referenced outdated option

### DIFF
--- a/docs/commands/unicorn-emulate.md
+++ b/docs/commands/unicorn-emulate.md
@@ -30,7 +30,7 @@ In this example, we can see that after executing
 ```
 The registers `eax` and `esp` are tainted (modified).
 
-A convenient option is `-e /path/to/file.py` that will generate a pure Python
+A convenient option is `-o /path/to/file.py` that will generate a pure Python
 script embedding your current execution context, ready to be re-used outside
 `gef`!! This can be useful for dealing with obfuscation or solve crackmes if
 powered with a SMT for instance.


### PR DESCRIPTION
`-e` doesn't exist, `-o` does and what `-e` claims to.

## fix outdated unicorn option ##

### Description/Motivation/Screenshots ###
docs are old. this makes them new. new is better than old

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x ] My code follows the code style of this project.
- [x ] My change includes a change to the documentation, if required.
- [ ] I have read and agree to the **CONTRIBUTING** document.
- [ ] I have tagged the PR as appropriate (e.g. bug fix).
