### PR TITLE
Basic Mach-O support for macOS

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3201,14 +3201,13 @@ def set_arch(arch=None, default=None):
         "ARM": ARM, Elf.ARM: ARM,
         "AARCH64": AARCH64, "ARM64": AARCH64, Elf.AARCH64: AARCH64,
         "X86": X86, Elf.X86_32: X86,
-        "X86_64": X86_64, Elf.X86_64: X86_64,
+        "X86_64": X86_64, Elf.X86_64: X86_64, "i386:x86-64": X86_64,
         "PowerPC": PowerPC, "PPC": PowerPC, Elf.POWERPC: PowerPC,
         "PowerPC64": PowerPC64, "PPC64": PowerPC64, Elf.POWERPC64: PowerPC64,
         "RISCV": RISCV, Elf.RISCV: RISCV,
         "SPARC": SPARC, Elf.SPARC: SPARC,
         "SPARC64": SPARC64, Elf.SPARC64: SPARC64,
         "MIPS": MIPS, Elf.MIPS: MIPS,
-        "i386:x86-64": X86_64
     }
     global current_arch, current_elf
 

--- a/gef.py
+++ b/gef.py
@@ -3193,7 +3193,7 @@ def is_arch(arch):
 def set_arch(arch=None, default=None):
     """Sets the current architecture.
     If an arch is explicitly specified, use that one, otherwise try to parse it
-    out of the ELF header. If that fails, and default is specified, select and
+    out of the current target. If that fails, and default is specified, select and
     set that arch.
     Return the selected arch, or raise an OSError.
     """

--- a/gef.py
+++ b/gef.py
@@ -587,7 +587,7 @@ class Elf:
 
     ELF_32_BITS       = 0x01
     ELF_64_BITS       = 0x02
-    ELF_MAGIC         = b"\x7fELF"
+    ELF_MAGIC         = 0x7f454c46
 
     X86_64            = 0x3e
     X86_32            = 0x03

--- a/gef.py
+++ b/gef.py
@@ -2743,7 +2743,7 @@ def get_process_maps_linux(proc_map_file):
             inode = rest[0]
             pathname = rest[1].lstrip()
 
-        addr_start, addr_end = list(map(lambda x: long(x, 16), addr.split("-")))
+        addr_start, addr_end = [long(x, 16) for x in addr.split("-")]
         off = long(off, 16)
         perm = Permission.from_process_maps(perm)
 
@@ -2761,7 +2761,7 @@ def get_mach_regions():
     for line in gdb.execute("info mach-regions", to_string=True).splitlines():
         line = line.strip()
         addr, perm, _ = line.split(" ", 2)
-        addr_start, addr_end = list(map(lambda x: long(x, 16), addr.split("-")))
+        addr_start, addr_end = [long(x, 16) for x in addr.split("-")]
         perm = Permission.from_process_maps(perm.split("/")[0])
 
         zone = file_lookup_address(addr_start)

--- a/gef.py
+++ b/gef.py
@@ -7271,7 +7271,8 @@ class EntryPointBreakCommand(GenericCommand):
         return self.set_init_tbreak(base_address + addr)
 
     def is_pie(self, fpath):
-        return checksec(fpath)["PIE"]
+        checksec_status = checksec(fpath)
+        return checksec_status and checksec_status["PIE"]
 
 
 @register_command
@@ -8936,6 +8937,10 @@ class GotCommand(GenericCommand):
                                                        "been resolved")
         self.add_setting("function_not_resolved", "yellow", "Line color of the got command output if the function has "
                                                        "not been resolved")
+        return
+
+    def pre_load(self):
+        which("readelf")
         return
 
     def get_jmp_slots(self, readelf, filename):

--- a/gef.py
+++ b/gef.py
@@ -1686,10 +1686,10 @@ class RISCV(Architecture):
     def is_branch_taken(self, insn):
         def long_to_twos_complement(v):
             """Convert a python long value to its two's complement."""
-            if is_elf32():
+            if is_32bit():
                 if v & 0x80000000:
                     return v - 0x100000000
