### PR TITLE
Use argv when running gdb with entry-break

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6608,7 +6608,7 @@ class EntryPointBreakCommand(GenericCommand):
             return
 
         self.set_init_tbreak(elf.e_entry)
-        gdb.execute("run")
+        gdb.execute("run {}".format(" ".join(argv)))
         return
 
     def set_init_tbreak(self, addr):
@@ -6620,7 +6620,7 @@ class EntryPointBreakCommand(GenericCommand):
         warn("PIC binary detected, retrieving text base address")
         gdb.execute("set stop-on-solib-events 1")
         disable_context()
-        gdb.execute("run")
+        gdb.execute("run {}".format(" ".join(argv)))
         enable_context()
         gdb.execute("set stop-on-solib-events 0")
         vmmap = get_process_maps()


### PR DESCRIPTION
## Use argv when running gdb with entry-break ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->
Over at line 6586, gdb executes run with argv. However, at lines 6611
and 6623, it only executes run.

I am not sure if this is intended behaviour. If it is, just close this
PR.

### How Has This Been Tested? ###
Didn't really test this, since it may just be a typo.

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |   |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
