### PR TITLE
Simple doc fix

### DIFF
--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -49,7 +49,7 @@ section name with `-` or just omit it.
 ```
 gef➤ gef config context.layout "-legend regs stack code args -source -threads -trace extra memory"
 ```
-This configuration will not display the `source`, `threads`, and `trace` sections.
+This configuration will not display the `legend`, `source`, `threads`, and `trace` sections.
 
 The `memory` pane will display the content of all locations specified by the
 `memory` command. For instance,


### PR DESCRIPTION
## A simple fix in the documentation of commands context ##

### Description/Motivation/Screenshots ###
Just a little change in the documentation of commands context

As said in this page, a section is hide when prepended by - ("To hide a section, simply use the context.layout setting, and prepend the section name with - or just omit it.").
So when running this command :
```
gef➤ gef config context.layout "-legend regs stack code args -source -threads -trace extra memory"
```
you will have no display of the legend section (or maybe have I missed something?)

You might have preferred to delete the "-" in the command instead adding "legend" to the ignored fields...

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, AND ONLY.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
