### PR TITLE
bufferize takes a function

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3650,7 +3650,7 @@ class GenericCommand(gdb.Command):
         try:
             argv = gdb.string_to_argv(args)
             self.__set_repeat_count(from_tty)
-            bufferize(self.do_invoke(argv))
+            bufferize(self.do_invoke)(argv)
         except Exception as e:
             # Note: since we are intercepting cleaning exceptions here, commands preferably should avoid
             # catching generic Exception, but rather specific ones. This is allows a much cleaner use.

--- a/gef.py
+++ b/gef.py
@@ -311,14 +311,14 @@ def bufferize(f):
         global __gef_int_stream_buffer__
 
         if __gef_int_stream_buffer__:
-            f(*args, **kwargs)
-            return
+            return f(*args, **kwargs)
 
         __gef_int_stream_buffer__ = StringIO()
-        f(*args, **kwargs)
+        rv = f(*args, **kwargs)
         sys.stdout.write(__gef_int_stream_buffer__.getvalue())
         sys.stdout.flush()
         __gef_int_stream_buffer__ = None
+        return rv
 
     return wrapper
 


### PR DESCRIPTION
Found while testing https://github.com/hugsy/gef/pull/338 on python 2, all commands return the following:

```
------------------------------- Exception raised -------------------------------
AttributeError: 'NoneType' object has no attribute '__module__'
----------------------------- Detailed stacktrace ------------------------------
\-> File "/usr/lib/python2.7/functools.py", line 33, in update_wrapper()
   ->    setattr(wrapper, attr, getattr(wrapped, attr))
\-> File "/home/will/github/gef/gef.py", line 308, in bufferize()
   ->    @functools.wraps(f)
\-> File "/home/will/github/gef/gef.py", line 3611, in invoke()
   ->    bufferize(self.do_invoke(argv))
```

I'm not really sure what `bufferize` does but we are currently always passing it `None` instead of a function, as it's getting the return value of `self.do_invoke(argv)`. Python 3 must just silently ignore this but python 2 blows up.

The other option would be to remove it as it wasn't doing anything for the past 3 months or so anyway :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hugsy/gef/349)
<!-- Reviewable:end -->
