### PR TITLE
set mode based on current thumb flag

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1520,7 +1520,6 @@ class RISCV(Architecture):
 
 class ARM(Architecture):
     arch = "ARM"
-    mode = "ARM"
 
     all_registers = ["$r0", "$r1", "$r2", "$r3", "$r4", "$r5", "$r6",
                      "$r7", "$r8", "$r9", "$r10", "$r11", "$r12", "$sp",
@@ -1543,6 +1542,10 @@ class ARM(Architecture):
     function_parameters = ["$r0", "$r1", "$r2", "$r3"]
     syscall_register = "$r7"
     syscall_instructions = ["swi 0x0", "swi NR"]
+
+    @property
+    def mode(self):
+        return "THUMB" if is_arm_thumb() else "ARM"
 
     @property
     def instruction_length(self):


### PR DESCRIPTION
Fixes https://github.com/hugsy/gef/issues/302 and https://github.com/hugsy/gef/issues/303

Tested using `./gdbserver-7.7.1-armel-eabi5-v1-sysv 0.0.0.0:12345 ./thumb_demo` in an arm_now `armv7-eabihf` machine.

cs in ARM mode:
![image](https://user-images.githubusercontent.com/1418260/46736939-04361e00-cce6-11e8-9540-997f10319ce3.png)

cs in THUMB mode:
![image](https://user-images.githubusercontent.com/1418260/46736960-0c8e5900-cce6-11e8-9b89-a06f79bece3e.png)

asm in ARM mode:
![image](https://user-images.githubusercontent.com/1418260/46736900-e5d02280-cce5-11e8-9d6a-0c2210bd2cc7.png)

asm in THUMB mode:
![image](https://user-images.githubusercontent.com/1418260/46736878-d5b84300-cce5-11e8-963a-5c9d0e5403df.png)

emu in ARM mode:
![image](https://user-images.githubusercontent.com/1418260/46737771-1b760b00-cce8-11e8-9bae-af7fd9fc7357.png)

emu in THUMB mode:
![image](https://user-images.githubusercontent.com/1418260/46737991-aa832300-cce8-11e8-8b4c-e8612a7c0ae3.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hugsy/gef/343)
<!-- Reviewable:end -->
