### PR TITLE
Add support of get_terminal_size on windows terminal

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2865,24 +2865,22 @@ def get_terminal_size():
     """Return the current terminal size."""
     if is_debug():
         return 600, 100
+    
     if platform.system() == "Windows":
         from ctypes import windll, create_string_buffer
-        #stdin handle = -10
-        #stdout handle = -11
-        #stderr handle = -12
-        herr = windll.kernel32.GetStdHandle(-12)
+        hStdErr = -12 
+        herr = windll.kernel32.GetStdHandle(hSdErr)
         csbi = create_string_buffer(22)
         res = windll.kernel32.GetConsoleScreenBufferInfo(herr, csbi)
         if res:
-            (_bufx, _bufy, _curx, _cury, _wattr,
+            (_, _, _, _, _,
              left, top, right, bottom,
-             _maxx, _maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+             _, _) = struct.unpack("hhhhHhhhhhh", csbi.raw)
             tty_columns = right - left + 1
             tty_rows = bottom - top + 1
             return tty_rows, tty_columns
         else:
             return 600,100
-
     else:
         import fcntl
         import termios

--- a/gef.py
+++ b/gef.py
@@ -2874,9 +2874,9 @@ def get_terminal_size():
         csbi = create_string_buffer(22)
         res = windll.kernel32.GetConsoleScreenBufferInfo(herr, csbi)
         if res:
-            (bufx, bufy, curx, cury, wattr,
+            (_bufx, _bufy, _curx, _cury, _wattr,
              left, top, right, bottom,
-             maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+             _maxx, _maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
             tty_columns = right - left + 1
             tty_rows = bottom - top + 1
             return tty_rows, tty_columns

--- a/gef.py
+++ b/gef.py
@@ -2869,7 +2869,7 @@ def get_terminal_size():
     if platform.system() == "Windows":
         from ctypes import windll, create_string_buffer
         hStdErr = -12 
-        herr = windll.kernel32.GetStdHandle(hSdErr)
+        herr = windll.kernel32.GetStdHandle(hStdErr)
         csbi = create_string_buffer(22)
         res = windll.kernel32.GetConsoleScreenBufferInfo(herr, csbi)
         if res:


### PR DESCRIPTION
## Support gef on windows terminal ##

### Description/Motivation/Screenshots ###
This change make a little modification to make the gef script can be run smoothly on windows terminal (cmder). Due to lack of python module __fcntl__ & __termios__ on windows platform, the function __get_terminal_size__ will meet some errors on windows. Therefore, I add some code to make get_terminal_size can also run on windows terminal.  This modification doesn't change other core functionality, so I think it will not affect the test result. 
By the way, this is awesome project and make me convenient find bugs in program.

#### Screenshot of execution on cmder 
![image](https://user-images.githubusercontent.com/12622489/62407391-7e73be00-b5ea-11e9-9d83-be86a15ccf7e.png)

<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

### How Has This Been Tested? ###

| Architecture | Yes/No                   | Comments               |
|--------------|:------------------------:|------------------------|
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                        |
| ARM          | :heavy_multiplication_x: |                        | 
| AARCH64      | :heavy_multiplication_x: |  :heavy_check_mark:  |
| MIPS         | :heavy_multiplication_x: |                        |
| POWERPC      | :heavy_multiplication_x: |                        |
| SPARC        | :heavy_multiplication_x: |                        |
| `make tests` | :heavy_multiplication_x: |                        |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [ x ] If my code is a bug fix it targets master, otherwise it targets dev.
- [ x ] My code follows the code style of this project.
- [ x ] My change includes a change to the documentation, if required.
- [ x ] My change adds tests as appropriate.
- [ x ] I have read and agree to the **CONTRIBUTING** document.
