### PR TITLE
Show changed reg colour in name and section in value

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ API to assist during the process of dynamic analysis and exploit development.
 It has full support for both Python2 and Python3 indifferently (as more and more
 distros start pushing `gdb` compiled with Python3 support).
 
-![gef-context](https://i.imgur.com/i0Hkw2C.png)
+![gef-context](https://i.imgur.com/E3EuQPs.png)
 
 
 *Some* of `GEF` features include:


### PR DESCRIPTION
In context_regs and 'registers' command, instead of colouring the value
of the register based on whether it changed since the last stop, colour
the name. This allows us to colour the value based on the section, as we
do with `deref`.
<img width="838" alt="1__tmux" src="https://user-images.githubusercontent.com/497310/46781542-e6ad8800-ccd6-11e8-80ba-dd204be28d8d.png">
