### PR TITLE
Fix register misalignment in show_registers_raw mode

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7063,7 +7063,7 @@ class ContextCommand(GenericCommand):
 
         widest = l = max(map(len, current_arch.all_registers))
         l += 5
-        l += current_arch.ptrsize
+        l += current_arch.ptrsize * 2
         nb = get_terminal_size()[1]//l
         i = 1
         line = ""
@@ -7101,7 +7101,7 @@ class ContextCommand(GenericCommand):
             else:
                 line += "{}: ".format(Color.colorify(padreg, changed_color))
             if new_value_type_flag:
-                line += "{:s} ".format(str(value))
+                line += "{:s} ".format(format_address_spaces(value))
             else:
                 addr = lookup_address(align_address(long(value)))
                 if addr.valid:


### PR DESCRIPTION
## Fix register misalignment in show_registers_raw mode ##

### Description/Motivation/Screenshots ###
To solve the register misaligned problem in show_registers_raw mode, I did the following modification:
- format the flag value with `format_address_spaces()`
- correct `l += current_arch.ptrsize` to `l += current_arch.ptrsize * 2`

#### Before ####
![image](https://user-images.githubusercontent.com/18047532/48004137-56365c00-e14b-11e8-8fba-c572fbf9f149.png)
#### After ####
![image](https://user-images.githubusercontent.com/18047532/48005700-0eb1cf00-e14f-11e8-9ddd-23c1ecec0a93.png)


### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark: |                        |


### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
