### PR TITLE
Allow packaging and importing as Python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ tests/pylint.txt
 tests/pylint3.html
 .vscode
 _build
+dist
+*.egg-info/

--- a/gef.py
+++ b/gef.py
@@ -9952,7 +9952,8 @@ def __gef_prompt__(current_prompt):
     return GEF_PROMPT_OFF
 
 
-if __name__  == "__main__":
+def init():
+    global __gef__
 
     if sys.version_info[0] == 2:
         err("GEF has dropped Python2 support for GDB when it reached EOL on 2020/01/01.")
@@ -10021,3 +10022,7 @@ if __name__  == "__main__":
 
         GefAliases()
         GefTmuxSetup()
+
+
+if __name__  == "__main__":
+    init()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.poetry]
+name = "gef"
+version = "2020.03-1"
+authors = ['hugsy']
+homepage = "https://gef.readthedocs.io/en/master/"
+documentation = "https://gef.readthedocs.io/en/master/"
+repository = "https://github.com/hugsy/gef"
+description = "GDB Enhanced Features for exploit devs & reversers"
+readme = "README.md"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Plugins",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.4",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Topic :: Software Development :: Debuggers",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.4"
+capstone = "^4.0.1"
+Ropper = "^1.13.3"
+keystone-engine = "^0.9.1"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
### Description/Motivation/Screenshots ###
The goal of this change is to allow gef to be built and versioned as a
Python module so that users can easily install it using `pip install
gef`. The wget and paste in `.gdbinit` is unnecessary in some cases.
To do this, I included a `pyproject.toml` so that a user can use Poetry
to build and publish the package easily to PyPi (which I ultimately want
to happen as well). I've chosen to include `capstone`, `keystone`, and
`Ropper` as dependencies of the module, but left out `unicorn` since
it failed to install with Python3.

The second piece to this is that it should be possible to `import gef`
and run the initialization when desired, instead of automatically. By
adding a `main()` around the default initialization, a user could choose
to initialize `gef` later on while in GDB instead of automatically at boot.

The real motivation is that this can now be used with 
[gdbundle](https://github.com/memfault/gdbundle). However, every GDB 
Python script should ultimately be a Python package so that it's
able to be version controlled within a project's `requirements.txt` file
and sourced manually through a project-specific `.gdbinit` script.

I did not update the documentation to include this method of installation.

### How Has This Been Tested? ###

- With a GDB compiled with Python 3.6, run `pip install .` within the
project directory and confirm that I can run the following:
```
$ gdb
(gdb) pi
>>> import gef
>>> gef.init()
>>> <ctrl-d>
gef> # YAY it works!
```
- Confirm that sourcing it as originally intended still works as well.

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.