### PR TITLE
Improved detection of libc version

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1011,7 +1011,7 @@ class GlibcChunk:
         return "\n".join(msg) + "\n"
 
 
-pattern_libc_ver = re.compile(b"glibc (\d+)\.(\d+)")
+pattern_libc_ver = re.compile(rb"glibc (\d+)\.(\d+)")
 
 @lru_cache()
 def get_libc_version():

--- a/gef.py
+++ b/gef.py
@@ -1026,9 +1026,9 @@ def get_libc_version():
                 if os.access(section.path, os.R_OK):
                     with open(section.path, "rb") as f:
                         data = f.read()
-                        for match in re.finditer(pattern_libc_ver, data):
-                            libc_version = tuple(int(_) for _ in match.group().split(b" ")[-1].split(b"."))
-                            break
+                    for match in re.finditer(pattern_libc_ver, data):
+                        libc_version = tuple(int(_) for _ in match.group().split(b" ")[-1].split(b"."))
+                        break
             break
     return libc_version
 

--- a/gef.py
+++ b/gef.py
@@ -1011,19 +1011,25 @@ class GlibcChunk:
         return "\n".join(msg) + "\n"
 
 
+pattern_libc_ver = re.compile(rb"glibc (\d+)\.(\d+)")
+
 @lru_cache()
 def get_libc_version():
     sections = get_process_maps()
-    try:
-        for section in sections:
-            if "libc" in section.path:
+    libc_version = 0, 0
+    for section in sections:
+        if "libc" in section.path:
+            try:
                 libc_version = tuple(int(_) for _ in
                                      re.search(r"libc6?[-_](\d+)\.(\d+)\.so", section.path).groups())
-                break
-        else:
-            libc_version = 0, 0
-    except AttributeError:
-        libc_version = 0, 0
+            except AttributeError:
+                if os.access(section.path, os.R_OK):
+                    with open(section.path, "rb") as f:
+                        data = f.read()
+                        for match in re.finditer(pattern_libc_ver, data):
+                            libc_version = tuple(int(_) for _ in match.group().split(b" ")[-1].split(b"."))
+                            break
+            break
     return libc_version
 
 

--- a/gef.py
+++ b/gef.py
@@ -1011,7 +1011,7 @@ class GlibcChunk:
         return "\n".join(msg) + "\n"
 
 
-pattern_libc_ver = re.compile(rb"glibc (\d+)\.(\d+)")
+pattern_libc_ver = re.compile(b"glibc (\d+)\.(\d+)")
 
 @lru_cache()
 def get_libc_version():

--- a/gef.py
+++ b/gef.py
@@ -1023,12 +1023,14 @@ def get_libc_version():
                 libc_version = tuple(int(_) for _ in
                                      re.search(r"libc6?[-_](\d+)\.(\d+)\.so", section.path).groups())
             except AttributeError:
-                if os.access(section.path, os.R_OK):
+                try:
                     with open(section.path, "rb") as f:
                         data = f.read()
                     for match in re.finditer(pattern_libc_ver, data):
                         libc_version = tuple(int(_) for _ in match.group().split(b" ")[-1].split(b"."))
                         break
+                except OSError:
+                    pass
             break
     return libc_version
 

--- a/gef.py
+++ b/gef.py
@@ -1024,6 +1024,7 @@ def get_libc_version():
                                      re.search(r"libc6?[-_](\d+)\.(\d+)\.so", section.path).groups())
             except AttributeError:
                 try:
+                    data = b""
                     with open(section.path, "rb") as f:
                         data = f.read()
                     for match in re.finditer(pattern_libc_ver, data):


### PR DESCRIPTION
## Improved detection of libc version ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
Sometimes libc may be called differently from "libc-x.xx.so" and in a similar way. For example, when using "ld" with "--library-path", it loads exactly "libc.so.6":
![image](https://user-images.githubusercontent.com/45942862/72023185-359fef80-3283-11ea-835d-f0e3e0895096.png)
<!-- Why is this patch will make a better world? -->
If it is not possible to find out the version of the libc from the name, we can try to look for the string "glibc X.XX" in the binary file. In tests on about 15 different versions (and for different architectures), this string was always present, unlike others.
<!-- How does this look? Add a screenshot if you can -->
After these changes, the library version was correctly defined (2.27 in my case) and I got the opportunity to work with the functionality for tcache.
Before:
![image](https://user-images.githubusercontent.com/45942862/72024224-f626d280-3285-11ea-8a22-24cb8256d7e3.png)
After:
![image](https://user-images.githubusercontent.com/45942862/72024009-608b4300-3285-11ea-8b49-4b677acff25a.png)

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |                                           |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |   the same as 'dev'     |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
