### PR TITLE
Allow the patch command to take an expression as the value

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7776,7 +7776,7 @@ class PatchCommand(GenericCommand):
 
         d = "<" if is_little_endian() else ">"
         for value in values:
-            value = int(value, 0) & ((1 << size * 8) - 1)
+            value = parse_address(value) & ((1 << size * 8) - 1)
             vstr = struct.pack(d + fcode, value)
             write_memory(addr, vstr, length=size)
             addr += size


### PR DESCRIPTION
I needed to patch something each time base on the address of `_IO_2_1_stdout_`, but the patch command only worked with raw addresses.

Example:
```bash
gef➤  patch qword $_heap(0xcc0) &_IO_2_1_stdout_
```