### PR TITLE
more threads info

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7745,7 +7745,7 @@ class ContextCommand(GenericCommand):
                 line += Color.colorify("stopped", "bold red")
                 thread.switch()
                 frame = gdb.selected_frame()
-                line += " {:s} in {:s} ()".format(Color.colorify(hex(frame.pc()), "blue"),Color.colorify(frame.name() or "??" ,"bold yellow"))
+                line += " {:s} in {:s} ()".format(Color.colorify("{:#x}".format(frame.pc()), "blue"),Color.colorify(frame.name() or "??" ,"bold yellow"))
                 line += ", reason: {}".format(Color.colorify(reason(), "bold pink"))
             elif thread.is_exited():
                 line += Color.colorify("exited", "bold yellow")

--- a/gef.py
+++ b/gef.py
@@ -7733,18 +7733,26 @@ class ContextCommand(GenericCommand):
             err("No thread selected")
             return
 
+        selected_thread = gdb.selected_thread()
+
         for i, thread in enumerate(threads):
-            line = """[{:s}] Id {:d}, Name: "{:s}", """.format(Color.colorify("#{:d}".format(i), "bold pink"),
-                                                               thread.num, thread.name or "")
+            line = """[{:s}] Id {:d}, """.format(Color.colorify("#{:d}".format(i), "bold green" if thread==selected_thread  else "bold pink"), thread.num)
+            if thread.name:
+                line += """Name: "{:s}", """.format(thread.name)
             if thread.is_running():
                 line += Color.colorify("running", "bold green")
             elif thread.is_stopped():
                 line += Color.colorify("stopped", "bold red")
+                thread.switch()
+                frame = gdb.selected_frame()
+                line += " {:s} in {:s} ()".format(Color.colorify(hex(frame.pc()), "blue"),Color.colorify(frame.name() or "??" ,"bold yellow"))
                 line += ", reason: {}".format(Color.colorify(reason(), "bold pink"))
             elif thread.is_exited():
                 line += Color.colorify("exited", "bold yellow")
             gef_print(line)
             i += 1
+
+        selected_thread.switch()
         return
 
 


### PR DESCRIPTION
## more threads info ##

### Description/Motivation/Screenshots ###
- Selected thread number is highlighted with green
- Name is shown only if nor empty
- Added info about thread frame (PC and name)

Before:
![gef_threads_old](https://user-images.githubusercontent.com/536109/60579974-e2595b80-9d8c-11e9-9f6c-589ca6b5d378.png)

After: 
![gef_threads_new](https://user-images.githubusercontent.com/536109/60579981-e7b6a600-9d8c-11e9-9acd-85bd4d7d63c8.png)


### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_check_mark: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_check_mark: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
