### PR TITLE
do not clear scrollback buffer

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3150,7 +3150,7 @@ def get_memory_alignment(in_bits=False):
 def clear_screen(tty=""):
     """Clear the screen."""
     if not tty:
-        gdb.execute("shell clear")
+        gdb.execute("shell clear -x")
         return
 
     # Since the tty can be closed at any time, a PermissionError exception can


### PR DESCRIPTION
## BUG FIX ##

### Description/Motivation/Screenshots ###
Sometimes `clear_screen` commands deletes scrollback buffer which is annoying. So we make sure we don't do that since the command is set the default now

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.