### PR TITLE
Add pl and mi conditional codes

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1740,6 +1740,10 @@ class AARCH64(ARM):
             taken, reason = val&(1<<flags["carry"]) and not val&(1<<flags["zero"]), "C && Z==O"
         elif mnemo.endswith("ls"):
             taken, reason = not val&(1<<flags["carry"]) or val&(1<<flags["zero"]), "C==O || Z"
+        elif mnemo.endswith("mi"):
+            taken, reason = val&(1<<flags["negative"]), "N"
+        elif mnemo.endswith("pl"):
+            taken, reason = not val&(1<<flags["negative"]), "N==O"
         return taken, reason
 
 


### PR DESCRIPTION
## Add the `pl` and `mi` conditional codes to Aarch64 branch logic

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_check_mark: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |
