### PR TITLE
Allow location of config file to be user-defined via an environment variable

### DIFF
--- a/docs/commands/aliases.md
+++ b/docs/commands/aliases.md
@@ -25,8 +25,8 @@ ps                              →  process-search
 alias that GDB provides through the built-in command `alias`.
 
 Users can create/modify/delete aliases by editing the `GEF` configuration file,
-located at `~/.gef.rc`. The aliases must be in the "`aliases`" section of the
-configuration file.
+by default located at `~/.gef.rc`. The aliases must be in the `aliases` section
+of the configuration file.
 
 Creating a new alias is as simple as creating a new entry in this section:
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -1,7 +1,8 @@
 ## Command config ##
 
-In addition to reading its config from _~/.gef.rc~, `gef` can also be
-configured at runtime with the `gef config` command.
+`gef` reads its config from a file which is by default located at `~/.gef.rc`, but which
+can also be specified via the `GEF_RC` environment variable. In addition, `gef` can also
+be configured at runtime with the `gef config` command.
 
 To view all settings for all commands loaded:
 ```
@@ -27,8 +28,8 @@ gef➤  gef save
 [+] Configuration saved to '/home/vagrant/.gef.rc'
 ```
 
-Upon startup, if `gef` finds a file `${HOME}/.gef.rc`, it will automatically
-loads its values.
+Upon startup, if `$GEF_RC` points to an existing file, or otherwise if
+`${HOME}/.gef.rc` exists, `gef` will automatically load its values.
 
 To reload the settings during the session, just run:
 ```

--- a/gef.py
+++ b/gef.py
@@ -169,7 +169,7 @@ __gef_redirect_output_fd__             = None
 
 DEFAULT_PAGE_ALIGN_SHIFT               = 12
 DEFAULT_PAGE_SIZE                      = 1 << DEFAULT_PAGE_ALIGN_SHIFT
-GEF_RC                                 = os.path.join(os.getenv("HOME"), ".gef.rc")
+GEF_RC                                 = os.getenv("GEF_RC") or os.path.join(os.getenv("HOME"), ".gef.rc")
 GEF_TEMP_DIR                           = os.path.join(tempfile.gettempdir(), "gef")
 GEF_MAX_STRING_LENGTH                  = 50
 


### PR DESCRIPTION
## Allow location of gef config to be user-defined via an environment variable ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->
Right now, gef stores its config file in the user's home directory, which can contribute a small amount of clutter. This one-line change allows a user to override the default location by setting the `GEF_RC` environment variable. Note, this specifies a path to the config file itself, not to the folder which contains it. The change is simple enough that I don't think it warrants the creation of any tests, though not sure.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                      |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [?] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
