### PR TITLE
Minor fix to allow redirects on installation script

### DIFF
--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -12,7 +12,7 @@ test -f "${HOME}/.gdbinit" && mv "${HOME}/.gdbinit" "${HOME}/.gdbinit.old"
 ref=$(curl --silent https://api.github.com/repos/hugsy/gef/git/ref/heads/${branch} | grep '"sha"' | tr -s ' ' | cut -d ' ' -f 3 | tr -d "," | tr -d '"')
 
 # Download the file
-curl --silent --output "${HOME}/.gef-${ref}.py" "https://github.com/hugsy/gef/raw/${branch}/gef.py"
+curl --silent -L --output "${HOME}/.gef-${ref}.py" "https://github.com/hugsy/gef/raw/${branch}/gef.py"
 
 # Create the new gdbinit
 echo "source ~/.gef-${ref}.py" > ~/.gdbinit


### PR DESCRIPTION
## Fix for issue 609 ##

### Description/Motivation/Screenshots ###
In a nutshell, I've enabled the `-L` flag on `curl` to follow redirects on `scripts/gef.sh` line 15. 
### How Has This Been Tested? ###
Manually.

```
$ cat script.sh
<snip>
curl --silent -L --output "${HOME}/.gef-${ref}.py" "https://github.com/hugsy/gef/raw/${branch}/gef.py"
<snip>
$ ls ~/.gef-60fd341ba076942faac96fd6118ca927998ec0d9.py
$ cat ~/.gef-60fd341ba076942faac96fd6118ca927998ec0d9.py
# -*- coding: utf-8 -*-
#
#
#######################################################################################
<snip>

        GefAliases()
        GefTmuxSetup()
```

I'm fairly unsure if you use some sort of lint for shell scripts (e.g. spellcheck) and I haven't used one. 
### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [N/A] My code follows the code style of this project.
- [] My change includes a change to the documentation, if required.
- [] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.

LMK if this works.