### PR TITLE
Replace imp with importlib

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -65,7 +65,7 @@ import ctypes
 import functools
 import getopt
 import hashlib
-import imp
+import importlib
 import inspect
 import itertools
 import os
@@ -4604,7 +4604,7 @@ class PCustomCommand(GenericCommand):
 
     def get_module(self, modname):
         _fullname = self.pcustom_filepath(modname)
-        return imp.load_source(modname, _fullname)
+        return importlib.machinery.SourceFileLoader(modname, _fullname).load_module()
 
 
     def get_structure_class(self, modname, classname):
@@ -9148,7 +9148,7 @@ class SyscallArgsCommand(GenericCommand):
 
     def get_module(self, modname):
         _fullname = self.get_filepath(modname)
-        return imp.load_source(modname, _fullname)
+        return importlib.machinery.SourceFileLoader(modname, _fullname).load_module()
 
     def get_syscall_table(self, modname):
         _mod = self.get_module(modname)

--- a/gef.py
+++ b/gef.py
@@ -4604,7 +4604,7 @@ class PCustomCommand(GenericCommand):
 
     def get_module(self, modname):
         _fullname = self.pcustom_filepath(modname)
-        return importlib.machinery.SourceFileLoader(modname, _fullname).load_module()
+        return importlib.machinery.SourceFileLoader(modname, _fullname).load_module(None)
 
 
     def get_structure_class(self, modname, classname):
@@ -9148,7 +9148,7 @@ class SyscallArgsCommand(GenericCommand):
 
     def get_module(self, modname):
         _fullname = self.get_filepath(modname)
-        return importlib.machinery.SourceFileLoader(modname, _fullname).load_module()
+        return importlib.machinery.SourceFileLoader(modname, _fullname).load_module(None)
 
     def get_syscall_table(self, modname):
         _mod = self.get_module(modname)


### PR DESCRIPTION

## Replace imp with importlib ##

### Description/Motivation/Screenshots ###
Fixes: DeprecationWarning: the imp module is deprecated in favour of
importlib; see the module's documentation for alternative uses.

I think this is equiv, but someone might want to double check. I just
ripped things off from here:
https://github.com/pyinvoke/invoke/pull/215/files

and tested a single codepath:
```
0:000   syscall-args
[+] Detected syscall exit_group
    exit_group(int error_code)
[+] Parameter            Register             Value
    error_code           $rdi                 0x0
```


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                           |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
