### PR TITLE
Add highlighting of vmmap entries based on permissions

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7911,7 +7911,7 @@ class HexdumpCommand(GenericCommand):
         valid_formats = ["byte", "word", "dword", "qword"]
         read_len = None
         reverse = False
-        
+
         for arg in argv:
             arg = arg.lower()
             is_format_given = False
@@ -7934,7 +7934,7 @@ class HexdumpCommand(GenericCommand):
                 reverse = True
                 continue
             target = arg
-            
+
         start_addr = to_unsigned_long(gdb.parse_and_eval(target))
         read_from = align_address(start_addr)
         if not read_len:
@@ -8113,7 +8113,7 @@ class DereferenceCommand(GenericCommand):
     def do_invoke(self, argv):
         target = "$sp"
         nb = 10
-        
+
         for arg in argv:
             if arg.isdigit():
                 nb = int(arg)
@@ -8283,6 +8283,9 @@ class VMMapCommand(GenericCommand):
             err("No address mapping information found")
             return
 
+        if not get_gef_setting("gef.disable_color"):
+            self.show_legend()
+
         color = get_gef_setting("theme.table_heading")
 
         headers = ["Start", "End", "Offset", "Perm", "Path"]
@@ -8291,18 +8294,46 @@ class VMMapCommand(GenericCommand):
         for entry in vmmap:
             if argv and not argv[0] in entry.path:
                 continue
-            l = []
-            l.append(format_address(entry.page_start))
-            l.append(format_address(entry.page_end))
-            l.append(format_address(entry.offset))
 
-            if entry.permission.value == (Permission.READ|Permission.WRITE|Permission.EXECUTE) :
-                l.append(Color.colorify(str(entry.permission), "bold red"))
-            else:
-                l.append(str(entry.permission))
+            self.print_entry(entry)
+        return
 
-            l.append(entry.path)
-            gef_print(" ".join(l))
+    def print_entry(self, entry):
+        line_attributes = []
+        if entry.path == "[stack]":
+            line_attributes.append(get_gef_setting("theme.address_stack"))
+        elif entry.path == "[heap]":
+            line_attributes.append(get_gef_setting("theme.address_heap"))
+        elif entry.permission.value & Permission.READ and entry.permission.value & Permission.EXECUTE:
+            line_attributes.append(get_gef_setting("theme.address_code"))
+
+        line_attributes = " ".join(line_attributes)
+
+        l = []
+        l.append(Color.colorify(format_address(entry.page_start), line_attributes))
+        l.append(Color.colorify(format_address(entry.page_end), line_attributes))
+        l.append(Color.colorify(format_address(entry.offset), line_attributes))
+
+        if entry.permission.value == (Permission.READ|Permission.WRITE|Permission.EXECUTE):
+            l.append(Color.colorify(str(entry.permission), "underline " + line_attributes))
+        else:
+            l.append(Color.colorify(str(entry.permission), line_attributes))
+
+        l.append(Color.colorify(entry.path, line_attributes))
+        line = " ".join(l)
+
+        gef_print(line)
+        return
+
+    def show_legend(self):
+        code_addr_color = get_gef_setting("theme.address_code")
+        stack_addr_color = get_gef_setting("theme.address_stack")
+        heap_addr_color = get_gef_setting("theme.address_heap")
+
+        gef_print("[ Legend:  {} | {} | {} ]".format(Color.colorify("Code", code_addr_color),
+                                                     Color.colorify("Heap", heap_addr_color),
+                                                     Color.colorify("Stack", stack_addr_color)
+        ))
         return
 
 

--- a/gef.py
+++ b/gef.py
@@ -8299,27 +8299,25 @@ class VMMapCommand(GenericCommand):
         return
 
     def print_entry(self, entry):
-        line_attributes = []
+        line_color = ""
         if entry.path == "[stack]":
-            line_attributes.append(get_gef_setting("theme.address_stack"))
+            line_color = get_gef_setting("theme.address_stack")
         elif entry.path == "[heap]":
-            line_attributes.append(get_gef_setting("theme.address_heap"))
+            line_color = get_gef_setting("theme.address_heap")
         elif entry.permission.value & Permission.READ and entry.permission.value & Permission.EXECUTE:
-            line_attributes.append(get_gef_setting("theme.address_code"))
-
-        line_attributes = " ".join(line_attributes)
+            line_color = get_gef_setting("theme.address_code")
 
         l = []
-        l.append(Color.colorify(format_address(entry.page_start), line_attributes))
-        l.append(Color.colorify(format_address(entry.page_end), line_attributes))
-        l.append(Color.colorify(format_address(entry.offset), line_attributes))
+        l.append(Color.colorify(format_address(entry.page_start), line_color))
+        l.append(Color.colorify(format_address(entry.page_end), line_color))
+        l.append(Color.colorify(format_address(entry.offset), line_color))
 
         if entry.permission.value == (Permission.READ|Permission.WRITE|Permission.EXECUTE):
-            l.append(Color.colorify(str(entry.permission), "underline " + line_attributes))
+            l.append(Color.colorify(str(entry.permission), "underline " + line_color))
         else:
-            l.append(Color.colorify(str(entry.permission), line_attributes))
+            l.append(Color.colorify(str(entry.permission), line_color))
 
-        l.append(Color.colorify(entry.path, line_attributes))
+        l.append(Color.colorify(entry.path, line_color))
         line = " ".join(l)
 
         gef_print(line)


### PR DESCRIPTION
## vmmap Highlighting ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
This patch highlights each vmmap entry based on its name/permissions.
- RX entries are colored with the `theme.address_code` setting
- RWX entries have an extra underline in the `Perm` column
- The heap entry is colored with `theme.address_heap`
- The stack entry is colored with `theme.address_stack`

<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
The `context` command currently highlights various addresses based on its permissions and whether it points to the heap or stack. I think it would be relevant to have the same kind of highlighting for `vmmap` to improve readability.
<!-- How does this look? Add a screenshot if you can -->
<img width="725" alt="vmmap_highlights" src="https://user-images.githubusercontent.com/6225588/60152666-5d2fde80-97af-11e9-8720-062a68dfc5d8.png">
<img width="701" alt="rwx_segments" src="https://user-images.githubusercontent.com/6225588/60152675-6620b000-97af-11e9-9698-cf8d4168f05e.png">

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark:|
| x86-64       |:heavy_check_mark:||
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x:|                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
