### PR TITLE
Check if arch is using Cortex registers

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1686,7 +1686,7 @@ class ARM(Architecture):
 
     all_registers = ["$r0", "$r1", "$r2", "$r3", "$r4", "$r5", "$r6",
                      "$r7", "$r8", "$r9", "$r10", "$r11", "$r12", "$sp",
-                     "$lr", "$pc", "$cpsr",]
+                     "$lr", "$pc", "$cpsr", "$xpsr"]
 
     # http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0041c/Caccegih.html
     # return b"\x00\x00\xa0\xe1" # mov r0,r0
@@ -1709,6 +1709,7 @@ class ARM(Architecture):
     @lru_cache()
     def is_thumb(self):
         """Determine if the machine is currently in THUMB mode."""
+        self.check_cortex()
         return is_alive() and get_register(self.flag_register) & (1<<5)
 
     @property
@@ -1717,6 +1718,13 @@ class ARM(Architecture):
         if self.is_thumb():
             pc += 1
         return pc
+
+    def check_cortex(self):
+        """ Determine if the processor is of the Cortex family """
+        if get_register(self.flag_register) is None:
+            self.flag_register = "$xpsr"
+            if get_register(self.flag_register) is None:
+                raise OSError("None of the flag registers are valid")
 
     @property
     def mode(self):


### PR DESCRIPTION
## Cortex M registers on ARM processors ##

### Description/Motivation/Screenshots ###
The patch prevents errors on Arm Cortex-M processors, which use a different register name for the status register. 

It solves the issue #571.

The patch adds register `$xpsr` and uses it, if it detects that the status register `$cpsr` cannot be read. Reading the register is necessary in order to display the correct context. The context always fails to load on Cortex-M processors. When determining the ARM processor mode, a check is made for the use of the correct register.


- Before:
```

[ Legend: Modified register | Code | Heap | Stack | String ]
───────────────────────────────────────────────────────────────────────────────────── registers ────
$r0  : 0x00000068  →  0x00000627  →  0x09496420  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r1  : 0x0000c006  →  0x58096809  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r2  : 0x00026000  →   ; <UNDEFINED> instruction: 0xffffffff
$r3  : 0xf0009900  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r4  : 0x20006d30  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r5  : 0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r6  : 0x00001388  →  0x20000000  →  0x00001000  →  0x20001378  →  0x78323023  →  0x00000000  →  0x20000400  →  0x20024e20
$r7  : 0x00001388  →  0x20000000  →  0x00001000  →  0x20001378  →  0x78323023  →  0x00000000  →  0x20000400  →  0x20024e20
$r8  : 0x20006854  →  0x00041e10  →  0x000308f5  →  0x1c4604b5  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000
$r9  : 0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r10 : 0x20000000  →  0x00001000  →  0x20001378  →  0x78323023  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000
$r11 : 0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r12 : 0x2000ff18  →  0x20006d10  →  0x00042a68  →  0x0003168d  →  0x13477061  →  0x00000000  →  0x20000400  →  0x20024e20
$sp  : 0x2000fe80  →  0x00000084  →  0x0000066d  →  0x09495320  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000
$lr  : 0xfffffff1  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$pc  : 0x00024cec  →  0x471868db  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
───────────────────────────────────────────────────────────────────────────────────────── stack ────
0x2000fe80│+0x0000: 0x00000084  →  0x0000066d  →  0x09495320  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000	 ← $sp
0x2000fe84│+0x0004: 0xf0009900  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
0x2000fe88│+0x0008: 0x4075092d  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
0x2000fe8c│+0x000c: 0xcafebabe  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
0x2000fe90│+0x0010: 0x2000ff18  →  0x20006d10  →  0x00042a68  →  0x0003168d  →  0x13477061  →  0x00000000  →  0x20000400
0x2000fe94│+0x0014: 0xffffffe9  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
0x2000fe98│+0x0018: 0x0000c008  →  0x47085809  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
0x2000fe9c│+0x001c: 0x010f0021  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]

─────────────────────────────── Exception raised ───────────────────────────────
TypeError: unsupported operand type(s) for &: 'NoneType' and 'int'
───────────────────────────── Detailed stacktrace ──────────────────────────────
↳ File "~/.gdbinit-gef.py", line 1712, in is_thumb()
    →             return is_alive() and get_register(self.flag_register) & (1<<5)
↳ File "~/.gdbinit-gef.py", line 1717, in pc()
    →             if self.is_thumb():
↳ File "~/.gdbinit-gef.py", line 7670, in context_code()
    →             pc = current_arch.pc
↳ File "~/.gdbinit-gef.py", line 7542, in do_invoke()
    →                     self.layout_mapping[section]()
↳ File "~/.gdbinit-gef.py", line 2502, in wrapper()
    →                 return f(*args, **kwargs)
↳ File "~/.gdbinit-gef.py", line 256, in wrapper()
    →                 rv = f(*args, **kwargs)
↳ File "~/.gdbinit-gef.py", line 3980, in invoke()
    →                 bufferize(self.do_invoke)(argv)
───────────────────────────── Last 10 GDB commands ─────────────────────────────
  226  elf-info 
  227  target remote localhost:2331
```

