### PR TITLE
add custom match highlighting

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,6 +26,7 @@ improve it.
 |heap                      | Base command to get information about the Glibc heap structure.|
 |heap-analysis-helper      | Tracks dynamic heap allocation through malloc/free to try to detect heap vulnerabilities.|
 |hexdump                   | Display arranged hexdump (according to architecture endianness) of memory range.|
+|highlight                 | Highlight text using custom matches.|
 |hijack-fd                 | ChangeFdCommand: redirect file descriptor during runtime.|
 |ida-interact              | IDA Interact: set of commands to interact with IDA via a XML RPC service deployed via the IDA script `ida_gef.py`. It should be noted that this command can also be used to interact with Binary Ninja (using the script `binja_gef.py`) using the same interface. (alias: binaryninja-interact, bn, binja)|
 |is-syscall                | Tells whether the next instruction to be executed is a system call.|

--- a/docs/commands/highlight.md
+++ b/docs/commands/highlight.md
@@ -1,0 +1,81 @@
+## Command highlight ##
+
+This command sets up custom highlighting for user set strings.
+
+Syntax:
+
+```
+highlight (add|remove|list|clear)
+```
+
+Alias:
+
+  - `hl`
+
+## Adding matches
+
+The following will add `41414141`/`'AAAA'` as yellow, and `42424242`/`'BBBB'`
+as blue:
+
+```
+gef➤  hl add 41414141 yellow
+gef➤  hl add 42424242 blue
+gef➤  hl add AAAA yellow
+gef➤  hl add BBBB blue
+```
+
+## Removing matches
+
+To remove a match, target it by the original string used, ex.:
+
+```
+gef➤  hl rm 41414141
+```
+
+## Listing matches
+
+To list all matches with their colors:
+
+```
+gef➤  hl list
+41414141 | yellow
+42424242 | blue
+AAAA     | yellow
+BBBB     | blue
+```
+
+## Clearing all matches
+
+To clear all matches currently setup:
+
+```
+gef➤  hl clear
+```
+
+## RegEx support
+
+RegEx support is disabled by default, this is done for performance reasons.
+
+To enable regular expressions on text matches:
+
+```
+gef➤  gef config highlight.regex True
+```
+
+To check the current status:
+
+```
+gef➤  gef config highlight.regex
+highlight.regex (bool) = True
+```
+
+## Performance
+
+_**NOTE:** Adding many matches may slow down debugging while using GEF.
+This includes enabling RegEx support._
+
+## Colors
+
+To find a list of supported colors, check the
+[theme](./theme.md#changing-colors) documentation.
+

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -69,13 +69,18 @@ No more endless manual pointer dereferencing `x/x` style. Just use `dereference`
 ![x86-unicorn](https://i.imgur.com/emhEsol.png)
 
 
-
 ### Comprehensive address space layout display
 
 ![mips-vmmap](https://i.imgur.com/TbC1kNa.png)
 
 
-
 ### Defining arbitrary custom structures
 
 ![sparc-arb-struct](https://i.imgur.com/dEMUuP7.png)
+
+
+### Highlight custom strings
+
+![highlight-command](https://i.imgur.com/UwSPXrV.png)
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ pages:
 - Command heap-analysis-helper: commands/heap-analysis-helper.md
 - Command help: commands/help.md
 - Command hexdump: commands/hexdump.md
+- Command highlight: commands/highlight.md
 - Command hijack-fd: commands/hijack-fd.md
 - Command ida-interact: commands/ida-interact.md
 - Command ksymaddr: commands/ksymaddr.md

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,14 +2,14 @@ import re
 import subprocess
 
 PATH_TO_DEFAULT_BINARY = "./tests/binaries/default.out"
-
+STRIP_ANSI_DEFAULT = True
 
 def ansi_clean(s):
     ansi_escape = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]")
     return ansi_escape.sub("", s)
 
 
-def gdb_run_cmd(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
+def gdb_run_cmd(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT):
     """Execute a command inside GDB. `before` and `after` are lists of commands to be executed
     before (resp. after) the command to test."""
     command = [
@@ -29,10 +29,15 @@ def gdb_run_cmd(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
     command += ["-ex", "quit", "--", target]
 
     lines = subprocess.check_output(command, stderr=subprocess.STDOUT).strip().splitlines()
-    return ansi_clean(b"\n".join(lines).decode("utf-8"))
+    result = b"\n".join(lines).decode("utf-8")
+
+    if strip_ansi:
+        result = ansi_clean(result)
+
+    return result
 
 
-def gdb_run_silent_cmd(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
+def gdb_run_silent_cmd(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT):
     """Disable the output and run entirely the `target` binary."""
     if not before:
         before = []
@@ -40,15 +45,15 @@ def gdb_run_silent_cmd(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINA
     before += ["gef config context.clear_screen False",
                "gef config context.layout '-code -stack'",
                "run"]
-    return gdb_run_cmd(cmd, before, after, target)
+    return gdb_run_cmd(cmd, before, after, target, strip_ansi)
 
 
-def gdb_run_cmd_last_line(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
+def gdb_run_cmd_last_line(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT):
     """Execute a command in GDB, and return only the last line of its output."""
-    return gdb_run_cmd(cmd, before, after, target).splitlines()[-1]
+    return gdb_run_cmd(cmd, before, after, target, strip_ansi).splitlines()[-1]
 
 
-def gdb_start_silent_cmd(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
+def gdb_start_silent_cmd(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT):
     """Execute a command in GDB by starting an execution context. This command disables the `context`
     and sets a tbreak at the most convenient entry point."""
     if not before:
@@ -57,14 +62,14 @@ def gdb_start_silent_cmd(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BI
     before += ["gef config context.clear_screen False",
                "gef config context.layout '-code -stack'",
                "entry-break"]
-    return gdb_run_cmd(cmd, before, after, target)
+    return gdb_run_cmd(cmd, before, after, target, strip_ansi)
 
 
-def gdb_start_silent_cmd_last_line(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY):
+def gdb_start_silent_cmd_last_line(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT):
     """Execute `gdb_start_silent_cmd()` and return only the last line of its output."""
-    return gdb_start_silent_cmd(cmd, before, after, target).splitlines()[-1]
+    return gdb_start_silent_cmd(cmd, before, after, target, strip_ansi).splitlines()[-1]
 
 
-def gdb_test_python_method(meth, before="", after="", target=PATH_TO_DEFAULT_BINARY):
+def gdb_test_python_method(meth, before="", after="", target=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT):
     cmd = "pi {}print({});{}".format(before+";" if before else "", meth, after)
-    return gdb_start_silent_cmd(cmd, target=target)
+    return gdb_start_silent_cmd(cmd, target=target, strip_ansi=strip_ansi)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -510,6 +510,26 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         self.assertIn("Patching XOR-ing ", res)
         return
 
+    def test_cmd_highlight(self):
+
+        cmds = [
+            "highlight add 41414141 yellow",
+            "highlight add 42424242 blue",
+            "highlight add 43434343 green",
+            "highlight add 44444444 pink",
+            'set $rsp = "AAAABBBBCCCCDDDD"',
+            "hexdump qword $rsp 2"
+        ]
+
+        res = gdb_start_silent_cmd('', after=cmds, strip_ansi=False)
+
+        self.assertNoException(res)
+        self.assertIn("\033[33m41414141\x1b[0m", res)
+        self.assertIn("\033[34m42424242\x1b[0m", res)
+        self.assertIn("\033[32m43434343\x1b[0m", res)
+        self.assertIn("\033[35m44444444\x1b[0m", res)
+
+
 class TestGefFunctions(GefUnitTestGeneric):
     """Tests GEF internal functions."""
 


### PR DESCRIPTION
## Add custom match colors using `highlight` command ##

### Description ###

This was created to identify memory addresses & strings while examining registers, hex dumps and heap layout.  Coloring the output seems to improve recognition speed during exploitation.

Further explanation may be found here - https://github.com/pwndbg/pwndbg/issues/366

A new command has been added called `highlight` and includes aliases `hh` & `hl`.
With this command you can add/remove/list matches associated with colors.

Example highlights using common identifiers (`41414141`, `42424242`, etc.):

![gef-highlight-cmd](https://user-images.githubusercontent.com/2328639/52527866-8e869280-2c84-11e9-9d14-104f116555a0.png)

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark: | |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_check_mark: | by  @hugsy                         |
| AARCH64      | :heavy_check_mark: |  by  @hugsy                   |
| MIPS         | :heavy_check_mark: |  by  @hugsy                        |
| POWERPC      | :heavy_check_mark: |  by  @hugsy                        |
| SPARC        |  :heavy_check_mark:  |  by  @hugsy                        |
| `make tests` | :heavy_check_mark: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [ ] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
