### PR TITLE
Set position independent arguments with default values for hexdump and dereference

### DIFF
--- a/docs/commands/dereference.md
+++ b/docs/commands/dereference.md
@@ -7,18 +7,40 @@ actually points to.
 It is a useful convienence function to spare to process of manually tracking
 values with successive `x/x` in GDB.
 
-`dereference` takes one mandatory argument, an address (or symbol or register,
-etc) to dereference:
+`dereference` takes two optional arguments, an address (or symbol or register, etc)
+to dereference (by default, `$sp`) and the number of consecutive addresses to
+dereference (by default, `10`):
 
 ```
-gef➤  dereference $sp
-0x00007fffffffe258│+0x00: 0x0000000000400489  →  hlt     ← $rsp
-gef➤  telescope 0x7ffff7b9d8b9
-0x00007ffff7b9d8b9│+0x00: 0x0068732f6e69622f ("/bin/sh"?)
+gef➤  dereference
+0x00007fffffffdec0│+0x0000: 0x00007ffff7ffe190  →  0x0000555555554000  →   jg 0x555555554047	 ← $rsp, $r13
+0x00007fffffffdec8│+0x0008: 0x00007ffff7ffe730  →  0x00007ffff7fd3000  →  0x00010102464c457f
+0x00007fffffffded0│+0x0010: 0x00007ffff7faa000  →  0x00007ffff7de9000  →  0x03010102464c457f
+0x00007fffffffded8│+0x0018: 0x00007ffff7ffd9f0  →  0x00007ffff7fd5000  →  0x00010102464c457f
+0x00007fffffffdee0│+0x0020: 0x00007fffffffdee0  →  [loop detected]
+0x00007fffffffdee8│+0x0028: 0x00007fffffffdee0  →  0x00007fffffffdee0  →  [loop detected]
+0x00007fffffffdef0│+0x0030: 0x00000000f7fa57e3
+0x00007fffffffdef8│+0x0038: 0x0000555555755d60  →  0x0000555555554a40  →   cmp BYTE PTR [rip+0x201601], 0x0        # 0x555555756048
+0x00007fffffffdf00│+0x0040: 0x0000000000000004
+0x00007fffffffdf08│+0x0048: 0x0000000000000001
+```
+
+Here is an example with arguments:
+
+```
+gef➤  telescope $rbp+0x10 8
+0x00007fffffffdf40│+0x0000: 0x00007ffff7fa5760  →  0x00000000fbad2887
+0x00007fffffffdf48│+0x0008: 0x00000001f7e65b63
+0x00007fffffffdf50│+0x0010: 0x0000000000000004
+0x00007fffffffdf58│+0x0018: 0x0000000000000000
+0x00007fffffffdf60│+0x0020: 0x00007fffffffdfa0  →  0x0000555555554fd0  →   push r15
+0x00007fffffffdf68│+0x0028: 0x0000555555554980  →   xor ebp, ebp
+0x00007fffffffdf70│+0x0030: 0x00007fffffffe080  →  0x0000000000000001
+0x00007fffffffdf78│+0x0038: 0x0000000000000000
 ```
 
 It also optionally accepts a second argument, the number of consecutive
-addresses to dereference (by default, `1`).
+addresses to dereference (by default, `10`).
 
 For example, if you want to dereference all the stack entries inside a function
 context (on a 64bit architecture):
@@ -26,10 +48,10 @@ context (on a 64bit architecture):
 ```
 gef➤  p ($rbp - $rsp)/8
 $3 = 4
-gef➤  dereference $rsp 5
-0x00007fffffffe170│+0x00: 0x0000000000400690  →  push r15        ← $rsp
-0x00007fffffffe178│+0x08: 0x0000000000400460  →  xor ebp, ebp
-0x00007fffffffe180│+0x10: 0x00007fffffffe270  →  0x1
-0x00007fffffffe188│+0x18: 0x1
-0x00007fffffffe190│+0x20: 0x0000000000400690  →  push r15        ← $rbp
+gef➤  dereference 5
+0x00007fffffffe170│+0x0000: 0x0000000000400690  →  push r15        ← $rsp
+0x00007fffffffe178│+0x0008: 0x0000000000400460  →  xor ebp, ebp
+0x00007fffffffe180│+0x0010: 0x00007fffffffe270  →  0x1
+0x00007fffffffe188│+0x0018: 0x1
+0x00007fffffffe190│+0x0020: 0x0000000000400690  →  push r15        ← $rbp
 ```

--- a/docs/commands/hexdump.md
+++ b/docs/commands/hexdump.md
@@ -7,7 +7,7 @@ This command takes 4 optional arguments:
   - The format for representing the data (by default, byte)
   - A value/address/symbol used as the location to print the hexdump from (by default, $sp)
   - The number of qword/dword/word/bytes to display (by default, 64 if the format is byte, 16 otherwise)
-  - The directionof output lines (by default, from low to high addresses)
+  - The direction of output lines (by default, from low to high addresses)
 
 The command provides WinDBG compatible aliases by default:
 

