### PR TITLE
context_code unable to disassemble $PC

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1186,7 +1186,7 @@ def gdb_get_nth_previous_instruction_address(addr, n):
         if insns[-1].address==cur_insn_addr:
             return insns[0].address
 
-    return -1
+    return None
 
 
 def gdb_get_nth_next_instruction_address(addr, n):


### PR DESCRIPTION
When stepping through a ROP chain if found that `gef_disassemble` calls `gdb_get_nth_previous_instruction_address` which could return `-1` causing the following:

<img width="530" alt="image" src="https://user-images.githubusercontent.com/1418260/47545991-e51cca80-d93a-11e8-9b2f-b1fbd14b6913.png">

I think `None` is more appropriate and `gef_disassemble` already checks for it fixing the issue:
<img width="520" alt="image" src="https://user-images.githubusercontent.com/1418260/47545961-c3234800-d93a-11e8-804c-96c8e14e76ca.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hugsy/gef/370)
<!-- Reviewable:end -->
