### PR TITLE
Macho support

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1494,7 +1494,7 @@ def get_entry_point():
 
 
 def is_pie(fpath):
-    return checksec(get_filepath())["PIE"]
+    return checksec(fpath)["PIE"]
 
 
 def is_big_endian():     return get_endian() == Elf.BIG_ENDIAN
@@ -2761,16 +2761,13 @@ def get_mach_regions():
 def get_process_maps():
     """Return the mapped memory sections"""
 
-    sections = []
-    try:
-        if inferior_is_macho():
-            sections = get_mach_regions()
-        else:
-            pid = get_pid()
-            fpath = "/proc/{:d}/maps".format(pid)
-            sections = get_process_maps_linux(fpath)
-        return list(sections)
+    if inferior_is_macho():
+        return list(get_mach_regions())
 
+    try:
+        pid = get_pid()
+        fpath = "/proc/{:d}/maps".format(pid)
+        return list(get_process_maps_linux(fpath))
     except FileNotFoundError as e:
         warn("Failed to read /proc/<PID>/maps, using GDB sections info: {}".format(e))
         return list(get_info_sections())

--- a/gef.py
+++ b/gef.py
@@ -7348,7 +7348,8 @@ class EntryPointBreakCommand(GenericCommand):
         return self.set_init_tbreak(base_address + addr)
 
     def is_pie(self, fpath):
-        return checksec(fpath)["PIE"]
+        checksec_status = checksec(fpath)
+        return checksec_status and checksec_status["PIE"]
 
 
 @register_command
@@ -9158,6 +9159,10 @@ class GotCommand(GenericCommand):
                                                        "been resolved")
         self.add_setting("function_not_resolved", "yellow", "Line color of the got command output if the function has "
                                                        "not been resolved")
+        return
+
+    def pre_load(self):
+        which("readelf")
         return
 
     def get_jmp_slots(self, readelf, filename):

--- a/gef.py
+++ b/gef.py
@@ -3143,7 +3143,7 @@ def is_arch(arch):
 def set_arch(arch=None, default=None):
     """Sets the current architecture.
     If an arch is explicitly specified, use that one, otherwise try to parse it
-    out of the ELF header. If that fails, and default is specified, select and
+    out of the current target. If that fails, and default is specified, select and
     set that arch.
     Return the selected arch, or raise an OSError.
     """

--- a/gef.py
+++ b/gef.py
@@ -483,7 +483,7 @@ class Elf:
 
     ELF_32_BITS       = 0x01
     ELF_64_BITS       = 0x02
-    ELF_MAGIC         = b"\x7fELF"
+    ELF_MAGIC         = 0x7f454c46
 
     X86_64            = 0x3e
     X86_32            = 0x03

--- a/gef.py
+++ b/gef.py
@@ -3151,14 +3151,13 @@ def set_arch(arch=None, default=None):
         "ARM": ARM, Elf.ARM: ARM,
         "AARCH64": AARCH64, "ARM64": AARCH64, Elf.AARCH64: AARCH64,
         "X86": X86, Elf.X86_32: X86,
-        "X86_64": X86_64, Elf.X86_64: X86_64,
+        "X86_64": X86_64, Elf.X86_64: X86_64, "i386:x86-64": X86_64,
         "PowerPC": PowerPC, "PPC": PowerPC, Elf.POWERPC: PowerPC,
         "PowerPC64": PowerPC64, "PPC64": PowerPC64, Elf.POWERPC64: PowerPC64,
         "RISCV": RISCV, Elf.RISCV: RISCV,
         "SPARC": SPARC, Elf.SPARC: SPARC,
         "SPARC64": SPARC64, Elf.SPARC64: SPARC64,
         "MIPS": MIPS, Elf.MIPS: MIPS,
-        "i386:x86-64": X86_64
     }
     global current_arch, current_elf
 

--- a/gef.py
+++ b/gef.py
@@ -1478,7 +1478,7 @@ def get_entry_point():
 
     for line in gdb.execute("info target", to_string=True).split("\n"):
         if "Entry point:" in line:
-            return long(line.strip().split(" ")[-1], 16)
+            return int(line.strip().split(" ")[-1], 16)
 
     return None
 