--- a/docs/commands/hexdump.md
+++ b/docs/commands/hexdump.md
@@ -2,10 +2,11 @@
 
 Imitation of the WinDBG command.
 
-This command requires at least 2 arguments, the format for representing the
-data, and a value/address/symbol used as the location to print the hexdump
-from. An optional 3rd argument is used to specify the number of
-qword/dword/word/bytes to display.
+This command takes 4 optional arguments, the format for representing the
+data (by default, byte), and a value/address/symbol used as the location
+to print the hexdump from (by default, $sp), the number of qword/dword/word/bytes
+to display (by default, 64 if the format is byte, 16 otherwise), and the direction
+of output lines (by default, from low to high addresses).
 
 The command provides WinDBG compatible aliases by default:
 
@@ -20,7 +21,7 @@ is printable (similarly to the `hexdump -C` command on Linux).
 The syntax is as following:
 
 ```
-hexdump (qword|dword|word|byte) LOCATION L[SIZE] [UP|DOWN]
+hexdump [qword|dword|word|byte] [LOCATION] [[L][SIZE]] [REVERSE]
 ```
 
 Examples:
@@ -41,4 +42,17 @@ gef➤  dq $pc l4
 gef➤  db 0x00007fffffffe5e5 l32
 0x00007fffffffe5e5     2f 68 6f 6d 65 2f 68 75 67 73 79 2f 63 6f 64 65     /home/hugsy/code
 0x00007fffffffe5f5     2f 67 65 66 2f 74 65 73 74 73 2f 77 69 6e 00 41     /gef/tests/win.A
