### PR TITLE
Display error for $_heap() when there is no heap

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -9032,7 +9032,11 @@ class HeapBaseFunction(GenericFunction):
     _function_ = "_heap"
 
     def do_invoke(self, args):
-        return self.arg_to_long(args, 0) + HeapBaseFunction.heap_base()
+        base = HeapBaseFunction.heap_base()
+        if not base:
+            err("Heap is not initialized")
+            return 0
+        return self.arg_to_long(args, 0) + base
 
     @staticmethod
     def heap_base():


### PR DESCRIPTION
## Display error for $_heap() when there is no heap ##

### Description/Motivation/Screenshots ###
Fixes #393. 

When the convenience function fails to find the heap, return 0 instead of `None`. Then, show an error saying "Heap is not initialized".

```
gef➤  p $_heap()
[!] Heap is not initialized
$1 = 0x0
```

Forced to return 0 here because GDB convenience functions are expected to return something. Another way to possibly do it is return the error message itself, but I feel it doesn't look nice like this

```
gef➤  p $_heap()
$1 = "Heap is not initialized"
```

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | :heavy_check_mark: |
| x86-64       | :heavy_multiplication_x: | :heavy_check_mark: |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
