### PR TITLE
Fix PIE checksec in foreign language system.

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1283,7 +1283,7 @@ def checksec(filename):
         results["NX"] = __check_security_property("-W -l", filename, r"GNU_STACK.*RWE") is False
     else:
         results["NX"] = False
-    results["PIE"] = __check_security_property("-h", filename, r"Type:.*EXEC") is False
+    results["PIE"] = __check_security_property("-h", filename, r":.*EXEC") is False
     results["Fortify"] = __check_security_property("-s", filename, r"_chk@GLIBC") is True
     results["Partial RelRO"] = __check_security_property("-l", filename, r"GNU_RELRO") is True
     results["Full RelRO"] = __check_security_property("-d", filename, r"BIND_NOW") is True


### PR DESCRIPTION
### Description
I have being using GEF in Ubuntu with Chinese language package. I found that the result of `checksec` command is not accurate on my OS.
This is the result of `checksec` from `pwntools`
```sh
[*] '/home/abc/test'
    Arch:     amd64-64-little
    RELRO:    Partial RELRO
    Stack:    No canary found
    NX:       NX enabled
    PIE:      No PIE (0x400000)
```
While in GEF, it gives:
```sh
Canary                        : No
NX                            : Yes
PIE                           : Yes
Fortify                       : No
RelRO                         : Partial
```
I look into the code of `checksec` command, it turns out the regular expression does not work correctly on when it is on a foreign language system. It checks `"Type:.*EXEC"` in the result of `readelf -h ./test`, but on my system the result looks like this for a binary without PIE.
```
ELF 头：
  Magic：   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 
  类别:                              ELF64
  数据:                              2 补码，小端序 (little endian)
  版本:                              1 (current)
  OS/ABI:                            UNIX - System V
  ABI 版本:                          0
  类型:                              EXEC (可执行文件)
  系统架构:                          Advanced Micro Devices X86-64
  版本:                              0x1
  入口点地址：               0x4008b0
  程序头起点：          64 (bytes into file)
  Start of section headers:          238080 (bytes into file)
  标志：             0x0
  本头的大小：       64 (字节)
  程序头大小：       56 (字节)
  Number of program headers:         9
  节头大小：         64 (字节)
  节头数量：         28
  字符串表索引节头： 27

```
The regex never matches because of the Chinese character in the result, I expect that this issue could also happens in other foreign language system.

<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

To fix this, I simply change `"Type:.*EXEC"` to `":.*EXEC"`. If you have other solution, please tell me.
### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | |
| x86-64       |:heavy_check_mark:|                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.
