### PR TITLE
Non main heap arena fixes

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6189,13 +6189,13 @@ class GlibcHeapBinsCommand(GenericCommand):
             return -1
 
         nb_chunk = 0
-        if bk == fw and ((int(arena)&~0xFFFF) == (bk&~0xFFFF)):
+        head = GlibcChunk(bk, from_base=True).fwd
+        if fw == head:
             return nb_chunk
 
         ok("{}bins[{:d}]: fw={:#x}, bk={:#x}".format(_type, index, fw, bk))
 
         m = []
-        head = GlibcChunk(bk, from_base=True).fwd
         while fw != head:
             chunk = GlibcChunk(fw, from_base=True)
             m.append("{:s}  {:s}".format(RIGHT_ARROW, str(chunk)))

--- a/gef.py
+++ b/gef.py
@@ -809,7 +809,7 @@ class GlibcChunk:
         return
 
     def get_chunk_size(self):
-        return read_int_from_memory(self.size_addr) & (~0x03)
+        return read_int_from_memory(self.size_addr) & (~0x07)
 
     @property
     def size(self):

--- a/tests/binaries/Makefile
+++ b/tests/binaries/Makefile
@@ -44,4 +44,6 @@ pattern.out: EXTRA_FLAGS := -D_FORTIFY_SOURCE=0 -fno-stack-protector
 
 canary.out: EXTRA_FLAGS := -fstack-protector-all
 
+heap-non-main.out: EXTRA_FLAGS := -pthread
+
 default.out: EXTRA_FLAGS := -fstack-protector-all -fpie -pie

--- a/tests/binaries/heap-non-main.c
+++ b/tests/binaries/heap-non-main.c
@@ -1,0 +1,31 @@
+/**
+ * -*- mode: c -*-
+ * -*- coding: utf-8 -*-
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+void *thread()
+{
+        void* p1 = malloc(0x18);
+        void* p2 = malloc(0x18);
+        free(p1);
+        __asm__ volatile("int3;" : : : );
+        (void)p2;
+
+        return NULL;
+}
+
+int main(int argc, char** argv, char** envp)
+{
+        void* p1 = malloc(0x10);
+
+        pthread_t thread1;
+        pthread_create(&thread1, NULL, thread, NULL);
+        pthread_join(thread1, NULL);
+
+        (void)p1;
+        return EXIT_SUCCESS;
+}

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -193,6 +193,14 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         self.assertIn("Fastbins[idx=0, size=0x10]", res)
         return
 
+    def test_cmd_heap_bins_non_main(self):
+        cmd = 'python gdb.execute("heap bins fast {}".format(get_main_arena().next))'
+        target = "tests/binaries/heap-non-main.out"
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertIn("size=0x20, flags=PREV_INUSE|NON_MAIN_ARENA", res)
+        return
+
     def test_cmd_heap_analysis(self):
         cmd = "heap-analysis-helper"
         target = "tests/binaries/heap-analysis.out"


### PR DESCRIPTION
While doing a recent CTF I ran into a few issues when dealing a thread arena:

* NON_MAIN_ARENA wasn't cleared from the chunk size
* heap bin commands didn't work as `(int(arena)&~0xFFFF) == (bk&~0xFFFF)` was always true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hugsy/gef/392)
<!-- Reviewable:end -->
