### PR TITLE
get_nth_prev..._inst...: Move back from PC

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1271,15 +1271,15 @@ def gdb_get_nth_previous_instruction_address(addr, n):
 
     # we try to find a good set of previous instructions by "guessing" disassembling backwards
     # the 15 comes from the longest instruction valid size
-    for i in range(15*n, 0, -1):
+    for i in range(1*n, 15*n+1): # Count up instead, likely fewer disassembles needed
         try:
             insns = list(gdb_disassemble(addr-i, end_pc=cur_insn_addr, count=n+1))
         except gdb.MemoryError:
             # this is because we can hit an unmapped page trying to read backward
             break
 
-        # 1. check that the disassembled instructions list size is correct
-        if len(insns)!=n+1: # we expect the current instruction plus the n before it
+        # 1. check that the disassembled instructions list size is correct or longer
+        if len(insns)<n+1: # we expect the current instruction plus the n before it
             continue
 
         # 2. check all instructions are valid


### PR DESCRIPTION
On variable-length instruction ISAs we currently guess where the
instructions start by going back as far as possible and then checking
over and over again until we find some offset where we disassemble the
correct number of instructions. For the default settings on x86_64 this
has us go back 45 instructions and it often takes a good handful of
tries ot find a valid offset.

This change guesses the other way: Start at the FEWEST possible bytes
back that could contain all of our previous instructions, and then add
instructions one at a time. This seems to average fewer tries.

Realize that this can result is a different set of instructions than the
old approach, though both approaches could get the wrong answer. This
approach could be considered 'greedy'.

In my testing of speed, not correctness, it makes `context` about 30%
faster. When testing the function itself against the old version, it's 4
to 6 times faster!