### PR TITLE
Improve output messages of syscall-arg command

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -9192,6 +9192,7 @@ class SyscallArgsCommand(GenericCommand):
         if path is None:
             err("Cannot open '{0}': check directory and/or `gef config {0}` setting, "
                 "currently: '{1}'".format("syscall-args.path", self.get_setting("path")))
+            info("This setting can be configured by running gef-extras' install script.")
             return
 
         arch = current_arch.__class__.__name__

--- a/gef.py
+++ b/gef.py
@@ -9215,9 +9215,9 @@ class SyscallArgsCommand(GenericCommand):
 
         headers = ["Parameter", "Register", "Value"]
         param_names = [re.split(r" |\*", p)[-1] for p in parameters]
-        info(Color.colorify("{:<28} {:<28} {}".format(*headers), color))
+        info(Color.colorify("{:<20} {:<20} {}".format(*headers), color))
         for name, register, value in zip(param_names, registers, values):
-            line = "    {:<15} {:<15} 0x{:x}".format(name, register, value)
+            line = "    {:<20} {:<20} 0x{:x}".format(name, register, value)
 
             addrs = DereferenceCommand.dereference_from(value)
 


### PR DESCRIPTION
## Improve output messages of `syscall-arg` command ##

### Description/Motivation/Screenshots ###
When the `syscall-args.path` setting is not configured, provide information that it can be installed using the gef-extras install script.

Also, the table output of `syscall-args` is not properly aligned. This is fixed here as well.

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