+```
+
+  * Display 8 WORD from `$sp` in reverse order:
+```
+gef➤  dw 8 r
+0x00007fffffffe0ee│+0x000e   0x0000   
+0x00007fffffffe0ec│+0x000c   0x7fff   
+0x00007fffffffe0ea│+0x000a   0xffff   
+0x00007fffffffe0e8│+0x0008   0xe3f5   
+0x00007fffffffe0e6│+0x0006   0x0000   
+0x00007fffffffe0e4│+0x0004   0x0000   
+0x00007fffffffe0e2│+0x0002   0x0000   
+0x00007fffffffe0e0│+0x0000   0x0001
 ```

--- a/docs/commands/hexdump.md
+++ b/docs/commands/hexdump.md
@@ -2,11 +2,12 @@
 
 Imitation of the WinDBG command.
 
-This command takes 4 optional arguments, the format for representing the
-data (by default, byte), and a value/address/symbol used as the location
-to print the hexdump from (by default, $sp), the number of qword/dword/word/bytes
-to display (by default, 64 if the format is byte, 16 otherwise), and the direction
-of output lines (by default, from low to high addresses).
+This command takes 4 optional arguments:
+
+  - The format for representing the data (by default, byte)
+  - A value/address/symbol used as the location to print the hexdump from (by default, $sp)
+  - The number of qword/dword/word/bytes to display (by default, 64 if the format is byte, 16 otherwise)
+  - The directionof output lines (by default, from low to high addresses)
 
 The command provides WinDBG compatible aliases by default:
 

--- a/gef.py
+++ b/gef.py
@@ -7900,8 +7900,8 @@ class HexdumpCommand(GenericCommand):
     """Display SIZE lines of hexdump from the memory location pointed by ADDRESS. """
 
     _cmdline_ = "hexdump"
-    _syntax_  = "{:s} (qword|dword|word|byte) ADDRESS [[L][SIZE]] [UP|DOWN] [S]".format(_cmdline_)
-    _example_ = "{:s} byte $rsp L16 DOWN".format(_cmdline_)
+    _syntax_  = "{:s} [qword|dword|word|byte] [ADDRESS] [[L][SIZE]] [REVERSE]".format(_cmdline_)
+    _example_ = "{:s} byte $rsp L16 REVERSE".format(_cmdline_)
 
     def __init__(self):
         super(HexdumpCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
@@ -7910,44 +7910,39 @@ class HexdumpCommand(GenericCommand):
 
     @only_if_gdb_running
     def do_invoke(self, argv):
-        argc = len(argv)
-        if argc < 2:
-            self.usage()
-            return
-
-        arg0, argv = argv[0].lower(), argv[1:]
+        fmt = "byte"
+        target = "$sp"
         valid_formats = ["byte", "word", "dword", "qword"]
-        fmt = None
-        for valid_format in valid_formats:
-            if valid_format.startswith(arg0):
-                fmt = valid_format
-                break
-        if not fmt:
-            self.usage()
-            return
+        read_len = None
+        reverse = False
+        
+        for arg in argv:
+            arg = arg.lower()
+            is_format_given = False
+            for valid_format in valid_formats:
+                if valid_format.startswith(arg):
+                    fmt = valid_format
+                    is_format_given = True
+                    break
+            if is_format_given:
+                continue
+            if arg.startswith("l"):
+                arg = arg[1:]
+            try:
+                read_len = long(arg, 0)
+                continue
+            except ValueError:
+                pass
 
-        start_addr = to_unsigned_long(gdb.parse_and_eval(argv[0]))
+            if "reverse".startswith(arg):
+                reverse = True
+                continue
+            target = arg
+            
+        start_addr = to_unsigned_long(gdb.parse_and_eval(target))
         read_from = align_address(start_addr)
-        read_len = 0x40 if fmt=="byte" else 0x10
-        up_to_down = True
-
-        if argc >= 2:
-            for arg in argv[1:]:
-                arg = arg.lower()
-                if arg.startswith("l"):
-                    arg = arg[1:]
-                try:
-                    read_len = long(arg, 0)
-                    continue
-                except ValueError:
-                    pass
-
-                if arg in {"up", "u"}:
-                    up_to_down = True
-                    continue
-                elif arg in {"down", "d"}:
-                    up_to_down = False
-                    continue
+        if not read_len:
+            read_len = 0x40 if fmt=="byte" else 0x10
 
         if fmt == "byte":
             read_from += self.repeat_count * read_len
@@ -7956,7 +7951,7 @@ class HexdumpCommand(GenericCommand):
         else:
             lines = self._hexdump(read_from, read_len, fmt, self.repeat_count * read_len)
 
-        if not up_to_down:
+        if reverse:
             lines.reverse()
 
         gef_print("\n".join(lines))

--- a/gef.py
+++ b/gef.py
@@ -8120,19 +8120,18 @@ class DereferenceCommand(GenericCommand):
 
     @only_if_gdb_running
     def do_invoke(self, argv):
-        argc = len(argv)
-
-        if argc < 1:
-            err("Missing location.")
-            return
-
+        target = "$sp"
         nb = 10
-        if argc==2 and argv[1][0] in ("l", "L") and argv[1][1:].isdigit():
-            nb = int(argv[1][1:])
-        elif argc == 2 and argv[1].isdigit():
-            nb = int(argv[1])
+        
+        for arg in argv:
+            if arg.isdigit():
+                nb = int(arg)
+            elif arg[0] in ("l", "L") and arg[1:].isdigit():
+                nb = int(arg[1:])
+            else:
+                target = arg
 
-        addr = safe_parse_and_eval(argv[0])
+        addr = safe_parse_and_eval(target)
         if addr is None:
             err("Invalid address")
             return

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -222,7 +222,7 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         self.assertNoException(res)
         res = gdb_start_silent_cmd("hexdump dword $pc l1")
         self.assertNoException(res)
-        res = gdb_start_silent_cmd("hexdump word $pc l5 down")
+        res = gdb_start_silent_cmd("hexdump word $pc l5 reverse")
         self.assertNoException(res)
         res = gdb_start_silent_cmd("hexdump byte $sp l32")
         self.assertNoException(res)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -82,7 +82,7 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         self.assertTrue(len(res.splitlines()) > 2)
         self.assertIn("$rsp", res)
 
-        res = gdb_start_silent_cmd("dereference 0")
+        res = gdb_start_silent_cmd("dereference 0x0")
         self.assertNoException(res)
         self.assertIn("Unmapped address", res)
         return


### PR DESCRIPTION
## Set position independent arguments with default values for hexdump and dereference ##

### Description/Motivation/Screenshots ###
This sets the address stored in stack register as default argument for dereference and hexdump commands, and makes the arguments position-independent. In addition, it sets the byte as the default format for hexdump. Also, skipping argument(s) does not affect the behavior of the following arguments.

In both exploit development and reverse engineering sessions, the contents of the stack is frequently investigated. By making the stack register default argument, we make the experience easier and faster. The same idea applies for the format argument of hexdump. Hexdump is usually used to see the bytes and dereference is used to see the dword/qword values stored. Also, position-independent arguments make the functions a lot easier to use.

Since the arguments are now position-independent, there was an ambiguity for `d`. It might mean either `dword` or `down`. Therefore, I renamed the `down` option as `reverse`.

Examples:

- `hexdump 128` => display 128 bytes from `$sp`
- `hexdump reverse $rbp` => display 64 bytes from `$rbp` in reverse order
- `hexdump 8 qword` => display 8 QWORD from `$sp`
- `hexdump $rbp reverse 48` => display 48 bytes from `$rbp` in reverse order 
- `hexdump word 12` => display 12 WORD from `$sp`

- `dereference` => dereference 10 consecutive addresses from `$sp`
- `dereference 5` => dereference 5 consecutive addresses from `$sp`
- `dereference 8 $rbp` => dereference 8 consectuive addresses from `$rbp`
- `dereference $rbp 12` => dereference 12 consecutive addresses from `$rbp`

Screenshots:
![dereference](https://user-images.githubusercontent.com/32958854/55923561-b3f53580-5c0e-11e9-90d3-5c2b03c79cb4.png)

![hexdump](https://user-images.githubusercontent.com/32958854/55923574-bbb4da00-5c0e-11e9-9e16-fd9b487d9fa4.png)


### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark: |                        |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_check_mark: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