-            elif is_elf64():
+            elif is_64bit():
                 if v & 0x8000000000000000:
                     return v - 0x10000000000000000
             else:
@@ -2574,20 +2574,20 @@ def only_if_gdb_version_higher_than(required_gdb_version):
 
 
 def use_stdtype():
-    if   is_elf32(): return "uint32_t"
-    elif is_elf64(): return "uint64_t"
+    if   is_32bit(): return "uint32_t"
+    elif is_64bit(): return "uint64_t"
     return "uint16_t"
 
 
 def use_default_type():
-    if   is_elf32(): return "unsigned int"
-    elif is_elf64(): return "unsigned long"
+    if   is_32bit(): return "unsigned int"
+    elif is_64bit(): return "unsigned long"
     return "unsigned short"
 
 
 def use_golang_type():
-    if   is_elf32(): return "uint32"
-    elif is_elf64(): return "uint64"
+    if   is_32bit(): return "uint32"
+    elif is_64bit(): return "uint64"
     return "uint16"
 
 
@@ -2699,7 +2699,7 @@ def download_file(target, use_cache=False, local_name=None):
     except gdb.error:
         # gdb-stub compat
         with open(local_name, "w") as f:
-            if is_elf32():
+            if is_32bit():
                 f.write("00000000-ffffffff rwxp 00000000 00:00 0                    {}\n".format(get_filepath()))
             else:
                 f.write("0000000000000000-ffffffffffffffff rwxp 00000000 00:00 0                    {}\n".format(get_filepath()))
@@ -3155,35 +3155,33 @@ def get_elf_headers(filename=None):
 
 
 @lru_cache()
-def is_elf64(filename=None):
-    """Checks if `filename` is an ELF64."""
-    elf = current_elf or get_elf_headers(filename)
-    return elf.e_class == Elf.ELF_64_BITS
+def is_64bit():
+    """Checks if current target is 64bit."""
+    voidptr = cached_lookup_type("void").pointer()
+    return voidptr.sizeof == 8
 
 
 @lru_cache()
-def is_elf32(filename=None):
-    """Checks if `filename` is an ELF32."""
-    elf = current_elf or get_elf_headers(filename)
-    return elf.e_class == Elf.ELF_32_BITS
+def is_32bit():
+    """Checks if current target is 32bit."""
+    voidptr = cached_lookup_type("void").pointer()
+    return voidptr.sizeof == 4
 
 
 @lru_cache()
-def is_x86_64(filename=None):
-    """Checks if `filename` is an x86-64 ELF."""
-    elf = current_elf or get_elf_headers(filename)
-    return elf.e_machine == Elf.X86_64
+def is_x86_64():
+    """Checks if current target is x86-64"""
+    return get_arch() == "i386:x86-64"
 
 
 @lru_cache()
-def is_x86_32(filename=None):
-    """Checks if `filename` is an x86-32 ELF."""
-    elf = current_elf or get_elf_headers(filename)
-    return elf.e_machine == Elf.X86_32
+def is_x86_32():
+    """Checks if current target is an x86-32"""
+    return get_arch() == "i386"
 
 @lru_cache()
-def is_x86(filename=None):
-    return is_x86_32(filename) or is_x86_64(filename)
+def is_x86():
+    return is_x86_32() or is_x86_64()
 
 
 @lru_cache()
