### PR TITLE
Fixed heap help message typo

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -5477,7 +5477,7 @@ class GlibcHeapCommand(GenericCommand):
     """Base command to get information about the Glibc heap structure."""
 
     _cmdline_ = "heap"
-    _syntax_  = "{:s} (chunk|chunk|bins|arenas)".format(_cmdline_)
+    _syntax_  = "{:s} (chunk|chunks|bins|arenas)".format(_cmdline_)
 
     def __init__(self):
         super(GlibcHeapCommand, self).__init__(prefix=True)


### PR DESCRIPTION
## Fixing typo in the heap command help message ##

### Description ###

See #280 

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
- [x] I have tagged the PR as appropriate (e.g. bug fix).
