### PR TITLE
hexdump: Allow shorter form for size and direction

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7590,8 +7590,15 @@ class HexdumpCommand(GenericCommand):
             self.usage()
             return
 
-        fmt, argv = argv[0], argv[1:]
-        if fmt not in {"qword", "dword", "word", "byte"}:
+        fmt, argv = argv[0].lower(), argv[1:]
+        fmt_map = {
+            "qword": "qword", "q": "qword",
+            "dword": "dword", "d": "dword",
+            "word": "word", "w": "word",
+            "byte": "byte", "b": "byte",
+        }
+        fmt = fmt_map.get(fmt)
+        if not fmt:
             self.usage()
             return
 
@@ -7611,10 +7618,10 @@ class HexdumpCommand(GenericCommand):
                 except ValueError:
                     pass
 
-                if arg == "up":
+                if arg in {"up", "u"}:
                     up_to_down = True
                     continue
-                elif arg == "down":
+                elif arg in {"down", "d"}:
                     up_to_down = False
                     continue
 

--- a/gef.py
+++ b/gef.py
@@ -7590,14 +7590,13 @@ class HexdumpCommand(GenericCommand):
             self.usage()
             return
 
-        fmt, argv = argv[0].lower(), argv[1:]
-        fmt_map = {
-            "qword": "qword", "q": "qword",
-            "dword": "dword", "d": "dword",
-            "word": "word", "w": "word",
-            "byte": "byte", "b": "byte",
-        }
-        fmt = fmt_map.get(fmt)
+        arg0, argv = argv[0].lower(), argv[1:]
+        valid_formats = ["byte", "word", "dword", "qword"]
+        fmt = None
+        for valid_format in valid_formats:
+            if valid_format.startswith(arg0):
+                fmt = valid_format
+                break
         if not fmt:
             self.usage()
             return

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -561,7 +561,7 @@ class TestGdbFunctions(GefUnitTestGeneric):
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd))
         res = gdb_start_silent_cmd(cmd)
         self.assertNoException(res)
-        self.assertIn(b"+0x20: 0x0000000000000000", res)
+        self.assertRegex(res.decode(), r"\+0x0*20: *0x0000000000000000\n")
         return
 
 class TestGefMisc(GefUnitTestGeneric):


### PR DESCRIPTION
Allow `hexdump q` instead of forcing `hexdump qword`, etc.