### PR TITLE
Fix loop not breaking

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1283,9 +1283,8 @@ def gdb_get_nth_previous_instruction_address(addr, n):
             continue
 
         # 2. check all instructions are valid
-        for insn in insns:
-            if not insn.is_valid():
-                continue
+        if any(not insn.is_valid() for insn in insns):
+            continue
 
         # 3. if cur_insn is at the end of the set
         if insns[-1].address==cur_insn_addr:


### PR DESCRIPTION
We were using `continue` in our loop trying to find an instruction boundary, but it was used in a nested loop making it completely useless!

This change uses `any` with a generator expression that keeps the break out of an inner loop, allowing the `continue` to work as expected.