### PR TITLE
Fix memory watch and hexdump confusing addr with size

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7868,7 +7868,7 @@ class HexdumpCommand(GenericCommand):
     @only_if_gdb_running
     def do_invoke(self, argv):
         fmt = "byte"
-        target = "$sp"
+        target = ""
         valid_formats = ["byte", "word", "dword", "qword"]
         read_len = None
         reverse = False
@@ -7883,18 +7883,21 @@ class HexdumpCommand(GenericCommand):
                     break
             if is_format_given:
                 continue
-            if arg.startswith("l"):
-                arg = arg[1:]
-            try:
-                read_len = int(arg, 0)
-                continue
-            except ValueError:
-                pass
-
             if "reverse".startswith(arg):
                 reverse = True
                 continue
+            if arg.startswith("l") or target:
+                if arg.startswith("l"):
+                    arg = arg[1:]
+                if read_len:
+                    self.usage()
+                    return
+                read_len = int(arg, 0)
+                continue
             target = arg
+
+        if not target:
+            target="$sp"
 
         start_addr = to_unsigned_long(gdb.parse_and_eval(target))
         read_from = align_address(start_addr)


### PR DESCRIPTION
## Fix memory watch and hexdump confusing addr with size ##

### Description/Motivation/Screenshots ###
This fixes a regression from commit 16aa313.

Assume these declarations in code:

    uint32_t arr[16];
    uint32_t a;

Before this fix, the following failed because content pointed by $sp
was shown instead:

    memory watch arr
    memory watch 0x404050
    memory watch (void*)0x404050
    memory watch &a

This commit also fixes this case (addr 0x404050 taken as size, $sp
used as address):

    hexdump byte 0x404050

This commit also print usage when relevant (double address or double
size).


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] (don't apply) My change includes a change to the documentation, if required.
- [x] (don't apply) My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
