### PR TITLE
Update target function regex

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7029,7 +7029,7 @@ class ContextCommand(GenericCommand):
             ops = " ".join(insn.operands)
             if "<" in ops and ">" in ops:
                 # extract it
-                target = re.sub(r".*<([^\(>]*).*", r"\1", ops)
+                target = re.sub(r".*<([^\(> ]*).*", r"\1", ops)
             else:
                 # it's an address, just use as is
                 target = re.sub(r".*(0x[a-fA-F0-9]*).*", r"\1", ops)


### PR DESCRIPTION
## Fix target function name extraction regex ##

The ops for a `call` instruction may be something like the following.

```
call <func_name at filename.c:42>
```

The current regex will attempt to lookup the global symbol "func_name at
filename.c:42". Instead we should lookup just "func_name".

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_check_mark: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
