### PR TITLE
Fix context for embedded ARM workaround

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1737,7 +1737,7 @@ class ARM(Architecture):
     @lru_cache()
     def is_thumb(self):
         """Determine if the machine is currently in THUMB mode."""
-        return is_alive() and get_register("$cpsr") & (1<<5)
+        return is_alive() and get_register(self.flag_register) & (1<<5)
 
     @property
     def pc(self):


### PR DESCRIPTION
##  Fix context for embedded ARM workaround ##

### Description/Motivation/Screenshots ###
https://github.com/hugsy/gef/issues/320#issuecomment-553081021 suggests a workaround for an inconsistenly named flag register on embedded ARM systems. (`$cpsr` vs. `$xPSR` vs. `$xpsr`) Unfortunately `$cpsr` was still hardcoded in this code which caused context to fail even with the workaround.

This patch just changes the code to use the `flag_register` field instead of an hard-coded value which in combination with the workaround linked earlier fixes gef on embedded ARM systems.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_check_mark:|                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
