### PR TITLE
Add option to hide the pc context from the source

### DIFF
--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -170,3 +170,8 @@ gef➤  gef config context.peek_calls False
 ```
 gef➤  gef config context.ignore_registers "$cs $ds $gs"
 ```
+
+* Hide the extra pc context info from the source code view.
+```
+gef➤  gef config context.show_source_code_variable_values 0
+```

--- a/gef.py
+++ b/gef.py
@@ -7411,6 +7411,7 @@ class ContextCommand(GenericCommand):
     def __init__(self):
         super(ContextCommand, self).__init__()
         self.add_setting("enable", True, "Enable/disable printing the context when breaking")
+        self.add_setting("show_source_code_variable_values", True, "Show extra PC context info in the source code")
         self.add_setting("show_stack_raw", False, "Show the stack pane as raw hexdump (no dereference)")
         self.add_setting("show_registers_raw", False, "Show the registers pane with raw values (no dereference)")
         self.add_setting("peek_calls", True, "Peek into calls")
@@ -7838,6 +7839,7 @@ class ContextCommand(GenericCommand):
         title = "source:{}+{}".format(fn, line_num + 1)
         cur_line_color = get_gef_setting("theme.source_current_line")
         self.context_title(title)
+        show_extra_info = self.get_setting("show_source_code_variable_values")
 
         for i in range(line_num - nb_line + 1, line_num + nb_line):
             if i < 0:
@@ -7849,11 +7851,12 @@ class ContextCommand(GenericCommand):
                 gef_print("{}{}".format(bp_prefix, Color.grayify("  {:4d}\t {:s}".format(i + 1, lines[i],))))
 
             if i == line_num:
-                extra_info = self.get_pc_context_info(pc, lines[i])
                 prefix = "{}{}{:4d}\t ".format(bp_prefix, RIGHT_ARROW[1:], i + 1)
                 leading = len(lines[i]) - len(lines[i].lstrip())
-                if extra_info:
-                    gef_print("{}{}".format(" "*(len(prefix) + leading), extra_info))
+                if show_extra_info:
+                    extra_info = self.get_pc_context_info(pc, lines[i])
+                    if extra_info:
+                        gef_print("{}{}".format(" "*(len(prefix) + leading), extra_info))
                 gef_print(Color.colorify("{}{:s}".format(prefix, lines[i]), cur_line_color))
 
             if i > line_num:


### PR DESCRIPTION
## Add option to hide the pc context from the source code view ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
The printing of the extra pc context info can be optionally turned off by setting:
```                                                                                                                                                                                                        
gef➤  gef config context.show_source_code_variable_values 0                                                                                                                                       
```   
<!-- Why is this change required? What problem does it solve? -->
In certain use cases that info is more distracting than useful.

<!-- Why is this patch will make a better world? -->
GEF can be used in more scenarios without distraction.

<!-- How does this look? Add a screenshot if you can -->
![Screenshot from 2020-08-21 19-33-35](https://user-images.githubusercontent.com/6553695/90918668-633a4300-e3e5-11ea-8e84-e3e4b5b36516.png)

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                      |
| x86-64       | :heavy_check_mark: |   The architecture should't be relevant  |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
