### PR TITLE
Add gdb convenience functions for working with heap and other randomised section addresses

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,6 +21,7 @@ improve it.
 |elf-info                  | Display ELF header informations.|
 |entry-break               | Tries to find best entry point and sets a temporary breakpoint on it. (alias: start-break)|
 |format-string-helper      | Exploitable format-string helper: this command will set up specific breakpoints at well-known dangerous functions (printf, snprintf, etc.), and check if the pointer holding the format string is writable, and  susceptible to format string attacks if an attacker can control its content. (alias: fmtstr-helper)|
+|functions                 | List the convenience functions provided by GEF.|
 |gef-remote                | gef wrapper for the `target remote` command. This command will automatically download the target binary in the local temporary directory (defaut /tmp) and then source it. Additionally, it will fetch all the /proc/PID/maps and loads all its information.|
 |heap                      | Base command to get information about the Glibc heap structure.|
 |heap-analysis-helper      | Tracks dynamic heap allocation through malloc/free to try to detect heap vulnerabilities.|

--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -1,0 +1,25 @@
+## Command functions ##
+
+The `functions` command will list all of the [convenience functions](https://sourceware.org/gdb/onlinedocs/gdb/Convenience-Funs.html) provided by GEF.
+
+* `$_bss([offset])`    -- Return the current bss base address plus the given offset.
+* `$_got([offset])`    -- Return the current bss base address plus the given offset.
+* `$_heap([offset])`   -- Return the current heap base address plus an optional offset.
+* `$_pie([offset])`    -- Return the current pie base address plus an optional offset.
+* `$_stack([offset])`  -- Return the current stack base address plus an optional offset.
+
+
+These functions can be used as arguments to other commands to dynamically calculate values.
+
+```
+gef➤  deref $_heap() l4
+0x0000000000602000│+0x00: 0x0000000000000000	 ← $r8
+0x0000000000602008│+0x08: 0x0000000000000021 ("!"?)
+0x0000000000602010│+0x10: 0x0000000000000000	 ← $rax, $rdx
+0x0000000000602018│+0x18: 0x0000000000000000
+gef➤  deref $_heap(0x20) l4
+0x0000000000602020│+0x00: 0x0000000000000000	 ← $rsi
+0x0000000000602028│+0x08: 0x0000000000020fe1
+0x0000000000602030│+0x10: 0x0000000000000000
+0x0000000000602038│+0x18: 0x0000000000000000
+```

--- a/gef.py
+++ b/gef.py
@@ -8652,21 +8652,21 @@ class GenericOffsetFunction(gdb.Function):
 @register_function
 class StackOffsetFunction(GenericOffsetFunction):
     """Return the current stack base address plus the given offset."""
-    _function_ = '_stack'
+    _function_ = "_stack"
     _section_ = "[stack]"
     _zone_ = None
 
 @register_function
 class HeapBaseFunction(GenericOffsetFunction):
     """Return the current heap base address plus the given offset."""
-    _function_ = '_heap'
+    _function_ = "_heap"
     _section_ = "[heap]"
     _zone_ = None
 
 @register_function
 class PieBaseFunction(GenericOffsetFunction):
     """Return the current pie base address plus the given offset."""
-    _function_ = '_pie'
+    _function_ = "_pie"
     _zone_ = None
     @property
     def _section_(self):
@@ -8675,14 +8675,14 @@ class PieBaseFunction(GenericOffsetFunction):
 @register_function
 class BssBaseFunction(GenericOffsetFunction):
     """Return the current bss base address plus the given offset."""
-    _function_ = '_bss'
+    _function_ = "_bss"
     _zone_ = ".bss"
     _section_ = None
 
 @register_function
 class GotBaseFunction(GenericOffsetFunction):
     """Return the current bss base address plus the given offset."""
-    _function_ = '_got'
+    _function_ = "_got"
     _zone_ = ".got"
     _section_ = None
 

--- a/gef.py
+++ b/gef.py
@@ -8695,7 +8695,7 @@ class GotBaseFunction(GenericOffsetFunction):
 @register_command
 class GefFunctionsCommand(GenericCommand):
     """List the convenience functions provided by GEF."""
-    _cmdline_ = 'functions'
+    _cmdline_ = "functions"
     _syntax_ = _cmdline_
 
     def __init__(self):

--- a/gef.py
+++ b/gef.py
@@ -8634,6 +8634,9 @@ class GenericOffsetFunction(gdb.Function):
         super(GenericOffsetFunction, self).__init__(self._function_)
 
     def invoke(self, offset=gdb.Value(0)):
+        if not is_alive():
+            raise gdb.GdbError("No debugging session active")
+
         base_address = self.get_base_address()
         if not base_address:
             raise gdb.GdbError("No {} section".format(self._section_ or self._zone_))

--- a/gef.py
+++ b/gef.py
@@ -8723,7 +8723,8 @@ class GefFunctionsCommand(GenericCommand):
     def do_invoke(self, argv):
         self.dont_repeat()
         gef_print(titlify("GEF - Convenience Functions"))
-        gef_print("These functions can be used as arguments to other commands to dynamically calculate values, eg: {:s}\n"
+        gef_print("These functions can be used as arguments to other "
+                  "commands to dynamically calculate values, eg: {:s}\n"
                   .format(Color.colorify("deref $_heap(0x20)", attrs="yellow")))
         gef_print(self.__doc__)
         return

--- a/gef.py
+++ b/gef.py
@@ -2532,7 +2532,7 @@ def process_lookup_path(name, perm=Permission.ALL):
     return None
 
 def file_lookup_name_path(name, path):
-    """Look up for a file by its name and path.
+    """Look up a file by name and path.
     Return a Zone object if found, None otherwise."""
     for xfile in get_info_files():
         if path == xfile.filename and name == xfile.name:
@@ -3591,7 +3591,7 @@ def register_priority_command(cls):
     return cls
 
 def register_function(cls):
-    """Decorator for registering new GEF (sub-)command to GDB."""
+    """Decorator for registering a new convenience function to GDB."""
     global __functions__
     __functions__.append(cls)
     return cls
@@ -8651,24 +8651,21 @@ class GenericOffsetFunction(gdb.Function):
 
 @register_function
 class StackOffsetFunction(GenericOffsetFunction):
-    """Returns the current stack base address plus the given offset"""
-
+    """Return the current stack base address plus the given offset."""
     _function_ = '_stack'
     _section_ = "[stack]"
     _zone_ = None
 
 @register_function
 class HeapBaseFunction(GenericOffsetFunction):
-    """Returns the current heap base address plus the given offset"""
-
+    """Return the current heap base address plus the given offset."""
     _function_ = '_heap'
     _section_ = "[heap]"
     _zone_ = None
 
 @register_function
 class PieBaseFunction(GenericOffsetFunction):
-    """Returns the current pie base address plus the given offset"""
-
+    """Return the current pie base address plus the given offset."""
     _function_ = '_pie'
     _zone_ = None
     @property
@@ -8677,16 +8674,14 @@ class PieBaseFunction(GenericOffsetFunction):
 
 @register_function
 class BssBaseFunction(GenericOffsetFunction):
-    """Returns the current bss base address plus the given offset"""
-
+    """Return the current bss base address plus the given offset."""
     _function_ = '_bss'
     _zone_ = ".bss"
     _section_ = None
 
 @register_function
 class GotBaseFunction(GenericOffsetFunction):
-    """Returns the current bss base address plus the given offset"""
-
+    """Return the current bss base address plus the given offset."""
     _function_ = '_got'
     _zone_ = ".got"
     _section_ = None
@@ -8792,7 +8787,7 @@ class GefCommand(gdb.Command):
 
 
     def load(self, initial=False):
-        """Load all the commands defined by GEF into GDB."""
+        """Load all the commands and functions defined by GEF into GDB."""
         nb_missing = 0
         self.commands = [(x._cmdline_, x) for x in __commands__]
 

--- a/gef.py
+++ b/gef.py
@@ -8621,12 +8621,14 @@ class GenericOffsetFunction(gdb.Function):
     def __init__ (self):
         super(GenericOffsetFunction, self).__init__(self._function_)
 
-    def invoke(self, offset=0):
+    def invoke(self, offset=gdb.Value(0)):
         section = process_lookup_path(self._section_)
+
         if not section:
             raise gdb.GdbError("No {} section".format(self._section_))
 
-        return long(section.page_start + offset)
+        addr = long(offset) if offset.address is None else long(offset.address)
+        return long(section.page_start + addr)
 
 @register_function
 class StackOffsetFunction(GenericOffsetFunction):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ pages:
 - Command entry-break: commands/entry-break.md
 - Command eval: commands/eval.md
 - Command format-string-helper: commands/format-string-helper.md
+- Command functions: commands/functions.md
 - Command gef-remote: commands/gef-remote.md
 - Command heap: commands/heap.md
 - Command heap-analysis-helper: commands/heap-analysis-helper.md

--- a/tests/binaries/bss.c
+++ b/tests/binaries/bss.c
@@ -1,0 +1,19 @@
+/**
+ * default.c
+ * -*- mode: c -*-
+ * -*- coding: utf-8 -*-
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+char msg[0x100];
+
+int main(int argc, char** argv, char** envp)
+{
+        strncpy(msg, "Hello world!", sizeof(msg));
+        __asm__ volatile("int3;" : : : );
+        return EXIT_SUCCESS;
+}

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -127,6 +127,13 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         self.assertIn(b"Possible insecure format string:", res)
         return
 
+    def test_cmd_functions(self):
+        cmd = "functions"
+        res = gdb_run_cmd(cmd)
+        self.assertNoException(res)
+        self.assertIn(b"$_heap", res)
+        return
+
     def test_cmd_heap_arenas(self):
         cmd = "heap arenas"
         target = "tests/binaries/heap.out"
@@ -501,6 +508,39 @@ class TestGefFunctions(GefUnitTestGeneric):
         self.assertTrue(int(res.splitlines()[-1]))
         return
 
+class TestGdbFunctions(GefUnitTestGeneric):
+    """Tests gdb convenience functions added by GEF."""
+
+    def test_func_pie(self):
+        cmd = "x/s $_pie()"
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd))
+        res = gdb_start_silent_cmd(cmd)
+        self.assertNoException(res)
+        self.assertIn(b"\\177ELF", res)
+
+        cmd = "x/s $_pie(1)"
+        res = gdb_start_silent_cmd(cmd)
+        self.assertNoException(res)
+        self.assertNotIn(b"\\177ELF", res)
+        self.assertIn(b"ELF", res)
+
+        return
+
+    def test_func_heap(self):
+        cmd = "deref $_heap()"
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target="tests/binaries/heap.out"))
+        res = gdb_run_silent_cmd(cmd, target="tests/binaries/heap.out")
+        self.assertNoException(res)
+        self.assertIn(b"0x0000000000000021", res)
+        self.assertIn(b"0x0000000000020fe1", res)
+
+        cmd = "deref $_heap(0x10+0x10)"
+        res = gdb_run_silent_cmd(cmd, target="tests/binaries/heap.out")
+        self.assertNoException(res)
+        self.assertNotIn(b"0x0000000000000021", res)
+        self.assertIn(b"0x0000000000020fe1", res)
+
+        return
 
 class TestGefMisc(GefUnitTestGeneric):
     """Tests external functionality."""
@@ -517,6 +557,7 @@ def run_tests():
     test_instances = [
         TestGefCommands,
         TestGefFunctions,
+        TestGdbFunctions,
         TestGefMisc,
     ]
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -523,7 +523,6 @@ class TestGdbFunctions(GefUnitTestGeneric):
         self.assertNoException(res)
         self.assertNotIn(b"\\177ELF", res)
         self.assertIn(b"ELF", res)
-
         return
 
     def test_func_heap(self):
@@ -539,7 +538,30 @@ class TestGdbFunctions(GefUnitTestGeneric):
         self.assertNoException(res)
         self.assertNotIn(b"0x0000000000000021", res)
         self.assertIn(b"0x0000000000020fe1", res)
+        return
 
+    def test_func_got(self):
+        cmd = "deref $_got()"
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target="tests/binaries/heap.out"))
+        res = gdb_run_silent_cmd(cmd, target="tests/binaries/heap.out")
+        self.assertNoException(res)
+        self.assertIn(b"malloc", res)
+        return
+
+    def test_func_bss(self):
+        cmd = "deref $_bss()"
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target="tests/binaries/bss.out"))
+        res = gdb_run_silent_cmd(cmd, target="tests/binaries/bss.out")
+        self.assertNoException(res)
+        self.assertIn(b"Hello world!", res)
+        return
+
+    def test_func_stack(self):
+        cmd = "deref $_stack()"
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd))
+        res = gdb_start_silent_cmd(cmd)
+        self.assertNoException(res)
+        self.assertIn(b"+0x20: 0x0000000000000000", res)
         return
 
 class TestGefMisc(GefUnitTestGeneric):


### PR DESCRIPTION
## Add gdb functions for working with heap and other randomised section addresses ##

### Description/Motivation/Screenshots ###
Quite often when debugging we need to print out the heap or an offset from the heap, and having to run `vmmap` to get the base address and copy/paste can be annoying. [GDB convenience functions](https://sourceware.org/gdb/onlinedocs/gdb/Functions-In-Python.html#Functions-In-Python) are just like convenience variables and can be used as arguments to other commands:

![image](https://user-images.githubusercontent.com/1418260/46603187-12493a80-cb3e-11e8-9b23-62e8cea617ee.png)

This PR adds functions for (offset is optional):
* `$_heap(offset)`
* `$_pie(offset)`
* `$_stack(offset)`
* `$_bss(offset)`
* `$_got(offset)`

 Happy to change or discuss the naming convention for these, this is just how the gdb built-in functions are (eg `$_strlen(str)`)

There's no doco or tests yet, just wanted to get any initial feedback first and then I'll make any changes and add them.

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hugsy/gef/339)
<!-- Reviewable:end -->
