### PR TITLE
Fix #565 flickering interface refresh

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3244,12 +3244,12 @@ def get_memory_alignment(in_bits=False):
     raise EnvironmentError("GEF is running under an unsupported mode")
 
 
-def clear_screen(tty=""):
-    """Clear the screen."""
+def clear_screen(tty=None):
+    """Clear the screen. This might not be immediate as it can get buffered."""
     # Since the tty can be closed at any time, a PermissionError exception can
     # occur when `clear_screen` is called. We handle this scenario properly
     try:
-        gef_print("\x1b[H\x1b[J", file=tty) # If tty is null, print will go to stdout
+        gef_print("\x1b[H\x1b[J", file=tty) # If tty is None, print will go to stdout
     except PermissionError:
         __gef_redirect_output_fd__ = None
         set_gef_setting("context.redirect", "")

--- a/gef.py
+++ b/gef.py
@@ -3246,15 +3246,24 @@ def get_memory_alignment(in_bits=False):
 
 def clear_screen(tty=None):
     """Clear the screen. This might not be immediate as it can get buffered."""
+
+    if tty == '':
+        tty = None
+
     # Since the tty can be closed at any time, a PermissionError exception can
     # occur when `clear_screen` is called. We handle this scenario properly
     try:
-        gef_print("\x1b[H\x1b[J", file=tty) # If tty is None, print will go to stdout
+        if isinstance(tty, str):
+            with open(tty, "wt") as f:
+                gef_print("\x1b[H\x1b[J", file=f) 
+        else:
+            # If tty is None, print will go to stdout
+            gef_print("\x1b[H\x1b[J", file=tty) 
     except PermissionError:
         __gef_redirect_output_fd__ = None
         set_gef_setting("context.redirect", "")
     return
-
+    
 
 def format_address(addr):
     """Format the address according to its size."""


### PR DESCRIPTION
## Fix #565 flickering interface refresh ##

### Description/Motivation/Screenshots ###
Add gef_delay_print(bool) which allows buffering output and then
printing it at once. Used in ContextCommand to disable printing then
once all the contexts have buffered their output clear the screen and
print all the output at once. This avoids the computing time between 
context_x functions and clearing the screen making the output not flicker.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                          |
| x86-64       | :heavy_multiplication_x: |                                            |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
