### PR TITLE
Remove python2 from lint and docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,6 @@ FROM circleci/python:3.4
 
 ENV PYTHONPATH /usr/local/lib/python3.4/site-packages
 
-# Setup Python2 Dependencies
-RUN sudo apt-get install python2.7 python-setuptools python-dev build-essential
-RUN sudo python2 -m easy_install pip
-RUN sudo python2 -m pip install pylint
-
 # Setup Development Tools
 RUN sudo apt-get update -y
 RUN sudo apt-get install gdb git cmake gcc g++ pkg-config libglib2.0-dev -y

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,5 @@ testbins: tests/binaries/*.c
 	@make -C tests/binaries all
 
 lint:
-	python2 -m py_compile gef.py
 	python3 -m pylint --rcfile ./.pylintrc tests/*.py
 	python3 -m pylint -E gef.py


### PR DESCRIPTION
Let's just make sure CI passes for this and that we can rebuild the docker image and run it locally.