### PR TITLE
Add M68K Architecture

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,7 @@
 | ARM          | :heavy_multiplication_x: |                        |
 | AARCH64      | :heavy_multiplication_x: |                        |
 | MIPS         | :heavy_multiplication_x: |                        |
+| M68K         | :heavy_multiplication_x: |                        |
 | POWERPC      | :heavy_multiplication_x: |                        |
 | SPARC        | :heavy_multiplication_x: |                        |
 | `make tests` | :heavy_multiplication_x: |                        |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GDB Enhanced Features (a.k.a. GEF) #
 
-`GEF` (pronounced ʤɛf - "Jeff") is a set of commands for x86/64, ARM, MIPS, PowerPC and SPARC to assist exploit developers and reverse-engineers when using old school GDB. It provides additional features to GDB using the Python API to assist during the process of dynamic analysis and exploit development. Application developers will also benefit from it, as GEF lifts a great part of regular GDB obscurity, avoiding repeating traditional commands, or bringing out the relevant information from the debugging runtime.
+`GEF` (pronounced ʤɛf - "Jeff") is a set of commands for x86/64, ARM, MIPS, M68K, PowerPC, and SPARC to assist exploit developers and reverse-engineers when using old school GDB. It provides additional features to GDB using the Python API to assist during the process of dynamic analysis and exploit development. Application developers will also benefit from it, as GEF lifts a great part of regular GDB obscurity, avoiding repeating traditional commands, or bringing out the relevant information from the debugging runtime.
 
 ![gef-context](https://i.imgur.com/E3EuQPs.png)
 
@@ -40,7 +40,7 @@ A few of `GEF` features include:
   * Works consistently on both Python2 and Python3.
   * Built around an architecture abstraction layer, so all commands work in any
     GDB-supported architecture such as x86-32/64, ARMv5/6/7, AARCH64, SPARC, MIPS,
-    PowerPC, etc. (unlike [PEDA](https://github.com/longld/peda))
+    M68K, PowerPC, etc. (unlike [PEDA](https://github.com/longld/peda))
   * Suited for real-life apps debugging, exploit development, just as much as
     CTF (unlike _PEDA_ or _PwnDBG_)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -246,6 +246,7 @@ representation classes, such as:
  * `SPARC`
  * `SPARC64`
  * `MIPS`
+ * `M68K`
 
 
 #### Heap ####

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,7 +8,7 @@ commands to make the exploitation development process smoother.
 However, PEDA suffers from a major drawbacks, which the code is too
 fundamentally linked to Intel architectures (x86-32 and x86-64). On the other
 hand, GEF not only supports all the architecture supported by GDB (currently
-x86, ARM, AARCH64, MIPS, PowerPC, SPARC) but is designed to integrate new
+x86, ARM, AARCH64, MIPS, M68K, PowerPC, SPARC) but is designed to integrate new
 architectures very easily as well!
 
 Also, PEDA development has been quite idle for a few years now, and many new

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 [![ReadTheDocs](https://readthedocs.org/projects/gef/badge/?version=master)](https://gef.readthedocs.org/en/master/) [![MIT](https://img.shields.io/packagist/l/doctrine/orm.svg?maxAge=2592000?style=plastic)](https://github.com/hugsy/gef/blob/master/LICENSE) [![Python 2 & 3](https://img.shields.io/badge/Python-2%20%26%203-green.svg)](https://github.com/hugsy/gef/) [![IRC](https://img.shields.io/badge/freenode-%23%23gef-yellowgreen.svg)](https://webchat.freenode.net/?channels=##gef) [![CircleCI status](https://circleci.com/gh/hugsy/gef/tree/master.svg?style=shield)](https://circleci.com/gh/hugsy/gef/tree/master)
 
-`GEF` (pronounced ʤɛf - "Jeff") is a kick-ass set of commands for X86, ARM, MIPS, PowerPC and SPARC to make GDB cool again for exploit dev. It is aimed to be used mostly by exploit developers and reverse-engineers, to provide additional features to GDB using the Python API to assist during the process of dynamic analysis and exploit development.
+`GEF` (pronounced ʤɛf - "Jeff") is a kick-ass set of commands for X86, ARM, MIPS, M68K, PowerPC and SPARC to make GDB cool again for exploit dev. It is aimed to be used mostly by exploit developers and reverse-engineers, to provide additional features to GDB using the Python API to assist during the process of dynamic analysis and exploit development.
 
 It has full support for both Python2 and Python3 indifferently (as more and more
 distros start pushing `gdb` compiled with Python3 support).
@@ -23,7 +23,7 @@ distros start pushing `gdb` compiled with Python3 support).
   * Works consistently on both Python2 and Python3.
   * Built around an architecture abstraction layer, so all commands work in any
     GDB-supported architecture such as x86-32/64, ARMv5/6/7, AARCH64, SPARC, MIPS,
-    PowerPC, etc. (unlike [PEDA](https://github.com/longld/peda))
+    M68K, PowerPC, etc. (unlike [PEDA](https://github.com/longld/peda))
   * Suited for real-life apps debugging, exploit development, just as much as
     CTF (unlike _PEDA_ or _PwnDBG_)
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -15,6 +15,7 @@ Currently `GEF` supports the following architectures:
  - ARM (v6/v7)
  - AARCH64
  - MIPS/MIPS64
+ - M68K
  - PowerPC
  - SPARC/SPARCv9
 

--- a/gef.py
+++ b/gef.py
@@ -2409,7 +2409,6 @@ class M68K(Architecture):
         4: "extend",
         12: "master",
         13: "supervisor",
-        15: "trace",
     }
     syscall_register = "$d0"
     syscall_instructions = ["trap #0"]

--- a/gef.py
+++ b/gef.py
@@ -7,7 +7,7 @@
 # by  @_hugsy_
 #######################################################################################
 #
-# GEF is a kick-ass set of commands for X86, ARM, MIPS, PowerPC and SPARC to
+# GEF is a kick-ass set of commands for X86, ARM, MIPS, M68K, PowerPC and SPARC to
 # make GDB cool again for exploit dev. It is aimed to be used mostly by exploit
 # devs and reversers, to provides additional features to GDB using the Python
 # API to assist during the process of dynamic analysis.
@@ -5988,15 +5988,15 @@ class RemoteCommand(GenericCommand):
         elif arch.startswith("mips"):
             current_elf.e_machine = Elf.MIPS
             current_arch = MIPS()
+        elif arch.startswith("m68k"):
+            current_elf.e_machine = Elf.M68K
+            current_arch = M68K()
         elif arch.startswith("powerpc"):
             current_elf.e_machine = Elf.POWERPC
             current_arch = PowerPC()
         elif arch.startswith("sparc"):
             current_elf.e_machine = Elf.SPARC
             current_arch = SPARC()
-        elif arch.startswith("m68k"):
-            current_elf.e_machine = Elf.M68K
-            current_arch = M68K()
         else:
             raise RuntimeError("unsupported architecture: {}".format(arch))
 
@@ -6910,11 +6910,11 @@ class AssembleCommand(GenericCommand):
             "ARM" : ["ARM", "THUMB"],
             "ARM64" : ["ARM", "THUMB", "V5", "V8", ],
             "MIPS" : ["MICRO", "MIPS3", "MIPS32", "MIPS32R6", "MIPS64",],
+            "M68K" : [],
             "PPC" : ["PPC32", "PPC64", "QPX",],
             "SPARC" : ["SPARC32", "SPARC64", "V9",],
             "SYSTEMZ" : ["32",],
             "X86" : ["16", "32", "64"],
-            "M68K" : [],
         }
         return
 
@@ -7121,6 +7121,7 @@ class ElfInfoCommand(GenericCommand):
         machines = {
             0x02: "SPARC",
             0x03: "x86",
+            0x04: "M68K",
             0x08: "MIPS",
             0x12: "SPARC64",
             0x14: "PowerPC",
@@ -7129,7 +7130,6 @@ class ElfInfoCommand(GenericCommand):
             0x32: "IA-64",
             0x3E: "x86-64",
             0xB7: "AArch64",
-            0x04: "M68K",
         }
 
         filename = argv[0] if argv else get_filepath()


### PR DESCRIPTION
## Add M68K Architecture ##

### Description/Motivation/Screenshots ###
Implement M68K architecture. Capstone / Keystone / Unicorn does not have special modes for this architecture and it is untested.
`mprotect_asm` is unimplemented because I am unaware of the Linux m68k system call numbers; I am working on supervisor code instead of user code.

Example context screenshot:
![Screenshot_2019-07-12_12-12-36](https://user-images.githubusercontent.com/2096920/61145980-766aa780-a49e-11e9-9b5d-26ce8f7957ce.png)

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |                        |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_check_mark: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.

Mostly copy-pasting here. I don't see significant differences; please correct me if wrong.

- [x] My change includes a change to the documentation, if required.

Unable to find architecture documentation in `docs/`.

- [x] My change adds tests as appropriate.

Unable to find cross-compiling architecture tests in `tests/`.

- [x] I have read and agree to the **CONTRIBUTING** document.
