### PR TITLE
FIX missing command name in `help`

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -5273,7 +5273,7 @@ class ChangePermissionCommand(GenericCommand):
     _cmdline_ = "set-permission"
     _syntax_  = "{:s} LOCATION [PERMISSION]".format(_cmdline_)
     _aliases_ = ["mprotect",]
-    _example_ = "{:s} $sp 7"
+    _example_ = "{:s} $sp 7".format(_cmdline_)
 
     def __init__(self):
         super(ChangePermissionCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
@@ -5950,7 +5950,7 @@ class StubCommand(GenericCommand):
     _syntax_  = """{:s} [-r RETVAL] [-h] [LOCATION]
 \tLOCATION\taddress/symbol to stub out
 \t-r RETVAL\tSet the return value""".format(_cmdline_)
-    _example_ = "{:s} -r 0 fork"
+    _example_ = "{:s} -r 0 fork".format(_cmdline_)
 
     def __init__(self):
         super(StubCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)


### PR DESCRIPTION
## Fix missing command name in "Example:" in `help` ##

### Description/Motivation/Screenshots ###
`help  stub` and `help set-permission` shows a python format string instead of the command name.
I've just added the missing `.format(_cmd_line_)`.