### PR TITLE
ensure that section has a path attribute

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -401,7 +401,7 @@ class Address:
 
     def is_in_text_segment(self):
         return (hasattr(self.info, "name") and ".text" in self.info.name) or \
-            (get_filepath() == self.section.path and self.section.is_executable())
+            (hasattr(self.section, "path") and get_filepath() == self.section.path and self.section.is_executable())
 
     def is_in_stack_segment(self):
         return hasattr(self.section, "path") and "[stack]" == self.section.path


### PR DESCRIPTION
## Fix error when using telescope##
Occasionall would get the following:
`[!] Command 'dereference' failed to execute properly, reason: 'NoneType' object has no attribute 'path'`

### Description/Motivation/Screenshots ###
Was broken in https://github.com/hugsy/gef/commit/edbadbef7813fb96827572fcac3db35c9550beaa


### Checklist ###
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hugsy/gef/287)
<!-- Reviewable:end -->
