### PR TITLE
Updated TinyURL links for the installer scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Simply make sure you have [GDB 7.7 or higher](https://www.gnu.org/s/gdb) compile
 ```bash
 # via the install script
 ## using curl
-$ sh -c "$(curl -fsSL https://tinyurl.com/gef-install)"
+$ sh -c "$(curl -fsSL https://tinyurl.com/gef-installer)"
 
 ## using wget
-$ sh -c "$(wget https://tinyurl.com/gef-install -O -)"
+$ sh -c "$(wget https://tinyurl.com/gef-installer -O -)"
 
 # or manually
 $ wget -O ~/.gdbinit-gef.py -q https://tinyurl.com/gef-master


### PR DESCRIPTION
## Fixed TinyURL installer script links ##

### Description ###
`https://tinyurl.com/gef-install` returns error 404 for the install scripts so I recreated the link (`https://tinyurl.com/gef-installer`) and updated the README.

### How Has This Been Tested? ###
| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | No change to the program itself|
| x86-64       | :heavy_check_mark: | ^|
| ARM          | :heavy_check_mark: | ^|
| AARCH64      | :heavy_check_mark: | ^|
| MIPS         | :heavy_check_mark: | ^|
| POWERPC      | :heavy_check_mark: | ^|
| SPARC        | :heavy_check_mark: | ^|
| RISC-V       | :heavy_check_mark: | ^|
| `make tests` | :heavy_check_mark: | ^|

### Checklist ###
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
