### PR TITLE
hijack-fd: Convert fd to signed integer

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -4828,7 +4828,10 @@ class ChangeFdCommand(GenericCommand):
 
     def get_fd_from_result(self, res):
         # Output example: $1 = 3
-        return int(res.split()[2], 0)
+        res = int(res.split()[2], 0)
+        res = gdb.execute("""p/d {}""".format(res), to_string=True)
+        res = int(res.split()[2], 0)
+        return res
 
 
 @register_command


### PR DESCRIPTION
## hijack-fd: Convert fd to signed integer ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->
Currently, the return value of `connect()` or `open()` is unsigned. To determine whether there was an error, the returned `fd` will be compared with -1. However since `fd` is unsigned, the error will never be detected.

To fix this, `fd` is converted to signed before performing the check.

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: | |
| x86-64       | :heavy_multiplication_x: | :heavy_check_mark:|
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [ ] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
