### PR TITLE
pie breakpoint parse address using gdb.parse_and_eval

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3714,9 +3714,9 @@ class PieBreakpointCommand(GenericCommand):
         bp_expr = " ".join(argv)
         tmp_bp_expr = bp_expr
 
-        try:
-            addr = long(gdb.parse_and_eval(bp_expr))
-        except:
+        if bp_expr[0] == '*':
+            addr = long(gdb.parse_and_eval(bp_expr[1:]))
+        else:
             addr = long(gdb.parse_and_eval("&{}".format(bp_expr))) # get address of symbol or function name
 
         self.set_pie_breakpoint(lambda base: "b *{}".format(base + addr), addr)


### PR DESCRIPTION
## pie breakpoint parse address using gdb.parse_and_eval ##

### Description/Motivation/Screenshots ###
Before this, `pie breakpoint` is not fully working.
```
gef➤  pie breakpoint 0x8FD
[!] Function "0x8FD" not defined.

gef➤  info breakpoints
No breakpoints or watchpoints.
gef➤  pie breakpoint *0x8FD
[!] Function "0x8FD" not defined.
```

This PR is to fix those issue
### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark: : | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