@@ -3255,9 +3253,9 @@ def get_memory_alignment(in_bits=False):
     Finally, try the size of $pc.
     If `in_bits` is set to True, the result is returned in bits, otherwise in
     bytes."""
-    if is_elf32():
+    if is_32bit():
         return 4 if not in_bits else 32
-    elif is_elf64():
+    elif is_64bit():
         return 8 if not in_bits else 64
 
     res = cached_lookup_type("size_t")
@@ -8103,9 +8101,6 @@ class HexdumpCommand(GenericCommand):
 
 
     def _hexdump(self, start_addr, length, arrange_as, offset=0):
-        elf = get_elf_headers()
-        if elf is None:
-            return
         endianness = endian_str()
 
         base_address_color = get_gef_setting("theme.dereference_base_address")

--- a/gef.py
+++ b/gef.py
@@ -2588,10 +2588,11 @@ def get_register(regname):
         regname = regname[1:]
         try:
             value = gdb.selected_frame().read_register(regname)
+            return long(value)
         except ValueError:
             return None
-
-        return long(value)
+        except gdb.error:
+            return None
 
 
 def get_path_from_info_proc():

--- a/gef.py
+++ b/gef.py
@@ -1500,6 +1500,12 @@ def checksec(filename):
         err("Missing `readelf`")
         return
 
+    try:
+        gef_execute_external([readelf, "-h", filename])
+    except Exception:
+        err("`readelf` failed to parse the binary")
+        return
+
     def __check_security_property(opt, filename, pattern):
         cmd   = [readelf,]
         cmd  += opt.split()

--- a/gef.py
+++ b/gef.py
@@ -587,6 +587,7 @@ class Elf:
 
     ELF_32_BITS       = 0x01
     ELF_64_BITS       = 0x02
+    ELF_MAGIC         = b"\x7fELF"
 
     X86_64            = 0x3e
     X86_32            = 0x03
@@ -604,7 +605,7 @@ class Elf:
     ET_CORE           = 4
 
 
-    e_magic           = b"\x7fELF"
+    e_magic           = ELF_MAGIC
     e_class           = ELF_32_BITS
     e_endianness      = LITTLE_ENDIAN
     e_eiversion       = None
@@ -663,6 +664,10 @@ class Elf:
             self.e_flags, self.e_ehsize, self.e_phentsize, self.e_phnum = struct.unpack("{}HHHH".format(endian), fd.read(8))
             self.e_shentsize, self.e_shnum, self.e_shstrndx = struct.unpack("{}HHH".format(endian), fd.read(6))
         return
+
+
+    def is_valid(self):
+        return self.e_magic == Elf.ELF_MAGIC
 
 
 class Instruction:
@@ -3156,6 +3161,7 @@ def set_arch(arch=None, default=None):
         "SPARC": SPARC, Elf.SPARC: SPARC,
         "SPARC64": SPARC64, Elf.SPARC64: SPARC64,
         "MIPS": MIPS, Elf.MIPS: MIPS,
+        "i386:x86-64": X86_64
     }
     global current_arch, current_elf
 
@@ -3166,9 +3172,13 @@ def set_arch(arch=None, default=None):
         except KeyError:
             raise OSError("Specified arch {:s} is not supported".format(arch.upper()))
 
-    current_elf = current_elf or get_elf_headers()
+    if not current_elf:
+        elf = get_elf_headers()
+        current_elf = elf if elf.is_valid() else None
+
+    arch_name = current_elf.e_machine if current_elf else get_arch()
     try:
-        current_arch = arches[current_elf.e_machine]()
+        current_arch = arches[arch_name]()
     except KeyError:
         if default:
             try:

--- a/gef.py
+++ b/gef.py
@@ -2653,6 +2653,15 @@ def get_filename():
     return os.path.basename(gdb.current_progspace().filename)
 
 
+@lru_cache()
+def is_macho():
+    """Return True if the current file is a Mach-O binary."""
+    for x in gdb.execute("info file", to_string=True).splitlines():
+        if "file type mach-o" in x:
+            return True
+    return False
+
+
 def download_file(target, use_cache=False, local_name=None):
     """Download filename `target` inside the mirror tree inside the get_gef_setting("gef.tempdir").
     The tree architecture must be get_gef_setting("gef.tempdir")/gef/<local_pid>/<remote_filepath>.
@@ -2733,15 +2742,41 @@ def get_process_maps_linux(proc_map_file):
     return
 
 
