### PR TITLE
Fix error when trying to guess arguments

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7476,7 +7476,7 @@ class ContextCommand(GenericCommand):
             pc = current_arch.pc
             try:
                 block_start = gdb.block_for_pc(pc).start
-            except RuntimeError:
+            except Exception:
                 # if stripped, let's roll back 5 instructions
                 block_start = gdb_get_nth_previous_instruction_address(pc, 5)
             return block_start


### PR DESCRIPTION
Changed try/catch to catch all Exceptions, not just RuntimeError, in the `print_guessed_arguments` function.

## Fixed error for `print_guessed_arguments` ##

### Description ###
<!-- Describe technically what your patch does. -->
When GDB updated to version 9.1, the guessed arguments function was no longer working, because an error was being raised that was not caught.  Changing the type of error caught to Exception resolved the issue and allowed GEF to show the guessed arguments again.

<!-- Why is this change required? What problem does it solve? -->
When GDB updated to version 9.1, the guessed arguments function was no longer working, because an error was being raised that was not caught.

<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                      |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
