### PR TITLE
Fix crash on Old GDB warning

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -9686,7 +9686,7 @@ if __name__  == "__main__":
 
     if GDB_VERSION < GDB_MIN_VERSION:
         err("You're using an old version of GDB. GEF will not work correctly. "
-            "Consider updating to GDB {} or higher.".format(".".join(GDB_MIN_VERSION)))
+            "Consider updating to GDB {} or higher.".format(".".join(map(str, GDB_MIN_VERSION))))
 
     else:
         try:


### PR DESCRIPTION
On a system with **gdb 7.6** and python 2.7, I get this nice traceback trying to install Gef:
```
Traceback (most recent call last):
  File "~/.gdbinit-gef.py", line 9473, in <module>
TypeError: sequence item 0: expected string, int found
```

Of course it's because `str.join('.', (7,7) )` doesn't work -- it needs the ints stringified. The fix is trivial, see diff.

In such a good project, having implemented the version check, you certainly don't want it to crash!

### How Has This Been Tested? ###

Manually, on Python 2.7.5 and Python 3.6.7.

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
