### PR TITLE
Fast chunks sizes miscalculated

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6457,7 +6457,7 @@ class GlibcHeapFastbinsYCommand(GenericCommand):
 
         gef_print(titlify("Fastbins for arena {:#x}".format(int(arena))))
         for i in range(NFASTBINS):
-            gef_print("Fastbins[idx={:d}, size={:#x}] ".format(i, (i+1)*SIZE_SZ*2), end="")
+            gef_print("Fastbins[idx={:d}, size={:#x}] ".format(i, (i+2)*SIZE_SZ*2), end="")
             chunk = arena.fastbin(i)
             chunks = set()
 


### PR DESCRIPTION
Fast chunks formula has been updated. Now it respects chunk min size in ptmalloc2.

## Fastbin size miscalculation ##

### Description/Motivation/Screenshots ###
Fastbin sizes are 0x10-0x40 on 32bit, not 0x8-0x38 since min chunk size is 16 (32 on 64bit)

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_check_mark: |                                           |
| AARCH64      | :heavy_check_mark: |                                           |
| MIPS         | :heavy_check_mark: |                                           |
| POWERPC      | :heavy_check_mark: |                                           |
| SPARC        | :heavy_check_mark: |                                           |
| `make test` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [:heavy_check_mark:] My PR was done against the `dev` branch, not `master`.
- [:heavy_check_mark:] My code follows the code style of this project.
- [not required] My change includes a change to the documentation, if required.
- [no new functionality] My change adds tests as appropriate.
- [:heavy_check_mark:] I have read and agree to the **CONTRIBUTING** document.
