### PR TITLE
Fix exception when the heap section is unavailable

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6298,7 +6298,11 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
             return
 
         # Get tcache_perthread_struct for this arena
-        addr = HeapBaseFunction.heap_base() + 0x10
+        heap_base = HeapBaseFunction.heap_base()
+        if heap_base is None:
+            err("No heap section")
+            return
+        addr = heap_base + 0x10
 
         gef_print(titlify("Tcachebins for arena {:#x}".format(int(arena))))
         for i in range(GlibcArena.TCACHE_MAX_BINS):


### PR DESCRIPTION
This is a quick fix for an exception I was getting:

```
─────────────────────────────── Exception raised ───────────────────────────────
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
───────────────────────────── Detailed stacktrace ──────────────────────────────
↳ File "/home/nat/.gdbinit-gef.py", line 6298, in do_invoke()
    →     addr = HeapBaseFunction.heap_base() + 0x10
↳ File "/home/nat/.gdbinit-gef.py", line 2403, in wrapper()
    →     return f(*args, **kwargs)
↳ File "/home/nat/.gdbinit-gef.py", line 244, in wrapper()
    →     return f(*args, **kwargs)
↳ File "/home/nat/.gdbinit-gef.py", line 3803, in invoke()
    →     bufferize(self.do_invoke)(argv)
```

I didn't do any real testing, but I figured you might want it here.