### PR TITLE
hexdump: Do not convert ADDRESS argument to lower case

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7909,6 +7909,7 @@ class HexdumpCommand(GenericCommand):
         reverse = False
 
         for arg in argv:
+            arg_old = arg   # if it were to be assigned to target, we don't want to convert it to lower case
             arg = arg.lower()
             is_format_given = False
             for valid_format in valid_formats:
@@ -7929,7 +7930,7 @@ class HexdumpCommand(GenericCommand):
                     return
                 read_len = int(arg, 0)
                 continue
-            target = arg
+            target = arg_old
 
         if not target:
             target="$sp"

--- a/gef.py
+++ b/gef.py
@@ -7909,28 +7909,27 @@ class HexdumpCommand(GenericCommand):
         reverse = False
 
         for arg in argv:
-            arg_old = arg   # if it were to be assigned to target, we don't want to convert it to lower case
-            arg = arg.lower()
+            arg_lower = arg.lower()
             is_format_given = False
             for valid_format in valid_formats:
-                if valid_format.startswith(arg):
+                if valid_format.startswith(arg_lower):
                     fmt = valid_format
                     is_format_given = True
                     break
             if is_format_given:
                 continue
-            if "reverse".startswith(arg):
+            if "reverse".startswith(arg_lower):
                 reverse = True
                 continue
-            if arg.startswith("l") or target:
-                if arg.startswith("l"):
-                    arg = arg[1:]
+            if arg_lower.startswith("l") or target:
+                if arg_lower.startswith("l"):
+                    arg_lower = arg_lower[1:]
                 if read_len:
                     self.usage()
                     return
-                read_len = int(arg, 0)
+                read_len = int(arg_lower, 0)
                 continue
-            target = arg_old
+            target = arg
 
         if not target:
             target="$sp"


### PR DESCRIPTION
## hexdump: Do not convert ADDRESS argument to lower case ##

### Description/Motivation/Screenshots ###
Fix #525. `hexdump` converts all its arguments to lower case, causing it to fail when a variable name (passed as the `ADDRESS` argument) contains uppercase letters (refer to issue for example).

Should be a quick one, anything I missed about keeping the case of `ADDRESS`?

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |         |
| x86-64       | :heavy_multiplication_x: |  :heavy_check_mark:   |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
