### PR TITLE
Allow specify address range in `scan` command

### DIFF
--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -9,3 +9,7 @@ belonging to another (needle).
 searched and the second is what will be searched for. The arguments are grepped
 against the processes memory mappings (just like [vmmap](docs/commands/vmmap.md)
 to determine the memory ranges to search.
+
+To check mappings without a path associated, an address range (start-end) can be used.
+
+![scan-address](https://i.imgur.com/ExJC2p7.png)

--- a/gef.py
+++ b/gef.py
@@ -5058,6 +5058,16 @@ class ScanSectionCommand(GenericCommand):
         needle_sections = []
         haystack_sections = []
 
+        if "0x" in haystack:
+            start = int(haystack.split("-")[0], 16)
+            end = int(haystack.split("-")[1], 16)
+            haystack_sections.append((start, end, ""))
+
+        if "0x" in needle:
+            start = int(needle.split("-")[0], 16)
+            end = int(needle.split("-")[1], 16)
+            needle_sections.append((start, end))
+
         for sect in get_process_maps():
             if haystack in sect.path:
                 haystack_sections.append((sect.page_start, sect.page_end, os.path.basename(sect.path)))
@@ -5078,8 +5088,11 @@ class ScanSectionCommand(GenericCommand):
                 for nstart, nend in needle_sections:
                     if target >= nstart and target < nend:
                         deref = DereferenceCommand.pprint_dereferenced(hstart, long(i / step))
-                        name = Color.colorify(hname, "yellow")
-                        gef_print("{:s}: {:s}".format(name, deref))
+                        if hname != "":
+                            name = Color.colorify(hname, "yellow")
+                            gef_print("{:s}: {:s}".format(name, deref))
+                        else:
+                            gef_print(" {:s}".format(deref))
 
         return
 

--- a/gef.py
+++ b/gef.py
@@ -3245,6 +3245,12 @@ def gef_convenience(value):
     return var_name
 
 
+def parse_string_range(s):
+    """Parses an address range (e.g. 0x400000-0x401000)"""
+    addrs = s.split("-")
+    return map(lambda x: int(x, 16), addrs)
+
+
 @lru_cache()
 def gef_get_auxiliary_values():
     """Retrieves the auxiliary values of the current execution. Returns None if not running, or a dict()
@@ -5059,13 +5065,11 @@ class ScanSectionCommand(GenericCommand):
         haystack_sections = []
 
         if "0x" in haystack:
-            start = int(haystack.split("-")[0], 16)
-            end = int(haystack.split("-")[1], 16)
+            start, end = parse_string_range(haystack)
             haystack_sections.append((start, end, ""))
 
         if "0x" in needle:
-            start = int(needle.split("-")[0], 16)
-            end = int(needle.split("-")[1], 16)
+            start, end = parse_string_range(needle)
             needle_sections.append((start, end))
 
         for sect in get_process_maps():


### PR DESCRIPTION
## Allow specify address range in `scan` command ##

### Description/Motivation/Screenshots ###
Currently there is no way to scan sections without a pathname, such as mmap anonymous mappings. This adds the ability to specify address ranges in the format `start-end` for the `scan` command.

![ss](https://i.imgur.com/ExJC2p7.png)

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | :heavy_check_mark: |
| x86-64       | :heavy_multiplication_x: | :heavy_check_mark:  |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
