### PR TITLE
Fix pcustom command

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -12,7 +12,7 @@
 # devs and reversers, to provides additional features to GDB using the Python
 # API to assist during the process of dynamic analysis.
 #
-# GEF fully relies on GDB API and other Linux-specific sources of information"
+# GEF fully relies on GDB API and other Linux-specific sources of information
 # (such as /proc/<pid>). As a consequence, some of the features might not work
 # on custom or hardened systems such as GrSec.
 #

--- a/gef.py
+++ b/gef.py
@@ -12,7 +12,7 @@
 # devs and reversers, to provides additional features to GDB using the Python
 # API to assist during the process of dynamic analysis.
 #
-# GEF fully relies on GDB API and other Linux-specific sources of information
+# GEF fully relies on GDB API and other Linux-specific sources of information"
 # (such as /proc/<pid>). As a consequence, some of the features might not work
 # on custom or hardened systems such as GrSec.
 #
@@ -4567,7 +4567,6 @@ class PCustomCommand(GenericCommand):
 
     _cmdline_ = "pcustom"
     _syntax_  = "{:s} [-l] [StructA [0xADDRESS] [-e]]".format(_cmdline_)
-    _aliases_ = ["dt"]
 
     def __init__(self):
         super(PCustomCommand, self).__init__(complete=gdb.COMPLETE_SYMBOL)

--- a/gef.py
+++ b/gef.py
@@ -4567,6 +4567,7 @@ class PCustomCommand(GenericCommand):
 
     _cmdline_ = "pcustom"
     _syntax_  = "{:s} [-l] [StructA [0xADDRESS] [-e]]".format(_cmdline_)
+    _aliases_ = ["dt"]
 
     def __init__(self):
         super(PCustomCommand, self).__init__(complete=gdb.COMPLETE_SYMBOL)
@@ -4619,15 +4620,9 @@ class PCustomCommand(GenericCommand):
 
 
     def get_pcustom_filepath_for_structure(self, structure_name):
-        structure_files = self.enumerate_structures()
-        fpath = None
-        for fname in structure_files:
-            if structure_name in structure_files[fname]:
-                fpath = fname
-                break
-        if not fpath:
-            raise FileNotFoundError("no file for structure '{}'".format(structure_name))
-        return fpath
+        root = self.get_pcustom_abspath()
+        filename = "{:s}.py".format(structure_name)
+        return os.sep.join([root, filename])
 
 
     def is_valid_struct(self, structure_name):
@@ -4667,12 +4662,6 @@ class PCustomCommand(GenericCommand):
         length = min(len(data), ctypes.sizeof(struct))
         ctypes.memmove(ctypes.addressof(struct), data, length)
         return
-
-
-    def load_custom_module(self, modname):
-        print("loading custom module %s" % modname)
-        _fullname = self.get_pcustom_filepath_for_structure(modname)
-        return importlib.machinery.SourceFileLoader(modname, _fullname).load_module(None)
 
 
     def get_structure_class(self, modname, classname):


### PR DESCRIPTION
## pcustom command fixes ##

### Description/Motivation/Screenshots ###
1) Add dt alias according to documentation
2) Remove file existence check from get_pcustom_filepath_for_structure as it is used with -e option that does not require existence

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          |  |                                           |
| AARCH64      |  |                                           |
| MIPS         |  |                                           |
| POWERPC      |  |                                           |
| SPARC        |  |                                           |
| `make test` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [not required] My change includes a change to the documentation, if required.
- [] My change adds tests as appropriate. Should we create some structures there to test command?
- [x] I have read and agree to the **CONTRIBUTING** document.
