### PR TITLE
Base function

### DIFF
--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -5,7 +5,7 @@ The `functions` command will list all of the [convenience functions](https://sou
 * `$_bss([offset])`    -- Return the current bss base address plus the given offset.
 * `$_got([offset])`    -- Return the current bss base address plus the given offset.
 * `$_heap([offset])`   -- Return the current heap base address plus an optional offset.
-* `$_pie([offset])`    -- Return the current pie base address plus an optional offset.
+* `$_base([offset])`   -- Return the current file's base address plus an optional offset. Useful for PIE binaries.
 * `$_stack([offset])`  -- Return the current stack base address plus an optional offset.
 
 

--- a/docs/commands/functions.md
+++ b/docs/commands/functions.md
@@ -2,10 +2,10 @@
 
 The `functions` command will list all of the [convenience functions](https://sourceware.org/gdb/onlinedocs/gdb/Convenience-Funs.html) provided by GEF.
 
+* `$_base([name])`     -- Return the base address of the matching section (default current file).
 * `$_bss([offset])`    -- Return the current bss base address plus the given offset.
 * `$_got([offset])`    -- Return the current bss base address plus the given offset.
 * `$_heap([offset])`   -- Return the current heap base address plus an optional offset.
-* `$_base([offset])`   -- Return the current file's base address plus an optional offset. Useful for PIE binaries.
 * `$_stack([offset])`  -- Return the current stack base address plus an optional offset.
 
 

--- a/gef.py
+++ b/gef.py
@@ -9268,9 +9268,9 @@ class HeapBaseFunction(GenericFunction):
         return get_section_base_address("[heap]")
 
 @register_function
-class PieBaseFunction(GenericFunction):
-    """Return the current pie base address plus an optional offset."""
-    _function_ = "_pie"
+class FileBaseFunction(GenericFunction):
+    """Return the current file's base address plus an optional offset."""
+    _function_ = "_base"
 
     def do_invoke(self, args):
         return self.arg_to_long(args, 0) + get_section_base_address(get_filepath())

--- a/gef.py
+++ b/gef.py
@@ -2591,7 +2591,7 @@ def get_filepath():
 @lru_cache()
 def get_filename():
     """Return the full filename of the file currently debugged."""
-    return os.path.basename(get_filepath())
+    return os.path.basename(gdb.current_progspace().filename)
 
 
 def download_file(target, use_cache=False, local_name=None):
@@ -9268,12 +9268,25 @@ class HeapBaseFunction(GenericFunction):
         return get_section_base_address("[heap]")
 
 @register_function
-class FileBaseFunction(GenericFunction):
-    """Return the current file's base address plus an optional offset."""
+class SectionBaseFunction(GenericFunction):
+    """Return the matching section's base address plus an optional offset."""
     _function_ = "_base"
 
     def do_invoke(self, args):
-        return self.arg_to_long(args, 0) + get_section_base_address(get_filepath())
+        try:
+            name = args[0].string()
+        except IndexError:
+            name = get_filename()
+        except gdb.error:
+            err("Invalid arg: {}".format(args[0]))
+            return 0
+
+        try:
+            addr = int(get_section_base_address(name))
+        except TypeError:
+            err("Cannot find section {}".format(name))
+            return 0
+        return addr
 
 @register_function
 class BssBaseFunction(GenericFunction):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -557,18 +557,20 @@ class TestGefFunctions(GefUnitTestGeneric):
 class TestGdbFunctions(GefUnitTestGeneric):
     """Tests gdb convenience functions added by GEF."""
 
-    def test_func_pie(self):
-        cmd = "x/s $_pie()"
+    def test_func_base(self):
+        cmd = "x/s $_base()"
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd))
         res = gdb_start_silent_cmd(cmd)
         self.assertNoException(res)
         self.assertIn("\\177ELF", res)
+        addr = res.splitlines()[-1].split()[0][:-1]
 
-        cmd = "x/s $_pie(1)"
+        cmd = "x/s $_base(\"libc\")"
         res = gdb_start_silent_cmd(cmd)
         self.assertNoException(res)
-        self.assertNotIn("\\177ELF", res)
-        self.assertIn("ELF", res)
+        self.assertIn("\\177ELF", res)
+        addr2 = res.splitlines()[-1].split()[0][:-1]
+        self.assertNotEqual(addr, addr2)
         return
 
     def test_func_heap(self):


### PR DESCRIPTION
Instead of `$_pie()`, this adds `$_base()`, which, instead of an offset, takes an optional file name to match against.

Also fixes a bug where this function didn't work for remote targets, due to `vmmap`'s section names not matching the result of `get_filepath`.

There's a problem with how we split args that makes this weird to use in our own commands.


```
gef➤  x/s $_base()
0x400000:       "\177ELF\002\001\001"
gef➤  deref $_base()
0x0000000000400000│+0x0000:  jg 0x400047
0x0000000000400008│+0x0008:  add BYTE PTR [rax], al
0x0000000000400010│+0x0010:  add al, BYTE PTR [rax]
...
gef➤  deref $_base("libc")
0x00007ffff7a0d000│+0x0000: 0x03010102464c457f
0x00007ffff7a0d008│+0x0008: 0x0000000000000000
0x00007ffff7a0d010│+0x0010: 0x00000001003e0003
...
```