### PR TITLE
Add dereference support for rust types

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2555,6 +2555,12 @@ def use_golang_type():
     return "uint16"
 
 
+def use_rust_type():
+    if   is_elf32(): return "u32"
+    elif is_elf64(): return "u64"
+    return "u16"
+
+
 def to_unsigned_long(v):
     """Cast a gdb.Value to unsigned long."""
     mask = (1 << 64) - 1
@@ -3324,7 +3330,8 @@ def dereference(addr):
     try:
         ulong_t = cached_lookup_type(use_stdtype()) or \
                   cached_lookup_type(use_default_type()) or \
-                  cached_lookup_type(use_golang_type())
+                  cached_lookup_type(use_golang_type()) or \
+                  cached_lookup_type(use_rust_type())
         unsigned_long_type = ulong_t.pointer()
         res = gdb.Value(addr).cast(unsigned_long_type).dereference()
         # GDB does lazy fetch by default so we need to force access to the value


### PR DESCRIPTION
## Add dereference support for rust types ##

### Description/Motivation/Screenshots ###
Currently when using gef with rust-gdb derefrencing fails as gef doesn't support Rust types. This patch adds support for Rust types much like the existing support for Golang.
Since certain gef commands use deference (e.g. pcustom), they also fail without this patch.

**Before**
Trying to deference when debugging rust binaries failed.
![image](https://user-images.githubusercontent.com/39744677/72180613-60ca3200-339c-11ea-9e7b-b4a81cbc25a0.png)

**Now**
Works nicely.
![image](https://user-images.githubusercontent.com/39744677/72180409-fca76e00-339b-11ea-8067-66591124e678.png)
### How Has This Been Tested? ###
Against a x86_64 rust binary with rust-gdb.

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                            |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                          |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
