### PR TITLE
Add tcache support

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -306,7 +306,6 @@ def gef_print(x="", *args, **kwargs):
 def bufferize(f):
     """Store the content to be printed for a function in memory, and flush it on function exit."""
 
-    return f # DELETEME
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         global __gef_int_stream_buffer__

--- a/gef.py
+++ b/gef.py
@@ -6089,25 +6089,6 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
     def __init__(self):
         super(GlibcHeapTcachebinsCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
         return
-        """
-        /* We overlay this structure on the user-data portion of a chunk when
-           the chunk is stored in the per-thread cache.  */
-        typedef struct tcache_entry
-        {
-          struct tcache_entry *next;
-        } tcache_entry;
-
-        /* There is one of these for each thread, which contains the
-           per-thread cache (hence "tcache_perthread_struct").  Keeping
-           overall size low is mildly important.  Note that COUNTS and ENTRIES
-           are redundant (we could have just counted the linked list each
-           time), this is for performance reasons.  */
-        typedef struct tcache_perthread_struct
-        {
-          char counts[TCACHE_MAX_BINS];
-          tcache_entry *entries[TCACHE_MAX_BINS];
-        }
-        """
 
     @only_if_gdb_running
     def do_invoke(self, argv):
@@ -6131,30 +6112,7 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
             return
 
         # Get tcache_perthread_struct for this arena
-        # TODO: Try &mp_.sbrk_base
         addr = int(gdb.execute("p/x $_heap()", to_string=True).split(" = ")[-1], 0) + 0x10
-
-        """
-        gef➤  p mp_
-        $197 = {
-            trim_threshold = 0x20000,
-            top_pad = 0x20000,
-            mmap_threshold = 0x20000,
-            arena_test = 0x8,
-            arena_max = 0x0,
-            n_mmaps = 0x0,
-            n_mmaps_max = 0x10000,
-            max_n_mmaps = 0x0,
-            no_dyn_threshold = 0x0,
-            mmapped_mem = 0x0,
-            max_mmapped_mem = 0x0,
-            sbrk_base = 0x555555756000 "",
-            tcache_bins = 0x40,
-            tcache_max_bytes = 0x408,
-            tcache_count = 0x7,
-            tcache_unsorted_limit = 0x0
-        }
-                """
 
         gef_print(titlify("Tcachebins for arena {:#x}".format(int(arena))))
         for i in range(GlibcArena.TCACHE_MAX_BINS):

--- a/gef.py
+++ b/gef.py
@@ -646,7 +646,7 @@ class GlibcArena:
 
     def tcachebin(self, i):
         """Return head chunk in tcache[i]."""
-        heap_base = int(gdb.execute("p/x $_heap()", to_string=True).split()[-1], 0)
+        heap_base = HeapBaseFunction.heap_base()
         addr = dereference(heap_base + 2*current_arch.ptrsize + self.TCACHE_MAX_BINS + i*current_arch.ptrsize)
         if not addr:
             return None
@@ -6108,7 +6108,7 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
             return
 
         # Get tcache_perthread_struct for this arena
-        addr = int(gdb.execute("p/x $_heap()", to_string=True).split(" = ")[-1], 0) + 0x10
+        addr = HeapBaseFunction.heap_base() + 0x10
 
         gef_print(titlify("Tcachebins for arena {:#x}".format(int(arena))))
         for i in range(GlibcArena.TCACHE_MAX_BINS):

--- a/gef.py
+++ b/gef.py
@@ -6092,9 +6092,15 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
     @only_if_gdb_running
     def do_invoke(self, argv):
         # Determine if we are using libc with tcache built in (2.26+)
-        libc = gdb.execute("vmmap libc", to_string=True)
+        sections = get_process_maps()
         try:
-            libc_version = tuple(int(_) for _ in re.search(r"libc-(\d+)\.(\d+)\.so", libc).groups())
+            for section in sections:
+                if "libc-" in section.path:
+                    libc_version = tuple(int(_) for _ in
+                                         re.search(r"libc-(\d+)\.(\d+)\.so", section.path).groups())
+                    break
+            else:
+                libc_version = 0, 0
         except AttributeError:
             libc_version = 0, 0
         if libc_version < (2, 26):


### PR DESCRIPTION
Add basic tcache support.

Super ugly for now.

`dereference_as_long` seems to be broken in my case: When I deference the start of the chain, I get the original address back. I have no idea how this function ever works. I use `read_memory` directly.

~This doesn't work with bufferize! We parse out the libc version, but if we are bufferizing, `gdb.execute("vmmap libc")` returns an empty string, so we can't get the version. See #362.~
^ We use `get_process_maps` to sidestep this issue.

- ~[ ] Merge after #364: This'll allow this to work without having to disable buffering.~
- [x] Merge after #366: This'll allow us to get the heap base using a helper function instead of `gdb.execute`.
- [x] Re-enable `bufferize`.