### PR TITLE
ida: Add IDA 7.2+ compatibility

### DIFF
--- a/docs/commands/ida-interact.md
+++ b/docs/commands/ida-interact.md
@@ -6,19 +6,19 @@ can be downloaded freely
 [here](https://raw.githubusercontent.com/hugsy/gef/master/scripts/ida_gef.py)).
 
 Simply download this script, and run it inside IDA. When the server is running,
-you will see a text in the Output Window such as:
+you should see some output:
 
 ```
 [+] Creating new thread for XMLRPC server: Thread-1
 [+] Starting XMLRPC server: 0.0.0.0:1337
-[+] Registered 6 functions.
+[+] Registered 12 functions.
 ```
 
-This indicates that the XML-RPC server is ready and listening.
+This indicates that IDA is ready to work with `gef`!
 
-`gef` can interact with it via the command `ida-interact`. This command receives
-as first argument the name of the function to execute, all the other arguments
-are the arguments of the remote function.
+`gef` can interact with it via the command `ida-interact` (alias `ida`). This
+command expects the name of the function to execute as the first argument, all the
+other arguments are the arguments of the remote function.
 
 To enumerate the functions available, simply run
 ```
@@ -31,14 +31,14 @@ with its arguments (if required).
 
 For example:
 ```
-gef➤  ida ida.set_color 0x40061E
+gef➤  ida setcolor 0x40061E
 ```
 will edit the remote IDB and set the background color of the location 0x40061E
 with the color 0x005500 (default value).
 
 Another convenient example is to add comment inside IDA directly from `gef`:
 ```
-gef➤  ida ida.add_comment 0x40060C "<<<--- stack overflow"
+gef➤  ida makecomm 0x40060C "<<<--- stack overflow"
 [+] Success
 ```
 
@@ -46,8 +46,7 @@ Result:
 
 ![gef-ida-example](https://i.imgur.com/jZ2eWG4.png)
 
-Please use the `--help` argument to see all the methods available and their
-syntax.
+Please use the `-h` argument to see all the methods available and their syntax.
 
 It is also note-worthy that [Binary Ninja](https://binary.ninja) support has be added:
 ![](https://pbs.twimg.com/media/CzSso9bUAAArL1f.jpg:large), by using the

--- a/gef.py
+++ b/gef.py
@@ -5063,7 +5063,7 @@ class IdaInteractCommand(GenericCommand):
         method_name = argv[0].lower()
         if method_name == "version":
             self.version = self.sock.version()
-            info("Enhancing {:s} with {:s} (v.{:s})".format(Color.greenify("gef"),
+            info("Enhancing {:s} with {:s} (SDK {:s})".format(Color.greenify("gef"),
                                                             Color.redify(self.version[0]),
                                                             Color.yellowify(self.version[1])))
             return

--- a/scripts/ida_gef.py
+++ b/scripts/ida_gef.py
@@ -211,7 +211,7 @@ class Gef:
     def makecomm(self, address, comment):
         """ makecomm(int addr, string comment) => None
         Add a comment to the current IDB at the location `address`.
-        Example: ida MakeComm 0x40000 "Important call here!"
+        Example: ida makecomm 0x40000 "Important call here!"
         """
         addr = long(address, 16) if ishex(address) else long(address)
         return api.MakeComm(addr, comment)
@@ -220,7 +220,7 @@ class Gef:
     def setcolor(self, address, color="0x005500"):
         """ setcolor(int addr [, int color]) => None
         Set the location pointed by `address` in the IDB colored with `color`.
-        Example: ida SetColor 0x40000
+        Example: ida setcolor 0x40000
         """
         addr = long(address, 16) if ishex(address) else long(address)
         color = long(color, 16) if ishex(color) else long(color)
@@ -230,7 +230,7 @@ class Gef:
     def makename(self, address, name):
         """ makename(int addr, string name]) => None
         Set the location pointed by `address` with the name specified as argument.
-        Example: ida MakeName 0x4049de __entry_point
+        Example: ida makename 0x4049de __entry_point
         """
         addr = long(address, 16) if ishex(address) else long(address)
         return api.MakeName(addr, name)
@@ -239,7 +239,7 @@ class Gef:
     def jump(self, address):
         """ jump(int addr) => None
         Move the IDA EA pointer to the address pointed by `addr`.
-        Example: ida Jump 0x4049de
+        Example: ida jump 0x4049de
         """
         addr = long(address, 16) if ishex(address) else long(address)
         return api.Jump(addr)
@@ -255,7 +255,7 @@ class Gef:
         """ importstruct(string name) => dict
         Import an IDA structure in GDB which can be used with the `pcustom`
         command.
-        Example: ida ImportStruct struct_1
+        Example: ida importstruct struct_1
         """
         struct = self.get_struct(name)
         if struct is None:
@@ -269,7 +269,7 @@ class Gef:
         """ importstructs() => dict
         Import all structures from the current IDB into GDB, to be used with the `pcustom`
         command.
-        Example: ida ImportStructs
+        Example: ida importstructs
         """
         structs = {}
         for _, _, name in api.Structs():
@@ -317,7 +317,7 @@ class RequestHandler(SimpleXMLRPCRequestHandler):
 
 def start_xmlrpc_server():
     """
-    Initialize the XMLRPC thread
+    Initialize the XMLRPC thread.
     """
     print("[+] Starting XMLRPC server: {}:{}".format(HOST, PORT))
     server = SimpleXMLRPCServer((HOST, PORT),

--- a/scripts/ida_gef.py
+++ b/scripts/ida_gef.py
@@ -29,9 +29,10 @@ from __future__ import print_function
 
 from SimpleXMLRPCServer import SimpleXMLRPCRequestHandler, SimpleXMLRPCServer, list_public_methods
 
-import threading
-import string
 import inspect
+import string
+import threading
+import types
 
 import idautils, idc, idaapi
 
@@ -62,6 +63,83 @@ def is_exposed(f):
 
 def ishex(s):
     return s.startswith("0x") or s.startswith("0X")
+
+
+class IDAWrapper(object):
+    """Class to wrap the various IDA modules. Makes them thread safe by
+    enforcing they run in the main thread (which is required by IDA >= 7.2).
+    Generators returned from the function are automatically wrapped with a
+    thread-safe generator.
+    This also provides a mapping from <=6.95 to the newer API.
+    Modified from
+    https://github.com/vrtadmin/FIRST-plugin-ida/blob/3a4287c4faa83127f8792bf2737be99edcb070e1/first_plugin_ida/first.py
+    """
+    api_map = {
+        "AddBpt": idc.add_bpt,
+        "GetBptEA": idc.get_bpt_ea,
+        "GetBptQty": idc.get_bpt_qty,
+        "GetColor": idc.get_color,
+        "Jump": idc.jumpto,
+        "MakeComm": lambda ea, comm: idc.set_cmt(ea, comm, 0),
+        "MakeName": idc.set_name,
+        "SetColor": idc.set_color,
+    }
+
+    def __getattribute__(self, name):
+        bad = "dummy not found"
+        v = bad
+        if idaapi.IDA_SDK_VERSION >= 700 and name in IDAWrapper.api_map:
+            v = IDAWrapper.api_map[name]
+
+        if v is bad:
+            v = getattr(idaapi, name, bad)
+        if v is bad:
+            v = getattr(idautils, name, bad)
+        if v is bad:
+            v = getattr(idc, name, bad)
+        if v is bad:
+            print("[!] Error: Cannot find API method {}".format(name))
+            return None
+
+        # Wrap callables
+        if callable(v):
+            def call_wrap(*args, **kwargs):
+                # Need a mutable value to store result
+                rv = [None]
+                # Wrapper that binds the args
+                def c():
+                    rv[0] = v(*args, **kwargs)
+                idaapi.execute_sync(c, idaapi.MFF_WRITE)
+                if isinstance(rv[0], types.GeneratorType):
+                    return IDAWrapper.gen_wrap(rv[0])
+                return rv[0]
+            return call_wrap
+
+        return v
+
+    @classmethod
+    def gen_wrap(cls, generator):
+        """Wrap the provided generator with a getter that executes `next`
+        in the main thread.
+        """
+
+        # Need a mutable value to store result
+        v = [None]
+
+        def c():
+            try:
+                v[0] = next(generator)
+            except StopIteration:
+                v[0] = StopIteration
+
+        while True:
+            idaapi.execute_sync(c, idaapi.MFF_WRITE)
+            if v[0] is StopIteration:
+                return
+            yield v[0]
+
+
+api = IDAWrapper()
 
 
 class Gef:
@@ -131,106 +209,106 @@ class Gef:
 
     @expose
     def makecomm(self, address, comment):
-        """ MakeComm(int addr, string comment) => None
+        """ makecomm(int addr, string comment) => None
         Add a comment to the current IDB at the location `address`.
         Example: ida MakeComm 0x40000 "Important call here!"
         """
         addr = long(address, 16) if ishex(address) else long(address)
-        return idc.MakeComm(addr, comment)
+        return api.MakeComm(addr, comment)
 
     @expose
     def setcolor(self, address, color="0x005500"):
-        """ SetColor(int addr [, int color]) => None
+        """ setcolor(int addr [, int color]) => None
         Set the location pointed by `address` in the IDB colored with `color`.
         Example: ida SetColor 0x40000
         """
         addr = long(address, 16) if ishex(address) else long(address)
         color = long(color, 16) if ishex(color) else long(color)
-        return idc.SetColor(addr, CIC_ITEM, color)
+        return api.SetColor(addr, CIC_ITEM, color)
 
     @expose
     def makename(self, address, name):
-        """ MakeName(int addr, string name]) => None
+        """ makename(int addr, string name]) => None
         Set the location pointed by `address` with the name specified as argument.
         Example: ida MakeName 0x4049de __entry_point
         """
         addr = long(address, 16) if ishex(address) else long(address)
-        return idc.MakeName(addr, name)
+        return api.MakeName(addr, name)
 
     @expose
     def jump(self, address):
-        """ Jump(int addr) => None
+        """ jump(int addr) => None
         Move the IDA EA pointer to the address pointed by `addr`.
         Example: ida Jump 0x4049de
         """
         addr = long(address, 16) if ishex(address) else long(address)
-        return idc.Jump(addr)
+        return api.Jump(addr)
 
-    def getstructbyname(self, name):
-        for (struct_idx, struct_sid, struct_name) in Structs():
-            if struct_name == name:
-                return struct_sid
+    def get_struct(self, name):
+        for idx, sid, sname in api.Structs():
+            if sname == name:
+                return sid
         return None
 
     @expose
-    def importstruct(self, struct_name):
-        """ ImportStruct(string name) => dict
+    def importstruct(self, name):
+        """ importstruct(string name) => dict
         Import an IDA structure in GDB which can be used with the `pcustom`
         command.
         Example: ida ImportStruct struct_1
         """
-        if self.GetStructByName(struct_name) is None:
+        struct = self.get_struct(name)
+        if struct is None:
             return {}
-        res = {struct_name: [x for x in StructMembers(self.GetStructByName(struct_name))]}
-        return res
+        return {
+            name: [x for x in api.StructMembers(struct)]
+        }
 
     @expose
     def importstructs(self):
-        """ ImportStructs() => dict
+        """ importstructs() => dict
         Import all structures from the current IDB into GDB, to be used with the `pcustom`
         command.
         Example: ida ImportStructs
         """
-        res = {}
-        for s in Structs():
-            res.update(self.ImportStruct(s[2]))
-        return res
+        structs = {}
+        for _, _, name in api.Structs():
+            structs.update(self.importstruct(name))
+        return structs
 
     @expose
     def sync(self, offset, added, removed):
-        """ Sync(offset, added, removed) => None
+        """ sync(offset, added, removed) => None
         Synchronize debug info with gef. This is an internal function. It is
         not recommended using it from the command line.
         """
         global _breakpoints, _current_instruction, _current_instruction_color
 
         if _current_instruction > 0:
-            idc.SetColor(_current_instruction, CIC_ITEM, _current_instruction_color)
+            api.SetColor(_current_instruction, CIC_ITEM, _current_instruction_color)
 
-        base_addr = idaapi.get_imagebase()
+        base_addr = api.get_imagebase()
         pc = base_addr + int(offset, 16)
         _current_instruction = long(pc)
-        _current_instruction_color = GetColor(_current_instruction, CIC_ITEM)
-        idc.SetColor(_current_instruction, CIC_ITEM, 0x00ff00)
-        print("PC @ " + hex(_current_instruction).strip('L'))
-        # post it to the ida main thread to prevent race conditions
-        idaapi.execute_sync(lambda: idc.Jump(_current_instruction), idaapi.MFF_WRITE)
+        _current_instruction_color = api.GetColor(_current_instruction, CIC_ITEM)
+        api.SetColor(_current_instruction, CIC_ITEM, 0x00ff00)
+        api.Jump(_current_instruction)
 
-        cur_bps = set([ idc.GetBptEA(n)-base_addr for n in range(idc.GetBptQty()) ])
+        cur_bps = {api.GetBptEA(n)-base_addr for n in range(api.GetBptQty())}
         ida_added = cur_bps - _breakpoints
         ida_removed = _breakpoints - cur_bps
         _breakpoints = cur_bps
 
-        # update bp from gdb
+        # update bps from gdb
         for bp in added:
-            idc.AddBpt(base_addr+bp)
+            api.AddBpt(base_addr+bp)
             _breakpoints.add(bp)
         for bp in removed:
             if bp in _breakpoints:
                 _breakpoints.remove(bp)
-            idc.DelBpt(base_addr+bp)
+            api.DelBpt(base_addr+bp)
 
-        return [list(ida_added), list(ida_removed)]
+        return [tuple(ida_added), tuple(ida_removed)]
 
 
 class RequestHandler(SimpleXMLRPCRequestHandler):


### PR DESCRIPTION
### Description/Motivation/Screenshots ###
This fixes up ida_gef.py to work with IDA > 7.2, while maintaining backwards compatibility.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [] My change includes a change to the documentation, if required.
- [] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.

- [x] improve docs