@@ -2556,7 +2556,7 @@ def get_register(regname):
         regname = regname[1:]
         try:
             value = gdb.selected_frame().read_register(regname)
-            return long(value)
+            return int(value)
         except ValueError:
             return None
         except gdb.error:
@@ -2696,7 +2696,7 @@ def get_process_maps_linux(proc_map_file):
             inode = rest[0]
             pathname = rest[1].lstrip()
 
-        addr_start, addr_end = [long(x, 16) for x in addr.split("-")]
+        addr_start, addr_end = [int(x, 16) for x in addr.split("-")]
         off = int(off, 16)
         perm = Permission.from_process_maps(perm)
 
@@ -2714,7 +2714,7 @@ def get_mach_regions():
     for line in gdb.execute("info mach-regions", to_string=True).splitlines():
         line = line.strip()
         addr, perm, _ = line.split(" ", 2)
-        addr_start, addr_end = [long(x, 16) for x in addr.split("-")]
+        addr_start, addr_end = [int(x, 16) for x in addr.split("-")]
         perm = Permission.from_process_maps(perm.split("/")[0])
 
         zone = file_lookup_address(addr_start)

--- a/gef.py
+++ b/gef.py
@@ -2537,10 +2537,11 @@ def get_register(regname):
         regname = regname[1:]
         try:
             value = gdb.selected_frame().read_register(regname)
+            return long(value)
         except ValueError:
             return None
-
-        return int(value)
+        except gdb.error:
+            return None
 
 
 def get_path_from_info_proc():

--- a/gef.py
+++ b/gef.py
@@ -2696,7 +2696,7 @@ def get_process_maps_linux(proc_map_file):
             inode = rest[0]
             pathname = rest[1].lstrip()
 
-        addr_start, addr_end = list(map(lambda x: int(x, 16), addr.split("-")))
+        addr_start, addr_end = [long(x, 16) for x in addr.split("-")]
         off = int(off, 16)
         perm = Permission.from_process_maps(perm)
 
@@ -2714,7 +2714,7 @@ def get_mach_regions():
     for line in gdb.execute("info mach-regions", to_string=True).splitlines():
         line = line.strip()
         addr, perm, _ = line.split(" ", 2)
-        addr_start, addr_end = list(map(lambda x: long(x, 16), addr.split("-")))
+        addr_start, addr_end = [long(x, 16) for x in addr.split("-")]
         perm = Permission.from_process_maps(perm.split("/")[0])
 
         zone = file_lookup_address(addr_start)

--- a/gef.py
+++ b/gef.py
@@ -1462,10 +1462,13 @@ def get_arch():
 @lru_cache()
 def get_endian():
     """Return the binary endianness."""
-    if is_alive():
-        return get_elf_headers().e_endianness
-    if gdb.execute("show endian", to_string=True).strip().split()[7] == "little" :
+
+    endian = gdb.execute("show endian", to_string=True).strip()
+    if "little endian" in endian:
         return Elf.LITTLE_ENDIAN
+    if "big endian" in endian:
+        return Elf.BIG_ENDIAN
+
     raise EnvironmentError("Invalid endianess")
 
 
@@ -3278,8 +3281,7 @@ def is_in_x86_kernel(address):
 
 @lru_cache()
 def endian_str():
-    elf = current_elf or get_elf_headers()
-    return "<" if elf.e_endianness == Elf.LITTLE_ENDIAN else ">"
+    return "<" if is_little_endian() else ">"
 
 
 @lru_cache()


### PR DESCRIPTION
Clone of #469 

## Allow Mach-O binaries to be debugged with gef on macOS ##

### Description/Motivation/Screenshots ###
Parts of gef depend on or expects the file being debugged to be an ELF. This PR allows for the correct `current_arch` to be set as well as adding support for getting the memory mappings via `info mach-regions`.

As there have now been a few ctfs with mac pwns (eg [machbook](https://github.com/how2hack/my-ctf-challenges/tree/master/balsnctf-2019/machbook) and [applepie](https://github.com/david942j/ctf-writeups/tree/master/0ctf-quals-2019/applepie)) being able to use gef would be great.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |       |
| x86-64       | :heavy_check_mark: |     also on macOS 10.15, gdb 8.3                                      |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |