### PR TITLE
Return None when read_register fails

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2531,7 +2531,13 @@ def get_register(regname):
         value = gdb.parse_and_eval(regname)
         return to_unsigned_long(value) if value.type.code == gdb.TYPE_CODE_INT else long(value)
     except gdb.error:
-        value = gdb.selected_frame().read_register(regname)
+        assert(regname[0] == '$')
+        regname = regname[1:]
+        try:
+            value = gdb.selected_frame().read_register(regname)
+        except ValueError:
+            return None
+
         return long(value)
 
 


### PR DESCRIPTION
### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->
When I use `gef` to connect with `qemu-system-ppc -S -s` or `qemu-ppc -g 1234`, there will be an error because `QEMU` doesn't implement the `trap` register.

And the name provided to `parse_and_eval` is different from `read_register`.
(`gdb.parse_and_eval('$rax')` vs `gdb.selected_frame().read_register('rax')`)

That's to say that this `except` part is never executed correctly, and nobody complains this before.
So I simply return `None` with when we can't find the register and don't add check for this return value. I think it's enough.


### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        |
| AARCH64      | :heavy_multiplication_x: |                        |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_check_mark: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] If my code is a bug fix it targets master, otherwise it targets dev.
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
