### PR TITLE
Fixed syntax issue in Dockerfile calling trinity script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,4 +14,4 @@ RUN sudo apt-get install gdb git cmake gcc g++ pkg-config libglib2.0-dev -y
 # Setup Python3 Dependencies
 RUN sudo pip3 install keystone-engine capstone unicorn
 RUN sudo pip3 install pylint ropper
-RUN https://raw.githubusercontent.com/hugsy/stuff/master/update-trinity.sh | bash
+RUN curl https://raw.githubusercontent.com/hugsy/stuff/master/update-trinity.sh | bash


### PR DESCRIPTION
I'm fixing a syntax error in the Dockerfile. The update trinity script was being called without the curl command