### PR TITLE
Libc filename regex changed

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1009,9 +1009,9 @@ def get_libc_version():
     sections = get_process_maps()
     try:
         for section in sections:
-            if "libc-" in section.path:
+            if "libc" in section.path:
                 libc_version = tuple(int(_) for _ in
-                                     re.search(r"libc-(\d+)\.(\d+)\.so", section.path).groups())
+                                     re.search(r"libc6?[-_](\d+)\.(\d+)\.so", section.path).groups())
                 break
         else:
             libc_version = 0, 0


### PR DESCRIPTION
Libc filename regex now respects libc6_{version}.so format.

Sometimes libc.so file is called just libc.so.6 and we can't extract its version from filename, but we may try to look for it in wd path.

<img width="710" alt="libc" src="https://user-images.githubusercontent.com/48091103/67929853-73bbcb80-fbcf-11e9-8821-3067c0e294b2.png">


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
