### PR TITLE
Fix checksec inaccuracy with RelRO

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1481,7 +1481,7 @@ def checksec(filename):
     results["PIE"] = __check_security_property("-h", filename, r":.*EXEC") is False
     results["Fortify"] = __check_security_property("-s", filename, r"_chk@GLIBC") is True
     results["Partial RelRO"] = __check_security_property("-l", filename, r"GNU_RELRO") is True
-    results["Full RelRO"] = __check_security_property("-d", filename, r"BIND_NOW") is True
+    results["Full RelRO"] = results["Partial RelRO"] and __check_security_property("-d", filename, r"BIND_NOW") is True
     return results
 
 


### PR DESCRIPTION
# Fix checksec inaccuracy with RelRO #

### Description/Motivation/Screenshots ###
Fix #430 

This is how checksec.sh does it. If `GNU_RELRO` is absent, then `Full RelRO` won't be set regardless of the presence of `BIND_NOW`.

https://github.com/slimm609/checksec.sh/blob/3eff9b7d4641a34d1eb5f6d9201899d6bca6c08e/checksec#L276-L285

In gef this was inaccurate because the presence of `BIND_NOW` was checked even when `GNU_RELRO` was absent.

![ss](https://i.imgur.com/XHl47Ej.png)
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

Not sure whether this should target `master` since it is a bugfix.

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [ ] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
