### PR TITLE
Fix disable_redirect_output to fix #383

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1160,8 +1160,8 @@ def enable_redirect_output(to_file="/dev/null"):
 
 def disable_redirect_output():
     """Disable the output redirection, if any."""
-    gdb.execute("set logging redirect off")
     gdb.execute("set logging off")
+    gdb.execute("set logging redirect off")
     return
 
 


### PR DESCRIPTION
We constant disable and reenable logging/redirection. Apparently we are
disabling it in the wrong order, which in GDB 8.1 causes issues.

