### PR TITLE
AAarch64: Add the `hi` and `ls` conditions to the conditional branch logic

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1687,6 +1687,10 @@ class AARCH64(ARM):
             taken, reason = val&(1<<flags["zero"]) == 0 and val&(1<<flags["negative"]) == val&(1<<flags["overflow"]), "!Z && N==O"
         elif mnemo.endswith("ge"):
             taken, reason = val&(1<<flags["negative"]) == val&(1<<flags["overflow"]), "N==O"
+        elif mnemo.endswith("hi"):
+            taken, reason = val&(1<<flags["carry"]) and not val&(1<<flags["zero"]), "C && Z==O"
+        elif mnemo.endswith("ls"):
+            taken, reason = not val&(1<<flags["carry"]) or val&(1<<flags["zero"]), "C==O || Z"
         return taken, reason
 
 


### PR DESCRIPTION
## AAarch64: Add the `hi` and `ls` conditions to the conditional branch logic

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_check_mark: : |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

Example:
```
.section .text
.global main
main:
  mov x1, #0x8
  mov x0, x1, LSL #0x1c
  cmp x0, #0
  bhi correct
  ret
correct:
  cmp x0, #0
  bls incorrect
  mov x0, #0
incorrect:
  ret
```
### Checklist ###

- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
