### PR TITLE
Advance the address instead of repeating for memory commands

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7527,7 +7527,7 @@ class HexdumpCommand(GenericCommand):
             mem = read_memory(read_from, read_len)
             lines = hexdump(mem, base=read_from).splitlines()
         else:
-            lines = self._hexdump(read_from, read_len, fmt)
+            lines = self._hexdump(read_from, read_len, fmt, self.repeat_count * read_len)
 
         if not up_to_down:
             lines.reverse()
@@ -7536,7 +7536,7 @@ class HexdumpCommand(GenericCommand):
         return
 
 
-    def _hexdump(self, start_addr, length, arrange_as):
+    def _hexdump(self, start_addr, length, arrange_as, offset=0):
         elf = get_elf_headers()
         if elf is None:
             return
@@ -7553,16 +7553,14 @@ class HexdumpCommand(GenericCommand):
         fmt_pack = endianness + r
         lines = []
 
-        i = 0 + self.repeat_count * length
-        end = length * (self.repeat_count + 1)
-
-        while i < end:
-            cur_addr = start_addr + i * l
+        i = 0
+        while i < length:
+            cur_addr = start_addr + (i + offset) * l
             sym = gdb_get_location_from_symbol(cur_addr)
             sym = "<{:s}+{:04x}>".format(*sym) if sym else ''
             mem = read_memory(cur_addr, l)
             val = struct.unpack(fmt_pack, mem)[0]
-            lines.append(fmt_str % (cur_addr, i * l,  sym, val))
+            lines.append(fmt_str % (cur_addr, (i + offset) * l,  sym, val))
             i += 1
 
         return lines

--- a/gef.py
+++ b/gef.py
@@ -7501,7 +7501,6 @@ class HexdumpCommand(GenericCommand):
 
         start_addr = to_unsigned_long(gdb.parse_and_eval(argv[0]))
         read_from = align_address(start_addr)
-
         read_len = 0x40 if fmt=="byte" else 0x10
         up_to_down = True
 

--- a/gef.py
+++ b/gef.py
@@ -3605,7 +3605,7 @@ class GenericCommand(gdb.Command):
     def invoke(self, args, from_tty):
         try:
             argv = gdb.string_to_argv(args)
-            self.__set_repeat_count(argv, from_tty)
+            self.__set_repeat_count(from_tty)
             bufferize(self.do_invoke(argv))
         except Exception as e:
             # Note: since we are intercepting cleaning exceptions here, commands preferably should avoid
@@ -3670,7 +3670,7 @@ class GenericCommand(gdb.Command):
         del __config__[key]
         return
 
-    def __set_repeat_count(self, args, from_tty):
+    def __set_repeat_count(self, from_tty):
         if not from_tty:
             self.repeat = False
             self.repeat_count = 0

--- a/gef.py
+++ b/gef.py
@@ -3593,7 +3593,7 @@ class GenericCommand(gdb.Command):
         example = Color.yellowify("\nExample: ") + self._example_ if self._example_ else ""
         self.__doc__ = self.__doc__.replace(" "*4, "") + syntax + example
         self.repeat = False
-        self._last_command = None
+        self.__last_command = None
         command_type = kwargs.setdefault("command", gdb.COMMAND_OBSCURE)
         complete_type = kwargs.setdefault("complete", gdb.COMPLETE_NONE)
         prefix = kwargs.setdefault("prefix", False)
@@ -3674,8 +3674,8 @@ class GenericCommand(gdb.Command):
             return False
 
         command = gdb.execute("show commands", to_string=True).strip().split("\n")[-1]
-        repeated = self._last_command == command
-        self._last_command = command
+        repeated = self.__last_command == command
+        self.__last_command = command
 
         return repeated
 

--- a/gef.py
+++ b/gef.py
@@ -7655,6 +7655,7 @@ class DereferenceCommand(GenericCommand):
     def __init__(self):
         super(DereferenceCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
         self.add_setting("max_recursion", 7, "Maximum level of pointer recursion")
+        self.repeat_count = 0
         return
 
     @staticmethod
@@ -7714,13 +7715,18 @@ class DereferenceCommand(GenericCommand):
             err("Unmapped address")
             return
 
+        if self.repeat:
+            self.repeat_count += 1
+        else:
+            self.repeat_count = 0
+
         if get_gef_setting("context.grow_stack_down") is True:
-            from_insnum = nb-1
-            to_insnum = -1
+            from_insnum = nb * (self.repeat_count + 1) - 1
+            to_insnum = self.repeat_count * nb - 1
             insnum_step = -1
         else:
-            from_insnum = 0
-            to_insnum = nb
+            from_insnum = 0 + self.repeat_count * nb
+            to_insnum = nb * (self.repeat_count + 1)
             insnum_step = 1
 
         start_address = align_address(addr)


### PR DESCRIPTION
## Advance the address instead of repeating command for memory commands ##


### Description/Motivation/Screenshots ###
Currently when running commands like `telescope` or `hexdump` and you press return a second time the same command is run again. This PR adds a boolean property called `repeat` to `GenericCommand` allowing commands handlers to know whether the user had repeated the command by just pressing return.

This allows for behaviour similar to gdbs `x` where you can keep scanning through memory by just pressing return.

Currently this PR used the new property in `DereferenceCommand` and `HexdumpCommand` to advance the start address on a repeat.

![image](https://user-images.githubusercontent.com/1418260/46578152-628fa200-ca43-11e8-8786-1fe83da431d6.png)

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |                         |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] I have read and agree to the **CONTRIBUTING** document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hugsy/gef/333)
<!-- Reviewable:end -->
