### PR TITLE
Patch the function get_filepath()

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2513,6 +2513,10 @@ def get_filepath():
         elif filename.startswith("target:"):
             fname = filename[len("target:"):]
             return download_file(fname, use_cache=True, local_name=fname)
+        
+        elif filename.startswith(".gnu_debugdata for target:"):
+            fname = filename[len(".gnu_debugdata for target:"):]
+            return download_file(fname, use_cache=True, local_name=fname)
 
         elif __gef_remote__ is not None:
             return "/tmp/gef/{:d}/{:s}".format(__gef_remote__, get_path_from_info_proc())


### PR DESCRIPTION
For a gdb with LZMA supported, the return value of gdb.current_progspace().filename could be a string with prefix ".gnu_debugdata for target:", I add some codes to handle this case.
This patch is used to solve the issue https://github.com/hugsy/gef/issues/458

## <ARM and ARM 64 arch, display context info incorrectly> ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | ✔️ |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [] My PR was done against the `dev` branch, not `master`.
- [] My code follows the code style of this project.
- [] My change includes a change to the documentation, if required.
- [] My change adds tests as appropriate.
- [] I have read and agree to the **CONTRIBUTING** document.
