### PR TITLE
heap commands with no symbols

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -5994,7 +5994,7 @@ class GlibcHeapSetArenaCommand(GenericCommand):
             return
 
         if argv[0].startswith("0x"):
-            new_arena = Address(to_unsigned_long(new_arena))
+            new_arena = Address(value=to_unsigned_long(new_arena))
             if new_arena is None or not new_arena.valid:
                 err("Invalid location")
                 return
@@ -6110,7 +6110,7 @@ class GlibcHeapChunksCommand(GenericCommand):
             if next_chunk is None:
                 break
 
-            next_chunk_addr = Address(next_chunk.address)
+            next_chunk_addr = Address(value=next_chunk.address)
             if not next_chunk_addr.valid:
                 # corrupted
                 break

--- a/gef.py
+++ b/gef.py
@@ -705,8 +705,8 @@ class GlibcArena:
     Ref: https://github.com/sploitfun/lsploits/blob/master/glibc/malloc/malloc.c#L1671 """
     TCACHE_MAX_BINS = 0x40
 
-    def __init__(self, addr, name=__gef_default_main_arena__):
-        self.__name = name
+    def __init__(self, addr, name=None):
+        self.__name = name or __gef_default_main_arena__
         try:
             arena = gdb.parse_and_eval(addr)
             malloc_state_t = cached_lookup_type("struct malloc_state")
@@ -6316,7 +6316,7 @@ class GlibcHeapUnsortedBinsCommand(GenericCommand):
             err("Invalid Glibc arena")
             return
 
-        arena_addr = "*{:s}".format(argv[0]) if len(argv) == 1 else "main_arena"
+        arena_addr = "*{:s}".format(argv[0]) if len(argv) == 1 else __gef_default_main_arena__
         gef_print(titlify("Unsorted Bin for arena '{:s}'".format(arena_addr)))
         nb_chunk = GlibcHeapBinsCommand.pprint_bin(arena_addr, 0, "unsorted_")
         if nb_chunk >= 0:
@@ -6340,7 +6340,7 @@ class GlibcHeapSmallBinsCommand(GenericCommand):
             err("Invalid Glibc arena")
             return
 
-        arena_addr = "*{:s}".format(argv[0]) if len(argv) == 1 else "main_arena"
+        arena_addr = "*{:s}".format(argv[0]) if len(argv) == 1 else __gef_default_main_arena__
         gef_print(titlify("Small Bins for arena '{:s}'".format(arena_addr)))
         bins = {}
         for i in range(1, 63):
@@ -6369,7 +6369,7 @@ class GlibcHeapLargeBinsCommand(GenericCommand):
             err("Invalid Glibc arena")
             return
 
-        arena_addr = "*{:s}".format(argv[0]) if len(argv) == 1 else "main_arena"
+        arena_addr = "*{:s}".format(argv[0]) if len(argv) == 1 else __gef_default_main_arena__
         gef_print(titlify("Large Bins for arena '{:s}'".format(arena_addr)))
         bins = {}
         for i in range(63, 126):

--- a/gef.py
+++ b/gef.py
@@ -8892,7 +8892,7 @@ class HeapBaseFunction(GenericFunction):
     def heap_base():
         try:
             base = long(gdb.parse_and_eval("mp_->sbrk_base"))
-            if base > 0:
+            if base != 0:
                 return base
         except gdb.error:
             pass

--- a/gef.py
+++ b/gef.py
@@ -622,6 +622,7 @@ class Instruction:
         return "(bad)" not in self.mnemonic
 
 class MallocStateStruct(object):
+    """GEF representation of malloc_state from https://github.com/bminor/glibc/blob/glibc-2.28/malloc/malloc.c#L1658"""
     def __init__(self, addr):
         self.addr = addr
         self.num_fastbins = 11 if is_x86_32() else 10

--- a/gef.py
+++ b/gef.py
@@ -8864,9 +8864,12 @@ class HeapBaseFunction(GenericFunction):
 
     @staticmethod
     def heap_base():
-      try:
-        return long(gdb.parse_and_eval("mp_->sbrk_base"))
-      except gdb.error:
+        try:
+            base = long(gdb.parse_and_eval("mp_->sbrk_base"))
+            if base > 0:
+                return base
+        except gdb.error:
+            pass
         return get_section_base_address("[heap]")
 
 @register_function

--- a/gef.py
+++ b/gef.py
@@ -657,6 +657,7 @@ class MallocStateStruct(object):
             self.fastbin_offset = align_address_to_size(self.int_size*3, 8)
         else:
             self.fastbin_offset = self.int_size*2
+        return
 
     @property
     def addr(self):

--- a/gef.py
+++ b/gef.py
@@ -658,7 +658,6 @@ class MallocStateStruct(object):
         else:
             self.fastbin_offset = self.int_size*2
 
-
     @property
     def addr(self):
         return self.__addr

--- a/gef.py
+++ b/gef.py
@@ -659,6 +659,7 @@ class MallocStateStruct(object):
             self.fastbin_offset = self.int_size*2
         return
 
+    # struct offsets
     @property
     def addr(self):
         return self.__addr
@@ -687,6 +688,7 @@ class MallocStateStruct(object):
     def struct_size(self):
         return self.system_mem_addr + current_arch.ptrsize*2 - self.__addr
 
+    # struct members
     @property
     def fastbinsY(self):
         return self.get_size_t_array(self.fastbins_addr, self.num_fastbins)
@@ -709,11 +711,14 @@ class MallocStateStruct(object):
     def system_mem(self):
         return self.get_size_t(self.system_mem_addr)
 
+    # helper methods
     def get_size_t(self, addr):
         return dereference(addr).cast(self.size_t)
+
     def get_size_t_pointer(self, addr):
         size_t_pointer = self.size_t.pointer()
         return dereference(addr).cast(size_t_pointer)
+
     def get_size_t_array(self, addr, length):
         size_t_array = self.size_t.array(length)
         return dereference(addr).cast(size_t_array)


### PR DESCRIPTION
A lot of ctfs provided a libc to use, and currently gef requires debug symbols in order for the heap commands to work (it uses `struct malloc_state`)

The aim is to have the heap commands work without debug symbols, and even in a stripped binary with no `main_arena`

~Need to add 32bit, tests, and clean up `get_main_arena_address`~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hugsy/gef/373)
<!-- Reviewable:end -->
