### PR TITLE
fallback to read memory when gdb api fails to retrieve a cstring

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2178,7 +2178,7 @@ def read_cstring_from_memory(address, max_length=GEF_MAX_STRING_LENGTH, encoding
         length = min(address|(DEFAULT_PAGE_SIZE-1), max_length+1)
         mem = bytes(read_memory(address, length)).decode("utf-8")
         res = mem.split("\x00", 1)[0]
-    res2 = res.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+    res2 = res.encode("unicode_escape")
 
     if max_length and len(res) > max_length:
         return "{}[...]".format(res2[:max_length])

--- a/gef.py
+++ b/gef.py
@@ -2172,7 +2172,12 @@ def read_cstring_from_memory(address, max_length=GEF_MAX_STRING_LENGTH, encoding
 
     char_t = cached_lookup_type("char")
     char_ptr = char_t.pointer()
-    res = gdb.Value(address).cast(char_ptr).string(encoding=encoding).strip()
+    try:
+        res = gdb.Value(address).cast(char_ptr).string(encoding=encoding).strip()
+    except gdb.error:
+        length = min(address|(DEFAULT_PAGE_SIZE-1), max_length+1)
+        mem = read_memory(address, length).decode('utf-8')
+        res = mem.split('\x00', 1)[0]
     res2 = res.replace('\n','\\n').replace('\r','\\r').replace('\t','\\t')
 
     if max_length and len(res) > max_length:

--- a/gef.py
+++ b/gef.py
@@ -2176,9 +2176,9 @@ def read_cstring_from_memory(address, max_length=GEF_MAX_STRING_LENGTH, encoding
         res = gdb.Value(address).cast(char_ptr).string(encoding=encoding).strip()
     except gdb.error:
         length = min(address|(DEFAULT_PAGE_SIZE-1), max_length+1)
-        mem = bytes(read_memory(address, length)).decode('utf-8')
-        res = mem.split('\x00', 1)[0]
-    res2 = res.replace('\n','\\n').replace('\r','\\r').replace('\t','\\t')
+        mem = bytes(read_memory(address, length)).decode("utf-8")
+        res = mem.split("\x00", 1)[0]
+    res2 = res.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
 
     if max_length and len(res) > max_length:
         return "{}[...]".format(res2[:max_length])
@@ -2916,7 +2916,7 @@ def cached_lookup_type(_type):
 def get_memory_alignment(in_bits=False):
     """Return sizeof(size_t). If `in_bits` is set to True, the result is
     returned in bits, otherwise in bytes."""
-    res = cached_lookup_type('size_t')
+    res = cached_lookup_type("size_t")
     if res is not None:
         return res.sizeof if not in_bits else res.sizeof * 8
     if is_elf32():

--- a/gef.py
+++ b/gef.py
@@ -2176,7 +2176,7 @@ def read_cstring_from_memory(address, max_length=GEF_MAX_STRING_LENGTH, encoding
         res = gdb.Value(address).cast(char_ptr).string(encoding=encoding).strip()
     except gdb.error:
         length = min(address|(DEFAULT_PAGE_SIZE-1), max_length+1)
-        mem = read_memory(address, length).decode('utf-8')
+        mem = bytes(read_memory(address, length)).decode('utf-8')
         res = mem.split('\x00', 1)[0]
     res2 = res.replace('\n','\\n').replace('\r','\\r').replace('\t','\\t')
 


### PR DESCRIPTION
## <TITLE OF YOUR PATCH HERE> ##

### Description/Motivation/Screenshots ###
sometimes I can encounter this problem `Getting a string is unsupported in this language`.
And according #301 , it is because gdb cannot retrieve string in obj-c. So I add a fallback to this function so it can read string as expected.
And this patch resolves #301

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
~- [ ] My change includes a change to the documentation, if required.~
~- [ ] My change adds tests as approriate.~
- [x] I have read and agree to the **CONTRIBUTING** document.