### PR TITLE
pcustom: Correctly find field offset

### DIFF
--- a/tests/binaries/Makefile
+++ b/tests/binaries/Makefile
@@ -46,4 +46,6 @@ canary.out: EXTRA_FLAGS := -fstack-protector-all
 
 heap-non-main.out: EXTRA_FLAGS := -pthread
 
+heap-tcache.out: EXTRA_FLAGS := -Wno-unused-label
+
 default.out: EXTRA_FLAGS := -fstack-protector-all -fpie -pie


### PR DESCRIPTION
Fixes #446 

Basically if you defined a structure with padding, the calculated/displayed offset wouldn't match the offset what the structure actually parses the value out of, size we just used the sum of the size of all of the previous fields, ignorant of padding.