### PR TITLE
elf class bugfix

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -523,8 +523,8 @@ class Elf:
     - http://refspecs.freestandards.org/elf/elfspec_ppc.pdf
     - http://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi.html
     """
-    BIG_ENDIAN        = 0
     LITTLE_ENDIAN     = 1
+    BIG_ENDIAN        = 2
 
     ELF_32_BITS       = 0x01
     ELF_64_BITS       = 0x02


### PR DESCRIPTION
The const `BIG_ENDIAN` in `class ELF` should be 2 instead of 0. According to `ELF_Format.pdf` (from Ref comment) `e_ident[EI_DATA]` is either 1 for LSB or 2 for MSB.

## elf class bugfix ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_check_mark: | encountered this bug while trying to get unicorn-emulation working on ELF 32-bit MSB, MIPS executable                       |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
