### PR TITLE
Add named breakpoints

### DIFF
--- a/docs/commands/name-break.md
+++ b/docs/commands/name-break.md
@@ -1,0 +1,47 @@
+## Command name-break ##
+
+The command `name-break` (alias `nb`) can be used to set a breakpoint on 
+a location with a name assigned to it.
+
+Everytime this breakpoint is hit, the specified name will also be shown
+in the `extra` section to make it easier to keep an overview when using
+multiple breakpoints in a stripped binary.
+
+`name-break <NAME> [LOCATION]`
+
+`LOCATION` may be a linespec, address, or explicit location, same as specified
+for `break`. If `LOCATION` isn't specified, it will create the breakpoint at the current
+instruction pointer address.
+
+Examples:
+
+- `nb first *0x400ec0`
+- `nb "main func" main`
+- `nb read_secret *main+149`
+- `nb check_heap`
+
+Example output:
+
+```
+─────────────────────────────────────────────────────────────────────────── code:x86:64 ────
+     0x400e04                  add    eax, 0xfffbe6e8
+     0x400e09                  dec    ecx
+     0x400e0b                  ret    
+ →   0x400e0c                  push   rbp
+     0x400e0d                  mov    rbp, rsp
+     0x400e10                  sub    rsp, 0x50
+     0x400e14                  mov    QWORD PTR [rbp-0x48], rdi
+     0x400e18                  mov    QWORD PTR [rbp-0x50], rsi
+     0x400e1c                  mov    rax, QWORD PTR fs:0x28
+───────────────────────────────────────────────────────────────────────────────── stack ────
+0x00007fffffffe288│+0x0000: 0x0000000000401117  →   movzx ecx, al	 ← $rsp
+0x00007fffffffe290│+0x0008: 0x00007fffffffe4b8  →  0x00007fffffffe71d  →  "/ctf/t19/srv_copy"
+0x00007fffffffe298│+0x0010: 0x0000000100000000
+0x00007fffffffe2a0│+0x0018: 0x0000000000000000
+0x00007fffffffe2a8│+0x0020: 0x0000000000000004
+0x00007fffffffe2b0│+0x0028: 0x0000000000000000
+───────────────────────────────────────────────────────────────────────────────── extra ────
+[+] Hit breakpoint *0x400e0c (check_entry)
+────────────────────────────────────────────────────────────────────────────────────────────
+gef➤  
+```

--- a/gef.py
+++ b/gef.py
@@ -3712,6 +3712,21 @@ class EntryBreakBreakpoint(gdb.Breakpoint):
         return True
 
 
+class NamedBreakpoint(gdb.Breakpoint):
+    """Breakpoint which shows a specified name, when hit."""
+
+    def __init__(self, location, name):
+        super(NamedBreakpoint, self).__init__(spec=location, type=gdb.BP_BREAKPOINT, internal=False, temporary=False)
+        self.name = name
+        self.loc = location
+
+        return
+
+    def stop(self):
+        push_context_message("info", "Hit breakpoint {} ({})".format(self.loc, Color.colorify(self.name, "red bold")))
+        return True
+
+
 #
 # Commands
 #
@@ -7038,6 +7053,31 @@ class EntryPointBreakCommand(GenericCommand):
 
     def is_pie(self, fpath):
         return checksec(fpath)["PIE"]
+
+
+@register_command
+class NamedBreakpointCommand(GenericCommand):
+    """Sets a breakpoint and assigns a name to it, which will be shown, when it's hit."""
+
+    _cmdline_ = "name-break"
+    _syntax_  = "{:s} NAME [LOCATION]".format(_cmdline_)
+    _aliases_ = ["nb",]
+    _example  = "{:s} main *0x4008a9"
+
+    def __init__(self, *args, **kwargs):
+        super(NamedBreakpointCommand, self).__init__()
+        return
+
+    def do_invoke(self, argv):
+        if not argv:
+            err("Missing name for breakpoint")
+            self.usage()
+            return
+
+        name = argv[0]
+        location = argv[1] if len(argv) > 1 else "*{}".format(hex(current_arch.pc))
+
+        NamedBreakpoint(location, name)
 
 
 @register_command

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ pages:
 - Command ida-interact: commands/ida-interact.md
 - Command ksymaddr: commands/ksymaddr.md
 - Command memory: commands/memory.md
+- Command name-break: commands/name-break.md
 - Command nop: commands/nop.md
 - Command patch: commands/patch.md
 - Command pattern: commands/pattern.md


### PR DESCRIPTION
## Add named breakpoints ##

### Description/Motivation/Screenshots ###
This adds a new command `name-break` (alias `nb`), which allows to set breakpoints while assigning a name to them. Everytime the breakpoint is hit, the assigned name will also be shown in the `extra` section.

Not a big change, but made it easier for me to debug stripped binaries when having many breakpoints to keep an overview where I'm currently at.

Syntax:
`name-break <NAME> [LOCATION]`

Examples:
- `nb first *0x400ec0`
- `nb "main func" main`
- `nb read_secret *main+149`
- `nb check_heap`

![gef_namebreak](https://user-images.githubusercontent.com/6137334/51345331-f63d2980-1a9a-11e9-99aa-b82c15ba7a62.png)

### How Has This Been Tested? ###

Tested it manually only.

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_check_mark: |                        |

### Checklist ###

- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
