### PR TITLE
Fix bufferize

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -314,10 +314,12 @@ def bufferize(f):
             return f(*args, **kwargs)
 
         __gef_int_stream_buffer__ = StringIO()
-        rv = f(*args, **kwargs)
-        sys.stdout.write(__gef_int_stream_buffer__.getvalue())
-        sys.stdout.flush()
-        __gef_int_stream_buffer__ = None
+        try:
+            rv = f(*args, **kwargs)
+        finally:
+            sys.stdout.write(__gef_int_stream_buffer__.getvalue())
+            sys.stdout.flush()
+            __gef_int_stream_buffer__ = None
         return rv
 
     return wrapper


### PR DESCRIPTION
@wbowling noticed that if you get a command to fail, all subsequent commands break.

This is because when the bufferize wrapper calls the function, if there's an unhandled exception, then it won't fix `sys.stdout`.

Simply moved the stdout repair into a finally block.