### PR TITLE
Fix idapro sync

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -4954,7 +4954,7 @@ class IdaInteractCommand(GenericCommand):
                     gef_print(str(res))
 
             if self.get_setting("sync_cursor") is True:
-                jump = getattr(self.sock, "Jump")
+                jump = getattr(self.sock, "jump")
                 jump(hex(current_arch.pc-main_base_address),)
 
         except socket.error:
@@ -4990,7 +4990,7 @@ class IdaInteractCommand(GenericCommand):
 
         try:
             # it is possible that the server was stopped between now and the last sync
-            rc = self.sock.Sync("{:#x}".format(pc-base_address), list(added), list(removed))
+            rc = self.sock.sync("{:#x}".format(pc-base_address), list(added), list(removed))
         except ConnectionRefusedError:
             self.disconnect()
             return

--- a/scripts/ida_gef.py
+++ b/scripts/ida_gef.py
@@ -193,7 +193,7 @@ class Gef:
         """
         res = {}
         for s in Structs():
-            res.update(self.ImportStruct(s[2]))
+            res.update(self.importstruct(s[2]))
         return res
 
     @expose


### PR DESCRIPTION
## Fix ida pro sync ##
Some previous commit changing the case of ida commands made ida stop working, because they didnt fix an rpc on the gef.py . This fixes it

### Checklist ###
- [X] If my code is a bug fix it targets master, otherwise it targets dev.
- [X] My code follows the code style of this project.
- [X] My change includes a change to the documentation, if required.
- [X] My change adds tests as appropriate.
- [X] I have read and agree to the **CONTRIBUTING** document.
