### PR TITLE
Fix multiline doc string not showing description

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8434,7 +8434,7 @@ class GefHelpCommand(gdb.Command):
         if " " in cmd:
             # do not print subcommands in gef help
             return
-        doc = getattr(class_name, "__doc__", "").lstrip() if hasattr(class_name, "__doc__") else ""
+        doc = getattr(class_name, "__doc__", "").lstrip()
         doc = "\n                         ".join(doc.split("\n"))
         aliases = "(alias: {:s})".format(", ".join(class_name._aliases_)) if hasattr(class_name, "_aliases_") else ""
         w = max(1, get_terminal_size()[1] - 29 - len(aliases))  # use max() to avoid zero or negative numbers

--- a/gef.py
+++ b/gef.py
@@ -8169,7 +8169,8 @@ class HeapAnalysisCommand(GenericCommand):
 
 @register_command
 class IsSyscallCommand(GenericCommand):
-    """Tells whether the next instruction is a system call."""
+    """
+    Tells whether the next instruction is a system call."""
     _cmdline_ = 'is-syscall'
     _syntax_ = _cmdline_
 
@@ -8433,7 +8434,7 @@ class GefHelpCommand(gdb.Command):
         if " " in cmd:
             # do not print subcommands in gef help
             return
-        doc = class_name.__doc__ if hasattr(class_name, "__doc__") else ""
+        doc = class_name.__doc__.lstrip() if hasattr(class_name, "__doc__") else ""
         doc = "\n                         ".join(doc.split("\n"))
         aliases = "(alias: {:s})".format(", ".join(class_name._aliases_)) if hasattr(class_name, "_aliases_") else ""
         w = max(1, get_terminal_size()[1] - 29 - len(aliases))  # use max() to avoid zero or negative numbers

--- a/gef.py
+++ b/gef.py
@@ -8434,7 +8434,7 @@ class GefHelpCommand(gdb.Command):
         if " " in cmd:
             # do not print subcommands in gef help
             return
-        doc = class_name.__doc__.lstrip() if hasattr(class_name, "__doc__") else ""
+        doc = getattr(class_name, "__doc__", "").lstrip() if hasattr(class_name, "__doc__") else ""
         doc = "\n                         ".join(doc.split("\n"))
         aliases = "(alias: {:s})".format(", ".join(class_name._aliases_)) if hasattr(class_name, "_aliases_") else ""
         w = max(1, get_terminal_size()[1] - 29 - len(aliases))  # use max() to avoid zero or negative numbers


### PR DESCRIPTION
## Fix multiline doc string not showing description ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->
As mentioned in #285, descriptions for a command is not shown when doing `gef` if there is a newline at the start of the doc string.

### How Has This Been Tested? ###
Added a newline to doc string of `is-syscall` to show that it works.

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
- [ ] I have tagged the PR as appropriate (e.g. bug fix).
