### PR TITLE
Context sub commands

### DIFF
--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -127,6 +127,18 @@ To go back to normal, remove the value:
 gef➤ gef config context.redirect ""
 ```
 
+### Display individual sections ###
+
+You can display a single section by specifying it as an argument:
+```
+gef➤ context regs
+```
+
+Multiple sections can be provided, even if they are not part of the current layout:
+```
+gef➤ context regs stack
+```
+
 ### Examples ###
 
 * Display the code section first, then register, and stack, hiding everything else:

--- a/gef.py
+++ b/gef.py
@@ -7089,7 +7089,7 @@ class ContextCommand(GenericCommand):
     states, the stack, and the disassembly code around $pc."""
 
     _cmdline_ = "context"
-    _syntax_  = _cmdline_
+    _syntax_  = "{:s} [legend|regs|stack|code|args|memory|source|trace|threads|extra]".format(_cmdline_)
     _aliases_ = ["ctx",]
 
     old_registers = {}
@@ -7155,7 +7155,15 @@ class ContextCommand(GenericCommand):
         if not self.get_setting("enable") or context_hidden:
             return
 
-        current_layout = self.get_setting("layout").strip().split()
+        if not all(_ in self.layout_mapping for _ in argv):
+            self.usage()
+            return
+
+        if len(argv) > 0:
+            current_layout = argv
+        else:
+            current_layout = self.get_setting("layout").strip().split()
+
         if not current_layout:
             return
 

--- a/gef.py
+++ b/gef.py
@@ -7173,7 +7173,7 @@ class ContextCommand(GenericCommand):
         if redirect and os.access(redirect, os.W_OK):
             enable_redirect_output(to_file=redirect)
 
-        if self.get_setting("clear_screen"):
+        if self.get_setting("clear_screen") and len(argv) == 0:
             clear_screen(redirect)
 
         for section in current_layout:


### PR DESCRIPTION
## Context sub commands ##

Quite often after doing a few derefs or anything at a breakpoint, you want to look at part of the context again. This allows you to specify a single or multiple sections to show:

```
gef➤  context -h
[!] Syntax
context [legend|regs|stack|code|args|memory|source|trace|threads|extra]
gef➤  context code
─────────────────────────────────────────────────────────────────────────────────────────── code:x86:64 ────
   0x7ffff743dbef <poll+63>        mov    rdi, rbx
   0x7ffff743dbf2 <poll+66>        mov    eax, 0x7
   0x7ffff743dbf7 <poll+71>        syscall
 → 0x7ffff743dbf9 <poll+73>        cmp    rax, 0xfffffffffffff000
   0x7ffff743dbff <poll+79>        ja     0x7ffff743dc32 <__GI___poll+130>
   0x7ffff743dc01 <poll+81>        mov    edi, r8d
```
### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-64       | :heavy_check_mark: |                        |
### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hugsy/gef/417)
<!-- Reviewable:end -->
