### PR TITLE
Try to resolve array accesses in context source

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7494,6 +7494,11 @@ class ContextCommand(GenericCommand):
                     if not sym.is_function and re.search(r"\W{}\W".format(symbol), line):
                         val = gdb.parse_and_eval(symbol)
                         if val.type.code in (gdb.TYPE_CODE_PTR, gdb.TYPE_CODE_ARRAY):
+                            # This isn't perfect, will break on nested [], for example
+                            ar = re.search(r"{}\[.+?\]".format(symbol), line)
+                            if ar: # If it's an array item access
+                                symbol = ar.group()
+                                val = gdb.parse_and_eval(symbol)
                             addr = long(val.address)
                             addrs = DereferenceCommand.dereference_from(addr)
                             if len(addrs) > 2:


### PR DESCRIPTION
Before
![1__tmux](https://user-images.githubusercontent.com/497310/48521352-ff0a4880-e828-11e8-9e9b-6b05f9a789b4.png)
(it prints argv, and its first element, not the correct element)
After
![1__tmux](https://user-images.githubusercontent.com/497310/48521333-ed28a580-e828-11e8-8190-13935087a70a.png)

This won't work for nested parens, e.g.
`argv[atoi(argv[0])]` will try to resolve `argv[atoi(argv[0]`, missing the last closing parens `)]`, since the regex is non-greedy.
If we used greedy, then `argv[0], argv[1]` would break.

Either way, it's handled gracefully.