- After 
```
[ Legend: Modified register | Code | Heap | Stack | String ]
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── registers ────
$r0  : 0x00000068  →  0x00000627  →  0x09496420  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r1  : 0x0000c006  →  0x58096809  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r2  : 0x00026000  →   ; <UNDEFINED> instruction: 0xffffffff
$r3  : 0xf0009900  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r4  : 0x20006d30  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r5  : 0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r6  : 0x00001388  →  0x20000000  →  0x00001000  →  0x20001378  →  0x78323023  →  0x00000000  →  0x20000400  →  0x20024e20
$r7  : 0x00001388  →  0x20000000  →  0x00001000  →  0x20001378  →  0x78323023  →  0x00000000  →  0x20000400  →  0x20024e20
$r8  : 0x20006854  →  0x00041e10  →  0x000308f5  →  0x1c4604b5  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000
$r9  : 0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r10 : 0x20000000  →  0x00001000  →  0x20001378  →  0x78323023  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000
$r11 : 0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$r12 : 0x2000ff18  →  0x20006d10  →  0x00042a68  →  0x0003168d  →  0x13477061  →  0x00000000  →  0x20000400  →  0x20024e20
$sp  : 0x2000fe80  →  0x00000084  →  0x0000066d  →  0x09495320  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000
$lr  : 0xfffffff1  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$pc  : 0x00024cec  →  0x471868db  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
$xpsr: 0x210f0003  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── stack ────
0x2000fe80│+0x0000: 0x00000084  →  0x0000066d  →  0x09495320  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000	 ← $sp
0x2000fe84│+0x0004: 0xf0009900  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
0x2000fe88│+0x0008: 0x4075092d  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
0x2000fe8c│+0x000c: 0xcafebabe  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
0x2000fe90│+0x0010: 0x2000ff18  →  0x20006d10  →  0x00042a68  →  0x0003168d  →  0x13477061  →  0x00000000  →  0x20000400
0x2000fe94│+0x0014: 0xffffffe9  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
0x2000fe98│+0x0018: 0x0000c008  →  0x47085809  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
0x2000fe9c│+0x001c: 0x010f0021  →  0x00000000  →  0x20000400  →  0x20024e20  →  0x00000000  →  [loop detected]
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── code:arm:ARM ────
      0x24ce0                  ldr    r3,  [pc,  #36]	; (0x24d08)
      0x24ce2                  bx     r3
      0x24ce4                  ldr    r3,  [pc,  #36]	; (0x24d0c)
 →    0x24cec                  ldr    r3,  [r3,  #12]
      0x24cee                  bx     r3
      0x24cf0                  mov.w  r0,  #4294967295	; 0xffffffff
      0x24cf4                  mov    r1,  lr
      0x24cf6                  mov.w  r2,  #0
      0x24cfa                  ldr    r3,  [pc,  #12]	; (0x24d08)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── threads ────
[#0] Id 1, stopped 0x24cec in ?? (), reason: SIGTRAP
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── trace ────
[#0] 0x24cec → ldr r3,  [r3,  #12]
[#1] 0xfffffff1 → movs r0,  r0
[#2] 0xc008 → ldr r1,  [r1,  r0]
[#3] 0xffffffe9 → movs r0,  r0
[#4] 0x35e30 → timer_req_schedule(type=<optimised out>, p_timer=0x20006d30 <m_timer_pool+40>)
[#5] 0x0 → lsls r0,  r0,  #16
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
0x00024cec in ?? ()
```

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | |
| x86-64       | :heavy_check_mark: |  Tested, no changes here            |
| ARM          | :heavy_check_mark: | It only applies here                 |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