+def get_mach_regions():
+    sp = current_arch.sp
+    for line in gdb.execute("info mach-regions", to_string=True).splitlines():
+        line = line.strip()
+        addr, perm, _ = line.split(" ", 2)
+        addr_start, addr_end = list(map(lambda x: long(x, 16), addr.split("-")))
+        perm = Permission.from_process_maps(perm.split("/")[0])
+
+        zone = file_lookup_address(addr_start)
+        if zone:
+            path = zone.filename
+        else:
+            path = "[stack]" if sp >= addr_start and sp < addr_end else ""
+
+        yield Section(page_start=addr_start,
+                      page_end=addr_end,
+                      offset=0,
+                      permission=perm,
+                      inode=None,
+                      path=path)
+    return
+
+
 @lru_cache()
 def get_process_maps():
-    """Parse the `/proc/pid/maps` file."""
+    """Return the mapped memory sections"""
 
     sections = []
     try:
-        pid = get_pid()
-        fpath = "/proc/{:d}/maps".format(pid)
-        sections = get_process_maps_linux(fpath)
+        if is_macho():
+            sections = get_mach_regions()
+        else:
+            pid = get_pid()
+            fpath = "/proc/{:d}/maps".format(pid)
+            sections = get_process_maps_linux(fpath)
         return list(sections)
 
     except FileNotFoundError as e:

--- a/gef.py
+++ b/gef.py
@@ -1558,6 +1558,17 @@ def get_endian():
     raise EnvironmentError("Invalid endianess")
 
 
+@lru_cache()
+def get_entry_point():
+    """Return the binary entry point."""
+
+    for line in gdb.execute("info target", to_string=True).split("\n"):
+        if "Entry point:" in line:
+            return long(line.strip().split(" ")[-1], 16)
+
+    return None
+
+
 def is_big_endian():     return get_endian() == Elf.BIG_ENDIAN
 def is_little_endian():  return not is_big_endian()
 
@@ -7233,16 +7244,16 @@ class EntryPointBreakCommand(GenericCommand):
             bp.delete()
 
         # break at entry point
-        elf = get_elf_headers()
-        if elf is None:
+        entry = get_entry_point()
+        if entry is None:
             return
 
         if self.is_pie(fpath):
-            self.set_init_tbreak_pie(elf.e_entry, argv)
+            self.set_init_tbreak_pie(entry, argv)
             gdb.execute("continue")
             return
 
-        self.set_init_tbreak(elf.e_entry)
+        self.set_init_tbreak(entry)
         gdb.execute("run {}".format(" ".join(argv)))
         return
 

--- a/gef.py
+++ b/gef.py
@@ -1548,10 +1548,13 @@ def get_arch():
 @lru_cache()
 def get_endian():
     """Return the binary endianness."""
-    if is_alive():
-        return get_elf_headers().e_endianness
-    if gdb.execute("show endian", to_string=True).strip().split()[7] == "little" :
+
+    endian = gdb.execute("show endian", to_string=True).strip()
+    if "little endian" in endian:
         return Elf.LITTLE_ENDIAN
+    if "big endian" in endian:
+        return Elf.BIG_ENDIAN
+
     raise EnvironmentError("Invalid endianess")
 
 
@@ -3328,8 +3331,7 @@ def is_in_x86_kernel(address):
 
 @lru_cache()
 def endian_str():
-    elf = current_elf or get_elf_headers()
-    return "<" if elf.e_endianness == Elf.LITTLE_ENDIAN else ">"
+    return "<" if is_little_endian() else ">"
 
 
 @lru_cache()


### PR DESCRIPTION
## Allow Mach-O binaries to be debugged with gef on macOS ##

### Description/Motivation/Screenshots ###
Parts of gef depend on or expects the file being debugged to be an ELF. This PR allows for the correct `current_arch` to be set as well as adding support for getting the memory mappings via `info mach-regions`.

As there have now been a few ctfs with mac pwns (eg [machbook](https://github.com/how2hack/my-ctf-challenges/tree/master/balsnctf-2019/machbook) and [applepie](https://github.com/david942j/ctf-writeups/tree/master/0ctf-quals-2019/applepie)) being able to use gef would be great.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |       |
| x86-64       | :heavy_check_mark: |     also on macOS 10.15, gdb 8.3                                      |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hugsy/gef/469)
<!-- Reviewable:end -->
