### PR TITLE
riscv: minor updates to the riscv arch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@
 | MIPS         | :heavy_multiplication_x: |                                           |
 | POWERPC      | :heavy_multiplication_x: |                                           |
 | SPARC        | :heavy_multiplication_x: |                                           |
+| RISC-V       | :heavy_multiplication_x: |                                           |
 | `make tests` | :heavy_multiplication_x: |                                           |
 
 ### Checklist ###

--- a/gef.py
+++ b/gef.py
@@ -1605,15 +1605,15 @@ class RISCV(Architecture):
     arch = "RISCV"
     mode = "RISCV"
 
-    all_registers = ["$zero", "$ra", "$sp", "$gp", "$x4", "$t0", "$t1",
-                     "$t2", "$fp", "$s1", "$a1", "$a2", "$a3", "$a4",
-                     "$a5", "$a6", "$a7", "$s2", "$s3", "$s4", "$s5",
-                     "$s6", "$s7", "$s8", "$s9", "$s10", "$s11", "$t3",
-                     "$t4", "$t5", "$t6",]
+    all_registers = ["$zero", "$ra", "$sp", "$gp", "$tp", "$t0", "$t1",
+                     "$t2", "$fp", "$s1", "$a0", "$a1", "$a2", "$a3",
+                     "$a4", "$a5", "$a6", "$a7", "$s2", "$s3", "$s4",
+                     "$s5", "$s6", "$s7", "$s8", "$s9", "$s10", "$s11",
+                     "$t3", "$t4", "$t5", "$t6",]
     return_register = "$a0"
     function_parameters = ["$a0", "$a1", "$a2", "$a3", "$a4", "$a5", "$a6", "$a7"]
     syscall_register = "$a7"
-    syscall_register = "ecall"
+    syscall_instructions = ["ecall"]
     nop_insn = b"\x00\x00\x00\x13"
     # RISC-V has no flags registers
     flag_register = None


### PR DESCRIPTION
## riscv: minor updates to the riscv arch

### Description/Motivation/Screenshots ###

     - Update the all_registers property
       - include the 'a0' register
       - rename the 'x4' register to the more common name 'tp'
     - Fix the `syscall_instructions` property

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                          |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                           |

^ I didn't add RISCV to this in 727ad0cb. Should it be added?

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
