### PR TITLE
Add vmmap functionality

### DIFF
--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -10,6 +10,8 @@ the main reasons I started `GEF` in a first place). For example, you can learn
 that ELF running on SPARC architectures always have their `.data` and `heap`
 sections set as Read/Write/Execute.
 
-`vmmap` accepts one argument, a pattern to grep interesting results:
+`vmmap` accepts one argument, a pattern to grep interesting results or an address to determine which section it belongs to:
 
 ![vmmap-grep](http://i.imgur.com/ZFF4QVf.png)
+
+![vmmap-address](https://i.imgur.com/hfcs1jH.png)

--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -1,6 +1,6 @@
 ## Command vmmap ##
 
-`vmmap` displays the entire memory space mapping.
+`vmmap` displays the target process's entire memory space mapping.
 
 ![vmmap-example](https://i.imgur.com/iau8SwS.png)
 
@@ -10,7 +10,8 @@ the main reasons I started `GEF` in a first place). For example, you can learn
 that ELF running on SPARC architectures always have their `.data` and `heap`
 sections set as Read/Write/Execute.
 
-`vmmap` accepts one argument, a pattern to grep interesting results or an address to determine which section it belongs to:
+`vmmap` accepts one argument, either a pattern to match again mapping names,
+or an address to determine which section it belongs to.
 
 ![vmmap-grep](http://i.imgur.com/ZFF4QVf.png)
 

--- a/gef.py
+++ b/gef.py
@@ -8742,8 +8742,7 @@ class VMMapCommand(GenericCommand):
             int(n,0)
         except ValueError:
             return False
-        else:
-            return True
+        return True
 
 
 @register_command

--- a/gef.py
+++ b/gef.py
@@ -8690,10 +8690,15 @@ class VMMapCommand(GenericCommand):
         gef_print(Color.colorify("{:<{w}s}{:<{w}s}{:<{w}s}{:<4s} {:s}".format(*headers, w=get_memory_alignment()*2+3), color))
 
         for entry in vmmap:
-            if argv and not argv[0] in entry.path:
+            if not argv:
+                self.print_entry(entry)
                 continue
-
-            self.print_entry(entry)
+            if argv[0] in entry.path:
+                self.print_entry(entry)
+            elif self.is_integer(argv[0]):
+                addr = int(argv[0],0)
+                if addr >= entry.page_start and addr < entry.page_end:
+                    self.print_entry(entry)
         return
 
     def print_entry(self, entry):
@@ -8731,6 +8736,14 @@ class VMMapCommand(GenericCommand):
                                                      Color.colorify("Stack", stack_addr_color)
         ))
         return
+
+    def is_integer(self, n):
+        try:
+            int(n,0)
+        except ValueError:
+            return False
+        else:
+            return True
 
 
 @register_command


### PR DESCRIPTION
## Add vmmap functionality ##

### Description/Motivation/Screenshots ###
This was created to help identify which section an arbitrary address belongs to. This should help exploit developers quickly find which section a leak/random address belongs to. It was orginally a seperate command, but @hugsy suggested adding it to vmmap.

![vmmap-address](https://i.imgur.com/vWZQGtg.png)


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | |
| x86-64       | :heavy_check_mark: |                                         |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                         |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [X] My PR was done against the `dev` branch, not `master`.
- [X] My code follows the code style of this project.
- [X] My change includes a change to the documentation, if required.
- [X] My change adds tests as appropriate.
- [X] I have read and agree to the **CONTRIBUTING** document.