### PR TITLE
Add search range for `search-pattern`

### DIFF
--- a/docs/commands/search-pattern.md
+++ b/docs/commands/search-pattern.md
@@ -27,3 +27,17 @@ The `search-pattern` command can also be used as a way to search for
 cross-references to an address. For this reason, the alias `xref` also points
 to the command `search-pattern`.  Therefore the command above is equivalent to
 `xref 0x4005f6` which makes it more intuitive to use.
+
+### Searching in a specific range ###
+Sometimes, you may need to search for a very common pattern. To limit the search space, you can also specify an address range or the section to be checked.
+
+```
+gef➤  search-pattern 0x4005f6 libc
+gef➤  search-pattern 0x4005f6 0x603100-0x603200
+```
+
+If you want to set endianness, but don't want to limit the search space:
+
+```
+gef➤  search-pattern 0x4005f6 memory big
+```

--- a/docs/commands/search-pattern.md
+++ b/docs/commands/search-pattern.md
@@ -32,12 +32,6 @@ to the command `search-pattern`.  Therefore the command above is equivalent to
 Sometimes, you may need to search for a very common pattern. To limit the search space, you can also specify an address range or the section to be checked.
 
 ```
-gef➤  search-pattern 0x4005f6 libc
-gef➤  search-pattern 0x4005f6 0x603100-0x603200
-```
-
-If you want to set endianness, but don't want to limit the search space:
-
-```
-gef➤  search-pattern 0x4005f6 memory big
+gef➤  search-pattern 0x4005f6 little libc
+gef➤  search-pattern 0x4005f6 little 0x603100-0x603200
 ```

--- a/gef.py
+++ b/gef.py
@@ -5106,9 +5106,9 @@ class SearchPatternCommand(GenericCommand):
     the command will also try to look for upwards cross-references to this address."""
 
     _cmdline_ = "search-pattern"
-    _syntax_  = "{:s} PATTERN [section] [small|big]".format(_cmdline_)
+    _syntax_  = "{:s} PATTERN [small|big] [section]".format(_cmdline_)
     _aliases_ = ["grep", "xref"]
-    _example_ = "\n{0:s} AAAAAAAA\n{0:s} 0x555555554000 stack\n{0:s}AAAA 0x600000-0x601000 \n{0:s} BBBB all little".format(_cmdline_)
+    _example_ = "\n{0:s} AAAAAAAA\n{0:s} 0x555555554000 little stack\n{0:s}AAAA 0x600000-0x601000".format(_cmdline_)
 
     def print_section(self, section):
         title = "In "
@@ -5181,9 +5181,9 @@ class SearchPatternCommand(GenericCommand):
         pattern = argv[0]
         endian = get_endian()
 
-        if argc==3:
-            if argv[2] == "big": endian = Elf.BIG_ENDIAN
-            elif argv[2] == "small": endian = Elf.LITTLE_ENDIAN
+        if argc >= 2:
+            if argv[1] == "big": endian = Elf.BIG_ENDIAN
+            elif argv[1] == "small": endian = Elf.LITTLE_ENDIAN
 
         if is_hex(pattern):
             if endian == Elf.BIG_ENDIAN:
@@ -5191,20 +5191,18 @@ class SearchPatternCommand(GenericCommand):
             else:
                 pattern = "".join(["\\x"+pattern[i:i+2] for i in range(len(pattern) - 2, 0, -2)])
 
-        if argc >= 2:
-            info("Searching '{:s}' in {:s}".format(Color.yellowify(pattern), argv[1]))
+        if argc == 3:
+            info("Searching '{:s}' in {:s}".format(Color.yellowify(pattern), argv[2]))
 
-            if "0x" in argv[1]:
-                start, end = parse_string_range(argv[1])
+            if "0x" in argv[2]:
+                start, end = parse_string_range(argv[2])
 
                 self.print_section(lookup_address(start).section)
 
                 for loc in self.search_pattern_by_address(pattern, start, end):
                     self.print_loc(loc)
             else:
-                section_name = argv[1]
-                if section_name == "memory":
-                    section_name = ""
+                section_name = argv[2]
                 if section_name == "binary":
                     section_name = get_filepath()
 

--- a/gef.py
+++ b/gef.py
@@ -5118,9 +5118,11 @@ class SearchPatternCommand(GenericCommand):
         title += "({:#x}-{:#x})".format(section.page_start, section.page_end)
         title += ", permission={}".format(section.permission)
         ok(title)
+        return
 
     def print_loc(self, loc):
         gef_print("""  {:#x} - {:#x} {}  "{}" """.format(loc[0], loc[1], RIGHT_ARROW, Color.pinkify(loc[2]),))
+        return
 
     def search_pattern_by_address(self, pattern, start_address, end_address):
         """Search a pattern within a range defined by arguments."""
@@ -5182,8 +5184,8 @@ class SearchPatternCommand(GenericCommand):
         endian = get_endian()
 
         if argc >= 2:
-            if argv[1] == "big": endian = Elf.BIG_ENDIAN
-            elif argv[1] == "small": endian = Elf.LITTLE_ENDIAN
+            if argv[1].lower() == "big": endian = Elf.BIG_ENDIAN
+            elif argv[1].lower() == "small": endian = Elf.LITTLE_ENDIAN
 
         if is_hex(pattern):
             if endian == Elf.BIG_ENDIAN:
@@ -5197,7 +5199,9 @@ class SearchPatternCommand(GenericCommand):
             if "0x" in argv[2]:
                 start, end = parse_string_range(argv[2])
 
-                self.print_section(lookup_address(start).section)
+                loc = lookup_address(start)
+                if loc.valid:
+                    self.print_section(loc.section)
 
                 for loc in self.search_pattern_by_address(pattern, start, end):
                     self.print_loc(loc)


### PR DESCRIPTION
## Add search range for `search-pattern` ##

### Description/Motivation/Screenshots ###
This adds an argument for the command `search-pattern` (`grep`, `xref`) for the user to choose an address range or section to search from.

This is because sometimes one may need to search for a very common pattern, and having the terminal flooded with output is troublesome.

![ss](https://i.imgur.com/n66F2Aj.png)

This argument comes before the one for endianness. To set endianness without limiting the search space, `grep 0x400123 memory big`.

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | :heavy_check_mark: |
| x86-64       | :heavy_multiplication_x: | :heavy_check_mark: |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [ ] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
