### PR TITLE
vmmap: allow filtering by address

### DIFF
--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -10,6 +10,6 @@ the main reasons I started `GEF` in a first place). For example, you can learn
 that ELF running on SPARC architectures always have their `.data` and `heap`
 sections set as Read/Write/Execute.
 
-`vmmap` accepts one argument, a pattern to grep interesting results:
+`vmmap` accepts one argument, a pattern or address to grep interesting results:
 
-![vmmap-grep](http://i.imgur.com/ZFF4QVf.png)
+![vmmap-grep](https://i.imgur.com/lgr8tw8.png)


### PR DESCRIPTION
## vmmap: allow filtering by address ##

### Description/Motivation/Screenshots ###

This patch extends the `vmmap` command to not just filter by mapping name (`vmmap heap`), but also for the inverse, to filter the mapping that contains a specific address, e.g `vmmap 0x41414141`.

This is something I find myself doing often when checking whether a certain pointer is readable, writeable or points to an executable page, or to identify which library a pointer points to, and is one of the features I am missing from peda.

![Screenshot](https://i.imgur.com/lgr8tw8.png)

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | :heavy_check_mark: |
| x86-64       | :heavy_multiplication_x: | :heavy_check_mark: |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
