### PR TITLE
Support Safe-Linking in GlibC 2.32+

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -787,12 +787,17 @@ class GlibcChunk:
         return GlibcChunk(addr)
 
     # if free-ed functions
-    def get_fwd_ptr(self):
-        return read_int_from_memory(self.address)
+    def get_fwd_ptr(self, sll):
+        # Not a single-linked-list (sll) or no Safe-Linking support yet
+        if not sll or get_libc_version() < (2, 32):
+            return read_int_from_memory(self.address)
+        # Unmask ("reveal") the Safe-Linking pointer
+        else:
+            return read_int_from_memory(self.address) ^ (self.address >> 12)
 
     @property
     def fwd(self):
-        return self.get_fwd_ptr()
+        return self.get_fwd_ptr(False)
 
     fd = fwd # for compat
 
@@ -860,7 +865,7 @@ class GlibcChunk:
 
         msg = []
         try:
-            msg.append("Forward pointer: {0:#x}".format(self.get_fwd_ptr()))
+            msg.append("Forward pointer: {0:#x}".format(self.get_fwd_ptr(False)))
         except gdb.MemoryError:
             msg.append("Forward pointer: {0:#x} (corrupted?)".format(fwd))
 
@@ -6320,7 +6325,7 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
 
                     chunks.add(chunk.address)
 
-                    next_chunk = chunk.get_fwd_ptr()
+                    next_chunk = chunk.get_fwd_ptr(True)
                     if next_chunk == 0:
                         break
 
@@ -6384,7 +6389,7 @@ class GlibcHeapFastbinsYCommand(GenericCommand):
 
                     chunks.add(chunk.address)
 
-                    next_chunk = chunk.get_fwd_ptr()
+                    next_chunk = chunk.get_fwd_ptr(True)
                     if next_chunk == 0:
                         break
 


### PR DESCRIPTION
## Support glibc's Safe-Linking in malloc ##
### Description/Motivation/Screenshots ###
glibc 2.32 will add support for protection of single-linked-lists such as the Fastbins and TCache lists. This support, which was [pushed](https://sourceware.org/git/?p=glibc.git;a=commit;h=a1a486d70ebcc47a686ff5846875eacad0940e41) already to glibc's master branch, is referred to us "Safe-Linking".

Safe-Linking masks the "fwd" pointers, and so this commit implements the support for unmasking ("reavel"ing) the pointers so they could be used properly by gef.

Note: Fixed my previous pull request so that the caller will explicitly pass True/False to specify if the "fwd" pointer is for a single-linked-list (SLL) or a double-linked-list which needs no unmasking.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |                                               |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
