### PR TITLE
Issue #342 Caching all project dependencies with custom docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,42 +1,11 @@
 version: 2
 jobs:
     build:
-        docker: # See https://docs.docker.com/get-started/#docker-concepts if you are new to Docker.
-          - image: circleci/python:3.4
-            environment:
-              PYTHONPATH: /usr/local/lib/python3.4/site-packages/
+        docker: 
+          - image: fibonascii/gefdev:latest
         working_directory: ~/repo
         steps:
           - checkout
-          - run:
-              command: |
-                  sudo apt-get install python2.7 python-setuptools python-dev build-essential
-                  sudo python2 -m easy_install pip
-                  sudo python2 -m pip install pylint
-          - run:
-              command: |
-                  sudo apt-get update
-                  sudo apt-get install gdb git cmake gcc g++ pkg-config libglib2.0-dev
-          # TODO: Cache gdb install
-          #- restore_cache:
-              #keys:
-                  #- pydeps-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
-          - run:
-              # For some reason we need to pip install keystone/capstone/unicorn
-              # even though we are installing it manually. If we don't, then gdb
-              # won't be able to import it.
-              command: |
-                  sudo pip3 install keystone-engine capstone unicorn
-          - run:
-              command: |
-                  sudo pip3 install pylint ropper
-          - run:
-              command: |
-                  curl https://gist.githubusercontent.com/Grazfather/91e1ea3c3b51be844552263ce0f0d538/raw/76ff432159654e83db7159df7027ca4b11a2bdd4/install-trinity.sh | bash
-          #- save_cache:
-              #key: pydeps-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
-              #paths:
-                  #- /usr/local/lib/python3.4/site-packages
           - run: python3 -m pylint -E gef.py
           - run: PYTHONPATH=/usr/lib/python2.7/site-packages python2 -m pylint -E gef.py
           - run: make lint

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM circleci/python:3.4
+
+ENV PYTHONPATH /usr/local/lib/python3.4/site-packages
+
+# Setup Python2 Dependencies
+RUN sudo apt-get install python2.7 python-setuptools python-dev build-essential
+RUN sudo python2 -m easy_install pip
+RUN sudo python2 -m pip install pylint
+
+# Setup Development Tools
+RUN sudo apt-get update -y
+RUN sudo apt-get install gdb git cmake gcc g++ pkg-config libglib2.0-dev -y
+
+# Setup Python3 Dependencies
+RUN sudo pip3 install keystone-engine capstone unicorn
+RUN sudo pip3 install pylint ropper
+RUN https://raw.githubusercontent.com/hugsy/stuff/master/update-trinity.sh | bash


### PR DESCRIPTION
## Caching All Project Dependencies ##

#342 

I created a custom Docker container per the CircleCI docs on recommended caching method. Their internal caching system is a bit limited and they recommend just building an image.

With the custom container this brought the build down to 1:58. With the docker image itself cached it was brought down to 1:51

I also created a docker folder in the root of the project that contains the Dockerfile and docker-compose.yml that way if the image needs to be removed to a repo not controlled by me it won't be difficult to do.

![screen shot 2018-10-27 at 11 49 23 pm](https://user-images.githubusercontent.com/11827510/47612353-fd7a0b80-da46-11e8-85f6-2ead21896b60.png)
