### PR TITLE
Fix arm and x86 conditionals

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1726,28 +1726,8 @@ class AARCH64(ARM):
                 if (op & 1<<i) == 0: taken, reason = True, "{}&1<<{}==0".format(reg,i)
                 else: taken, reason = False, "{}&1<<{}!=0".format(reg,i)
 
-        elif mnemo.endswith("eq"): taken, reason = bool(val&(1<<flags["zero"])), "Z"
-        elif mnemo.endswith("ne"): taken, reason = not val&(1<<flags["zero"]), "!Z"
-        elif mnemo.endswith("lt"):
-            taken, reason = bool(val&(1<<flags["negative"])) != bool(val&(1<<flags["overflow"])), "N!=V"
-        elif mnemo.endswith("le"):
-            taken, reason = val&(1<<flags["zero"]) or \
-                bool(val&(1<<flags["negative"])) != bool(val&(1<<flags["overflow"])), "Z || N!=V"
-        elif mnemo.endswith("gt"):
-            taken, reason = val&(1<<flags["zero"]) == 0 and \
-                bool(val&(1<<flags["negative"])) == bool(val&(1<<flags["overflow"])), "!Z && N==V"
-        elif mnemo.endswith("ge"):
-            taken, reason = bool(val&(1<<flags["negative"])) == bool(val&(1<<flags["overflow"])), "N==V"
-        elif mnemo.endswith("vs"): taken, reason = bool(val&(1<<flags["overflow"])), "V"
-        elif mnemo.endswith("vc"): taken, reason = not val&(1<<flags["overflow"]), "!V"
-        elif mnemo.endswith("mi"):
-            taken, reason = bool(val&(1<<flags["negative"])), "N"
-        elif mnemo.endswith("pl"):
-            taken, reason = not val&(1<<flags["negative"]), "N==0"
-        elif mnemo.endswith("hi"):
-            taken, reason = val&(1<<flags["carry"]) and not val&(1<<flags["zero"]), "C && !Z"
-        elif mnemo.endswith("ls"):
-            taken, reason = not val&(1<<flags["carry"]) or val&(1<<flags["zero"]), "!C || Z"
+        if not reason:
+            taken, reason = super(AARCH64, self).is_branch_taken(insn)
         return taken, reason
 
 


### PR DESCRIPTION
Fixes #360 

On ARM, AARCH64, and x86 we were not correctly comparing if two flags
were equal: Because we were comparing the masked value instead of
whether the bit was set, these would NEVER be true.

For example for `ge` on x86, the branch is taken is SF==OF, but we were
comparing  flags&(1<<7) == flags&(1<<11). Even if both flags were set,
we'd be comparing 0b10000000 with 0b100000000000, which would never be
true.

This assumes that gdb prints conditionals in a certain way (e.g. `ble` not `bleq`). This needs to be tested.

- [x] Test on ARM.