### PR TITLE
Add segment offset to xinfo

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8423,6 +8423,7 @@ class XAddressInfoCommand(GenericCommand):
             gef_print("Segment: {:s} ({:s}-{:s})".format(info.name,
                                                          format_address(info.zone_start),
                                                          format_address(info.zone_end)))
+            gef_print("Offset (from segment): {:#x}".format(addr.value-info.zone_start))
 
         sym = gdb_get_location_from_symbol(address)
         if sym:


### PR DESCRIPTION
## Add segment offset to xinfo ##

### Description/Motivation/Screenshots ###
Just adds a single extra line to xinfo output with the offset from segment start; like we currently have for offset from page start. I find myself needing the offset from segments with pwntools more than the page offset.
![image](https://user-images.githubusercontent.com/434626/61061594-20c0cd00-a3c2-11e9-896a-4d0c32a0ea16.png)

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_check_mark: |                        |
| x86-64       | :heavy_check_mark: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_check_mark: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
