### PR TITLE
fix bug where improper spaces where being stripped

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -166,7 +166,15 @@ There, you're now fully equipped epic pwnage with **all** GEF's goodness!!
 To discuss `gef`, `gdb`, exploitation or other topics, feel free to join the
 `##gef` channel on the Freenode IRC network. You can also to me (`hugsy`) via the
 channel. For those who do not have an IRC client (like `weechat` or `irssi`),
-simply [click here](https://webchat.freenode.net/?channels=##gef).
+simply [click here](https://webchat.freenode.net/?channels=##gef). 
+
+__Note about the IRC channel__: Due to some spambots overly active on the Freenode 
+network, a password was set to reach the IRC channel: the password is `gefrocks!`. 
+To reach the channel once connected to Freenode, you now have to enter the command:
+
+```
+/join ##gef gefrocks!
+```
 
 For bugs or feature requests, just
 go [here](https://github.com/hugsy/gef/issues) and provide a thorough description

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,17 +164,9 @@ There, you're now fully equipped epic pwnage with **all** GEF's goodness!!
 ## Bugs & Feedbacks ##
 
 To discuss `gef`, `gdb`, exploitation or other topics, feel free to join the
-`##gef` channel on the Freenode IRC network. You can also to me (`hugsy`) via the
+`##gef` channel on the Freenode IRC network. You can also talk to me (`hugsy`) on the
 channel. For those who do not have an IRC client (like `weechat` or `irssi`),
 simply [click here](https://webchat.freenode.net/?channels=##gef). 
-
-__Note about the IRC channel__: Due to some spambots overly active on the Freenode 
-network, a password was set to reach the IRC channel: the password is `gefrocks!`. 
-To reach the channel once connected to Freenode, you now have to enter the command:
-
-```
-/join ##gef gefrocks!
-```
 
 For bugs or feature requests, just
 go [here](https://github.com/hugsy/gef/issues) and provide a thorough description

--- a/gef.py
+++ b/gef.py
@@ -2289,7 +2289,7 @@ def get_process_maps_linux(proc_map_file):
             pathname = ""
         else:
             inode = rest[0]
-            pathname = rest[1].replace(" ", "")
+            pathname = rest[1].lstrip()
 
         addr_start, addr_end = list(map(lambda x: long(x, 16), addr.split("-")))
         off = long(off, 16)


### PR DESCRIPTION
## Space stripping bug fix ##

### Description/Motivation/Screenshots ###
ida-interact was throwing errors when the file contained a space because it was not properly matching with vmmap
line 4596 was throwing errors due to min being passed 0 args

### How Has This Been Tested? ###

yes

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [ x] My code follows the code style of this project.
- [ x] My change includes a change to the documentation, if required.
- [ x] I have read and agree to the **CONTRIBUTING** document.