### PR TITLE
hijack-fd: Support connecting to ip:port

### DIFF
--- a/docs/commands/hijack-fd.md
+++ b/docs/commands/hijack-fd.md
@@ -17,3 +17,12 @@ Will modify the current process file descriptors to redirect STDOUT to
 
 Check this asciicast for visual example:
 [![asciicast](https://asciinema.org/a/2o9bhveyikb1uvplwakjftxlq.png)](https://asciinema.org/a/2o9bhveyikb1uvplwakjftxlq)
+
+This command also supports connecting to an ip:port if it is provided as an argument. For example
+```
+gef➤ hijack-fd 0 localhost:8888
+```
+Will redirect STDIN to localhost:8888
+
+There is also an example at:
+[![asciicast](https://asciinema.org/a/0dizAXevliwGYboibPUJmJntO.png)](https://asciinema.org/a/0dizAXevliwGYboibPUJmJntO)

--- a/gef.py
+++ b/gef.py
@@ -4310,38 +4310,52 @@ class ChangeFdCommand(GenericCommand):
         disable_context()
 
         if ':' in new_output:
-            address = socket.gethostbyname(new_output.split(':')[0])
-            port = int(new_output.split(':')[1])
+            address = socket.gethostbyname(new_output.split(":")[0])
+            port = int(new_output.split(":")[1])
 
+            # socket(int domain, int type, int protocol)
             # AF_INET = 2, SOCK_STREAM = 1
             res = gdb.execute("""call socket(2, 1, 0)""", to_string=True)
-            new_fd = int(res.split()[2], 0)
+            new_fd = self.get_fd_from_result(res)
 
             # fill in memory with sockaddr_in struct contents
             # we will do this in the stack, since connect() wants a pointer to a struct
             vmmap = get_process_maps()
-            stack_addr = next(entry.page_start for entry in vmmap if entry.path == '[stack]')
+            stack_addr = [entry.page_start for entry in vmmap if entry.path == "[stack]"][0]
             original_contents = read_memory(stack_addr, 8)
 
-            write_memory(stack_addr, '\x02\x00', 2)
-            write_memory(stack_addr + 0x2, struct.pack('<H', socket.htons(port)), 2)
+            '''
+            struct sockaddr_in {
+                short            sin_family;   // e.g. AF_INET
+                unsigned short   sin_port;     // e.g. htons(3490)
+                struct in_addr   sin_addr;     // see struct in_addr, below
+                char             sin_zero[8];  // just padding
+            };
+
+            struct in_addr {
+                unsigned long s_addr;  // load with inet_aton()
+            };
+
+            '''
+            write_memory(stack_addr, "\x02\x00", 2)
+            write_memory(stack_addr + 0x2, struct.pack("<H", socket.htons(port)), 2)
             write_memory(stack_addr + 0x4, socket.inet_aton(address), 4)
 
-            info('Trying to connect to {}'.format(new_output))
+            info("Trying to connect to {}".format(new_output))
+            # connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
             res = gdb.execute("""call connect({}, {}, {})""".format(new_fd, stack_addr, 16), to_string=True)
 
             # recover stack state
             write_memory(stack_addr, original_contents, 8)
 
-            res = int(res.split()[2], 0)
+            res = self.get_fd_from_result(res)
             if res == -1:
-                err('Failed to connect to {}'.format(addr))
+                err("Failed to connect to {}".format(addr))
                 return
 
-            info('Connected to {}'.format(new_output))
+            info("Connected to {}".format(new_output))
         else:
             res = gdb.execute("""call open("{:s}", 66, 0666)""".format(new_output), to_string=True)
-            # Output example: $1 = 3
             new_fd = int(res.split()[2], 0)
         
         info("Opened '{:s}' as fd=#{:d}".format(new_output, new_fd))
@@ -4351,6 +4365,10 @@ class ChangeFdCommand(GenericCommand):
         ok("Success")
         enable_context()
         return
+
+    def get_fd_from_result(self, res):
+        # Output example: $1 = 3
+        return int(res.split()[2], 0)
 
 
 @register_command


### PR DESCRIPTION
## hijack-fd: Support connecting to ip:port ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
Like what is mentioned in #139, in addition to be able to open a file, if it detects `:` in the second
arg, it will make a `connect` call to the given address and port.
<!-- Why is this patch will make a better world? -->
The user could spoof a web server that an application under testing is connecting to. Or, just open another terminal to provide input/receive output more cleanly.
<!-- How does this look? Add a screenshot if you can -->
https://asciinema.org/a/0dizAXevliwGYboibPUJmJntO

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
- [ ] I have tagged the PR as appropriate (e.g. bug fix).
