### PR TITLE
Issue #359 Fixed Heap Analysis Hard Coding Malloc In BreakPoint

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -189,8 +189,8 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         self.assertIn("Tracking", res)
         self.assertIn("correctly setup", res)
         self.assertIn("malloc(16)=", res)
-        self.assertIn("malloc(32)=", res) # Actually calloc
-        addr = int(res.split("malloc(32)=")[1].split("\n")[0], 0)
+        self.assertIn("calloc(32)=", res)
+        addr = int(res.split("calloc(32)=")[1].split("\n")[0], 0)
         self.assertRegex(res, r"realloc\(.+, 48")
         self.assertIn("free({:#x}".format(addr), res)
         return


### PR DESCRIPTION
## Fixed Heap Analysis Hard Coding Malloc In BreakPoint ##

I fixed the hardcoding of malloc in the TraceMallocRetBreakPoint class to pull it's name from self.name in TraceMallocBreakpoint. I also updated the test cases to now look calloc(32). 

`__libc_malloc(16)=0x555555756010\n[+] Heap-Analysis - __libc_malloc(16)=0x555555756010\n[+] Heap-Analysis - __libc_calloc(32)=0x555555756030\n[+] Heap-Analysis -`

![screen shot 2018-10-28 at 2 52 59 pm](https://user-images.githubusercontent.com/11827510/47621141-57b7b280-dac1-11e8-89af-ed4c6a8e67ee.png)
