### PR TITLE
Workaround a crash with negative nb_insn on ARM64

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1372,6 +1372,7 @@ def gef_next_instruction(addr):
 def gef_disassemble(addr, nb_insn, nb_prev=0):
     """Disassemble `nb_insn` instructions after `addr` and `nb_prev` before `addr`.
     Return an iterator of Instruction objects."""
+    nb_insn = max(1, nb_insn)
     count = nb_insn + 1 if nb_insn & 1 else nb_insn
 
     if nb_prev:


### PR DESCRIPTION
Hi @hugsy! First of all: thanks for your OSS involvement, beautiful and useful project, your volunteer effort is honestly appreciated.

Now. I've been using Gef to grease up debug of a **Linux kernel running under Aarch64 QEMU**. Mostly, works great, except this one little crash.

Pretty much every time I step into `hlist_add_head()` kernel function, `gef context` explodes trying to disassemble negative-something instructions. The traceback:

```
    667		rest_init();
    [ Legend: Modified register | Code | Heap | Stack | String ]
    ------------------------------------------------------------------------------------- registers ----
    $x0  : 0x0000000000000000 -> 0x0000000000000000
    $x1  : 0xffffffc01d84a080 -> 0x00008124f000000f -> 0x00008124f000000f
    $x2  : 0x00000000000000d6 -> 0x00000000000000d6
    $x3  : 0x3677200000000000 -> 0x3677200000000000
    $x4  : 0xffffffc01d84a0f5 -> 0x007370756f726763 -> 0x007370756f726763
    $x5  : 0x07080e0000000000 -> 0x07080e0000000000
    $x6  : 0x00000000000e0807 -> 0x00000000000e0807
    $x7  : 0x746e6cfefefefefe -> 0x746e6cfefefefefe
    $x8  : 0x7f7f7fffffffffff -> 0x7f7f7fffffffffff
    $x9  : 0x0000000000000000 -> 0x0000000000000000
    $x10 : 0x0101010101010101 -> 0x0101010101010101
    $x11 : 0x000000000000002c -> 0x000000000000002c
    $x12 : 0x0000000000000020 -> 0x0000000000000020
    $x13 : 0x0000000000000020 -> 0x0000000000000020
    $x14 : 0x0fffffffffffffff -> 0x0fffffffffffffff
    $x15 : 0x0000000000000200 -> 0x0000000000000200
    $x16 : 0x0000000000007fff -> 0x0000000000007fff
    $x17 : 0x000000000000000d -> 0x000000000000000d
    $x18 : 0x0000000000001c80 -> 0x0000000000001c80
    $x19 : 0xffffffc001373000 -> 0x0000000000000000 -> 0x0000000000000000
    $x20 : 0xffffffc001304000 -> 0x0000000000000000 -> 0x0000000000000000
    $x21 : 0xffffffc0010b1238 -> 0x3d656c6f736e6f63 -> 0x3d656c6f736e6f63
    $x22 : 0xffffffc001168000 -> 0x0000000000000000 -> 0x0000000000000000
    $x23 : 0xffffffc001304000 -> 0x0000000000000000 -> 0x0000000000000000
    $x24 : 0xffffffc0010b1238 -> 0x3d656c6f736e6f63 -> 0x3d656c6f736e6f63
    $x25 : 0xffffffc01eff5f40 -> 0x3d656c6f736e6f63 -> 0x3d656c6f736e6f63
    $x26 : 0x000000004007d000 -> 0x000000004007d000
    $x27 : 0xffffffc000080148 -> <__mmap_switched+0> adr x3,  0xffffffc000080118 <__switch_data+8>
    $x28 : 0x0000004040000000 -> 0x0000004040000000
    $x29 : 0xffffffc00116bf90 -> 0x0000000000000000 -> 0x0000000000000000
    $x30 : 0xffffffc0010567fc -> <start_kernel+928> bl 0xffffffc000aa4b60 <rest_init>
    $sp  : 0xffffffc00116bf90 -> 0x0000000000000000 -> 0x0000000000000000
    $pc  : 0xffffffc0010567fc -> <start_kernel+928> bl 0xffffffc000aa4b60 <rest_init>
    $cpsr: [FAST interrupt overflow carry zero negative]
    $fpsr: 0x0000000000000000 -> 0x0000000000000000
    $fpcr: 0x0000000000000000 -> 0x0000000000000000
    ----------------------------------------------------------------------------------------- stack ----
    [!] Unmapped address
    -------------------------------------------------------------------------------- code:arm64:ARM ----
       0xffffffc0010567f0 <start_kernel+916> bl     0xffffffc0010657f0 <page_writeback_init>
       0xffffffc0010567f4 <start_kernel+920> bl     0xffffffc00106bf84 <proc_root_init>
       0xffffffc0010567f8 <start_kernel+924> bl     0xffffffc0010626cc <cgroup_init>
       0xffffffc0010567fc <start_kernel+928> bl     0xffffffc000aa4b60 <rest_init>
       0xffffffc001056800 <start_kernel+932> ldr    x25,  [sp, #64]
       0xffffffc001056804 <start_kernel+936> ldp    x19,  x20,  [sp, #16]
       0xffffffc001056808 <start_kernel+940> ldp    x21,  x22,  [sp, #32]
       0xffffffc00105680c <start_kernel+944> ldp    x23,  x24,  [sp, #48]
       0xffffffc001056810 <start_kernel+948> ldp    x29,  x30,  [sp], #96

    ------------------------------- Exception raised -------------------------------
    TypeError: Argument 'count' should be an non-negative integer.
    ----------------------------- Detailed stacktrace ------------------------------
    \-> File "/home/ulidtko/.gdbinit-gef.py", line 1291, in gdb_disassemble()
       ->    for insn in arch.disassemble(start_pc, **kwargs):
    \-> File "/home/ulidtko/.gdbinit-gef.py", line 1384, in gef_disassemble()
       ->    for insn in gdb_disassemble(addr, count=count):
    \-> File "/home/ulidtko/.gdbinit-gef.py", line 7535, in print_guessed_arguments()
       ->    for insn in instruction_iterator(block_start, pc-block_start):
    \-> File "/home/ulidtko/.gdbinit-gef.py", line 7482, in context_args()
       ->    self.print_guessed_arguments(target)
    \-> File "/home/ulidtko/.gdbinit-gef.py", line 7270, in do_invoke()
       ->    self.layout_mapping[section]()
    \-> File "/home/ulidtko/.gdbinit-gef.py", line 2464, in wrapper()
       ->    return f(*args, **kwargs)
    \-> File "/home/ulidtko/.gdbinit-gef.py", line 356, in wrapper()
       ->    rv = f(*args, **kwargs)
    \-> File "/home/ulidtko/.gdbinit-gef.py", line 3832, in invoke()
       ->    bufferize(self.do_invoke)(argv)
    ----------------------------- Last 10 GDB commands -----------------------------
      176  n
      177  lx-dmesg
      178  gef config gef.debug true
      179  gef config gef.debug
      180  target remote :1234
      181  break start_kernel
      182  conti
      183  n
      184  lx-dmesg
      185  n
    ----------------------------- Runtime environment ------------------------------
    * GDB: 7.11
    * Python: 2.7.5 - final
    * OS: Linux - 4.19.67-1-lts (64bit) on
    --------------------------------------------------------------------------------
```

This also brings down the whole gdb (it segfaults), which is... you get it.

The PR'd patch helps. It doesn't tackle the root cause; merely guards the `nb_insn` to be minimum 1.

I didn't bother investigating why `pc-block_start` might become negative; neither did I minimize the test case, as the setup is rather involved (and I also have other stuff to do).

Do as you see fit: either merge as-is (I hope it doesn't break anything) fixing the crash, or dig aarch64 and fix the root cause. In any case, I've done my duty to share the bug and fix for it.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_check_mark:  |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] This PR and the commit message is the change's documentation
- [ ] No tests, repro case is costly to minimize
- [x] I have read and agree to the **CONTRIBUTING** document.
