### PR TITLE
Workaround to fix failing tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,7 +29,20 @@ def gdb_run_cmd(cmd, before=None, after=None, target=PATH_TO_DEFAULT_BINARY, str
     command += ["-ex", "quit", "--", target]
 
     lines = subprocess.check_output(command, stderr=subprocess.STDOUT).strip().splitlines()
-    result = b"\n".join(lines).decode("utf-8")
+    output = b"\n".join(lines)
+    result = None
+
+    # The following is necessary because ANSI escape sequences might have been added in the middle of multibyte
+    # characters, e.g. \x1b[H\x1b[2J is added into the middle of \xe2\x94\x80 to become \xe2\x1b[H\x1b[2J\x94\x80
+    # which causes a UnicodeDecodeError when trying to decode \xe2.
+    # Such broken multibyte characters would need to be removed, otherwise the test will result in an error.
+    while not result:
+        try:
+            result = output.decode("utf-8")
+        except UnicodeDecodeError as e:
+            faulty_idx_start = int(e.start)
+            faulty_idx_end = int(e.end)
+            output = output[:faulty_idx_start] + output[faulty_idx_end:]
 
     if strip_ansi:
         result = ansi_clean(result)


### PR DESCRIPTION
## Workaround to fix failing tests ##

The error came from a `UnicodeDecodeError` when trying to decode the output from GDB.

I looked into the bytes that were being decoded, and realized it is `\xe2\x1b[H\x1b[2J\x94\x80`, which seems to be an ANSI character sequence `\x1b[H\x1b[2J` being inserted to the middle of a multibyte character `\xe2\x94\x80`, causing the decoding to fail at https://github.com/hugsy/gef/blob/d8cbb45c56c40bfe54d391423fe50d7811900c7e/tests/helpers.py#L31-L32

This is pretty weird. I wonder if it is a GEF problem, or a problem with `subprocess` buffering?

One option would be to remove such broken multibyte characters, since they don't impact the test cases, and I don't think they ever will. It would be a workaround for now to prevent the tests from failing.

```
    lines = subprocess.check_output(command, stderr=subprocess.STDOUT).strip().splitlines()
    output = b"\n".join(lines)
    result = None

    # The following is necessary because ANSI escape sequences might have been added in the middle of multibyte
    # characters, e.g. \x1b[H\x1b[2J is added into the middle of \xe2\x94\x80 to become \xe2\x1b[H\x1b[2J\x94\x80
    # which causes a UnicodeDecodeError when trying to decode \xe2.
    # Such broken multibyte characters would need to be removed, otherwise the test will result in an error.
    while not result:
        try:
            result = output.decode("utf-8")
        except UnicodeDecodeError as e:
            faulty_idx_start = int(e.start)
            faulty_idx_end = int(e.end)
            output = output[:faulty_idx_start] + output[faulty_idx_end:]
```

Not even sure if this problem is reproducible. Looks like it sometimes is fine and sometimes isn't.

![image](https://user-images.githubusercontent.com/8130120/108952402-5c4a0100-76a4-11eb-8ae4-7546627ccc35.png)

I hope this fixes it.

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
