### PR TITLE
Add support for virtual environments

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -10382,6 +10382,14 @@ if __name__  == "__main__":
             site.addsitedir(site_packages_dir)
         except FileNotFoundError:
             pass
+        
+        # when Python virtual enviromrnt is used GDB still loads system Python
+        # so GEF doesn't load site-packages dir from environment
+        pythonbin = which("python3")
+        PREFIX = gef_pystring(subprocess.check_output([pythonbin, '-c', 'import os,sys;print((sys.prefix))'])).strip("\\n")
+        if PREFIX != sys.base_prefix:
+            SITE_PACKAGES_DIR = subprocess.check_output([pythonbin, "-c", "import os,sys;print(os.linesep.join(sys.path).strip())"]).decode("utf-8").split()
+            sys.path.extend(SITE_PACKAGES_DIR)
 
         # setup prompt
         gdb.prompt_hook = __gef_prompt__

--- a/gef.py
+++ b/gef.py
@@ -10385,6 +10385,9 @@ if __name__  == "__main__":
         
         # When using a Python virtual environment, GDB still loads the system Python
         # so GEF doesn't load site-packages dir from environment
+        # In order to fix it, from the shell with venv activated we run the python binary, 
+        # take and parse it's path, add path to the current python process using sys.path.extend
+        
         pythonbin = which("python3")
         PREFIX = gef_pystring(subprocess.check_output([pythonbin, '-c', 'import os,sys;print((sys.prefix))'])).strip("\\n")
         if PREFIX != sys.base_prefix:

--- a/gef.py
+++ b/gef.py
@@ -10383,15 +10383,15 @@ if __name__  == "__main__":
         except FileNotFoundError:
             pass
         
-        # When using a Python virtual environment, GDB still loads the system Python
+        # When using a Python virtual environment, GDB still loads the system-installed Python
         # so GEF doesn't load site-packages dir from environment
         # In order to fix it, from the shell with venv activated we run the python binary, 
-        # take and parse it's path, add path to the current python process using sys.path.extend
+        # take and parse its path, add the path to the current python process using sys.path.extend
         
         pythonbin = which("python3")
         PREFIX = gef_pystring(subprocess.check_output([pythonbin, '-c', 'import os,sys;print((sys.prefix))'])).strip("\\n")
         if PREFIX != sys.base_prefix:
-            SITE_PACKAGES_DIR = subprocess.check_output(
+            SITE_PACKAGES_DIRS = subprocess.check_output(
                 [pythonbin, "-c", "import os,sys;print(os.linesep.join(sys.path).strip())"]).decode("utf-8").split()
             sys.path.extend(SITE_PACKAGES_DIR)
 

--- a/gef.py
+++ b/gef.py
@@ -10383,7 +10383,7 @@ if __name__  == "__main__":
         except FileNotFoundError:
             pass
         
-        # when Python virtual enviromrnt is used GDB still loads system Python
+        # When using a Python virtual environment, GDB still loads the system Python
         # so GEF doesn't load site-packages dir from environment
         pythonbin = which("python3")
         PREFIX = gef_pystring(subprocess.check_output([pythonbin, '-c', 'import os,sys;print((sys.prefix))'])).strip("\\n")

--- a/gef.py
+++ b/gef.py
@@ -10388,7 +10388,8 @@ if __name__  == "__main__":
         pythonbin = which("python3")
         PREFIX = gef_pystring(subprocess.check_output([pythonbin, '-c', 'import os,sys;print((sys.prefix))'])).strip("\\n")
         if PREFIX != sys.base_prefix:
-            SITE_PACKAGES_DIR = subprocess.check_output([pythonbin, "-c", "import os,sys;print(os.linesep.join(sys.path).strip())"]).decode("utf-8").split()
+            SITE_PACKAGES_DIR = subprocess.check_output(
+                [pythonbin, "-c", "import os,sys;print(os.linesep.join(sys.path).strip())"]).decode("utf-8").split()
             sys.path.extend(SITE_PACKAGES_DIR)
 
         # setup prompt


### PR DESCRIPTION
## Add support for virtual environments ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->
When running GDB from virtual environment GDB always loads system's python so GEF can't load modules from the venv required to perform some GEF commands. This patch aims to provide a support for virtual environments so GEF is able to load modules from them. While it is mostly a GDB related problem I thought it would be nice to have this kind of feature in GEF since no other software I use really need such support for venvs.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                    |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [] My change includes a change to the documentation, if required.
- [] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
