### PR TITLE
Allow user to specify substitution function in pcustom struct

### DIFF
--- a/docs/commands/pcustom.md
+++ b/docs/commands/pcustom.md
@@ -80,7 +80,6 @@ class person_t(Structure):
     		(None, "Invalid person")
     	])
     ]
-
 ```
 
 `pcustom` requires at least one argument, which is the name of the

--- a/docs/commands/pcustom.md
+++ b/docs/commands/pcustom.md
@@ -70,6 +70,17 @@ class person_t(Structure):
         ("id", c_int),
     ]
 
+    _values_ = [
+    	# You can define a function to substitute the value
+    	("age", lambda age: "Old" if age > 40 else "Young"),
+    	# Or alternatively a list of 2-tuples
+    	("id", [
+    		(0, "root"),
+    		(1, "normal user"),
+    		(None, "Invalid person")
+    	])
+    ]
+
 ```
 
 `pcustom` requires at least one argument, which is the name of the
@@ -78,9 +89,9 @@ structure.
 
 ```
 gef➤  dt person_t
-+0000 age c_int (0x4)
++0000 age c_int (0x4)  →  Young
 +0004 name c_char_Array_256 (0x100)
-+0104 id c_int (0x4)
++0104 id c_int (0x1)   →  normal user
 ```
 
 

--- a/gef.py
+++ b/gef.py
@@ -4231,12 +4231,16 @@ class PCustomCommand(GenericCommand):
         default = ""
         for name, values in values_list:
             if name != item: continue
-            if type(values) == list:
-                for val, desc in values:
-                    if value == val: return desc
-                    if val is None: default = desc
-            else:
+            if callable(values):
                 return values(value)
+            else:
+                try:
+                    for val, desc in values:
+                        if value == val: return desc
+                        if val is None: default = desc
+                except:
+                    err("Error while trying to obtain values from __values__[\"{}\"]".format(name))
+
         return default
 
 

--- a/gef.py
+++ b/gef.py
@@ -4239,7 +4239,7 @@ class PCustomCommand(GenericCommand):
                         if value == val: return desc
                         if val is None: default = desc
                 except:
-                    err("Error while trying to obtain values from __values__[\"{}\"]".format(name))
+                    err("Error while trying to obtain values from _values_[\"{}\"]".format(name))
 
         return default
 

--- a/gef.py
+++ b/gef.py
@@ -4231,9 +4231,12 @@ class PCustomCommand(GenericCommand):
         default = ""
         for name, values in values_list:
             if name != item: continue
-            for val, desc in values:
-                if value == val: return desc
-                if val is None: default = desc
+            if type(values) == list:
+                for val, desc in values:
+                    if value == val: return desc
+                    if val is None: default = desc
+            else:
+                return values(value)
         return default
 
 


### PR DESCRIPTION
## Allow user to specify subsitution function in pcustom struct  ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
Currently the user can specify how to substitute values in a struct using `_values_` in the pcustom struct file.

In addition to the current ability to substitute values using a list of tuples, after this patch the user can also specify a function to do the substitution,  giving more flexibility.
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->
An example of this being used is in the [socketaddr_in](https://github.com/hugsy/gef-extras/pull/8/files#diff-949c9b64b64de1131b192b7bd065b4ae) struct.

https://asciinema.org/a/0iygyS51V8j6dLmft243wABGq

### How Has This Been Tested? ###
Tested using the [socketaddr_in](https://github.com/hugsy/gef-extras/pull/8/files#diff-949c9b64b64de1131b192b7bd065b4ae) struct.

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
- [ ] I have tagged the PR as appropriate (e.g. bug fix).
