### PR TITLE
made endianness check case insensitive

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1480,13 +1480,13 @@ def get_arch():
 def get_endian():
     """Return the binary endianness."""
 
-    endian = gdb.execute("show endian", to_string=True).strip()
+    endian = gdb.execute("show endian", to_string=True).strip().lower()
     if "little endian" in endian:
         return Elf.LITTLE_ENDIAN
     if "big endian" in endian:
         return Elf.BIG_ENDIAN
 
-    raise EnvironmentError("Invalid endianess")
+    raise EnvironmentError("Invalid endianness")
 
 
 @lru_cache()


### PR DESCRIPTION
## Multi-language support for endianness check ##

In some languages gdb prints the current endianness capitalized (e.g. "Little Endian").
To make this work with gef's `get_endian` function I added a conversion to lowercase letters.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                |
| x86-64       | :heavy_check_mark: |       |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
