### PR TITLE
AARCH64: Fix Functio Call Parameter Registers

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1626,7 +1626,7 @@ class AARCH64(ARM):
         7: "interrupt",
         6: "fast"
     }
-    function_parameters = ["$x0", "$x1", "$x2", "$x3"]
+    function_parameters = ["$x0", "$x1", "$x2", "$x3", "$x4", "$x5", "$x6", "$x7"]
     syscall_register = "$x8"
     syscall_instructions = ["svc $x0"]
 


### PR DESCRIPTION
## AARCH64: Fix Function Call Parameter Registers ##

### Description ###

Per the AARCH64 Procedure Call Standard Section 5.1.1 "The first eight
registers" are used to pass parameters to a function.

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |   |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | ✔️  |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
