### PR TITLE
Use $(MAKE) instead of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ test: testbins
 	python3 tests/runtests.py
 	@rm -f /tmp/gef.py
 	@rm -f /tmp/gef-*
-	@make -C tests/binaries clean
+	@$(MAKE) -C tests/binaries clean
 
 Test%: testbins
 	@cp gef.py /tmp/gef.py
@@ -12,7 +12,7 @@ Test%: testbins
 	@rm -f /tmp/gef-*
 
 testbins: tests/binaries/*.c
-	@make -C tests/binaries all
+	@$(MAKE) -C tests/binaries all
 
 lint:
 	python3 -m pylint --rcfile ./.pylintrc tests/*.py


### PR DESCRIPTION
## Use $(MAKE) instead of make ##

### Description/Motivation/Screenshots ###

This way the correct make binary is going to be called.

GEF depends on gmake, which is not always available as
make. By using $(MAKE) we can make sure that this recursive
make invocation is going to use a proper make.

I stumbled upon this issue while porting GEF to FreeBSD.
### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | N/A |
| x86-64       | :heavy_multiplication_x: |       N/A                                    |
| ARM          | :heavy_multiplication_x: |             N/A                              |
| AARCH64      | :heavy_multiplication_x: |              N/A                             |
| MIPS         | :heavy_multiplication_x: |                         N/A                  |
| POWERPC      | :heavy_multiplication_x: |                        N/A                   |
| SPARC        | :heavy_multiplication_x: |                                  N/A         |
| RISC-V       | :heavy_multiplication_x: |                                     N/A      |
| `make tests` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
