### PR TITLE
Fix unsigned long cast problem and fix some problems in `syscall-args` command

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8375,7 +8375,7 @@ class SyscallArgsCommand(GenericCommand):
         if reg_value not in syscall_table:
             warn("There is no system call for %#x" % reg_value)
             return
-        syscall_entry = syscall_table[get_register(current_arch.syscall_register)]
+        syscall_entry = syscall_table[reg_value]
 
         values = []
         for param in syscall_entry.params:

--- a/gef.py
+++ b/gef.py
@@ -2157,10 +2157,7 @@ def use_golang_type():
 
 def to_unsigned_long(v):
     """Cast a gdb.Value to unsigned long."""
-    unsigned_long_t = cached_lookup_type(use_stdtype()) \
-                      or cached_lookup_type(use_default_type()) \
-                      or cached_lookup_type(use_golang_type())
-    return long(v.cast(unsigned_long_t))
+    return long(str(v), 16)
 
 
 def get_register(regname):

--- a/gef.py
+++ b/gef.py
@@ -8372,8 +8372,12 @@ class SyscallArgsCommand(GenericCommand):
             return
 
         arch = current_arch.__class__.__name__
-
         syscall_table = self.get_syscall_table(arch)
+
+        reg_value = get_register(current_arch.syscall_register)
+        if reg_value not in syscall_table:
+            warn("There is no system call for %#x" % reg_value)
+            return
         syscall_entry = syscall_table[get_register(current_arch.syscall_register)]
 
         values = []


### PR DESCRIPTION
1.
The old implementation of `to_unsigned_long` was wrong, you can test it by passing something like 0xffffffffffffffff, and it will return -1. 
And I did not find an elegant way to resolve this problem. So I cast `gdb.Value` to `str` and then cast back to `long`.

2.
Catch annoying error message when key error occurred during running `syscall-args`

3.
There was a display bug when running `registers` command on 64bit machines because of wrong masking.

4.
There should be a warning message to remind user where to download syscall table(gef-extra). But I'm not sure whether it is a better idea to include it in gef since `syscall-args` has been integrated into gef.