### PR TITLE
Cache more functions

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2401,6 +2401,7 @@ def write_memory(address, buffer, length=0x10):
     return gdb.selected_inferior().write_memory(address, buffer, length)
 
 
+@lru_cache()
 def read_memory(addr, length=0x10):
     """Return a `length` long byte array with the copy of the process memory at `addr`."""
     return gdb.selected_inferior().read_memory(addr, length).tobytes()
@@ -3618,6 +3619,7 @@ class FormatStringBreakpoint(gdb.Breakpoint):
         return
 
     def stop(self):
+        reset_all_caches()
         msg = []
         ptr, addr = current_arch.get_ith_parameter(self.num_args)
         addr = lookup_address(addr)
@@ -3688,6 +3690,7 @@ class TraceMallocBreakpoint(gdb.Breakpoint):
         return
 
     def stop(self):
+        reset_all_caches()
         _, size = current_arch.get_ith_parameter(0)
         self.retbp = TraceMallocRetBreakpoint(size, self.name)
         return False
@@ -3834,6 +3837,7 @@ class TraceFreeBreakpoint(gdb.Breakpoint):
         return
 
     def stop(self):
+        reset_all_caches()
         _, addr = current_arch.get_ith_parameter(0)
         msg = []
         check_free_null = get_gef_setting("heap-analysis-helper.check_free_null")
@@ -3897,6 +3901,7 @@ class TraceFreeRetBreakpoint(gdb.FinishBreakpoint):
         return
 
     def stop(self):
+        reset_all_caches()
         wp = UafWatchpoint(self.addr)
         __heap_uaf_watchpoints__.append(wp)
         return False
@@ -3914,6 +3919,7 @@ class UafWatchpoint(gdb.Breakpoint):
 
     def stop(self):
         """If this method is triggered, we likely have a UaF. Break the execution and report it."""
+        reset_all_caches()
         frame = gdb.selected_frame()
         if frame.name() in ("_int_malloc", "malloc_consolidate", "__libc_calloc"):
             # ignore when the watchpoint is raised by malloc() - due to reuse
@@ -3941,6 +3947,7 @@ class EntryBreakBreakpoint(gdb.Breakpoint):
         return
 
     def stop(self):
+        reset_all_caches()
         return True
 
 
@@ -3955,6 +3962,7 @@ class NamedBreakpoint(gdb.Breakpoint):
         return
 
     def stop(self):
+        reset_all_caches()
         push_context_message("info", "Hit breakpoint {} ({})".format(self.loc, Color.colorify(self.name, "red bold")))
         return True
 

--- a/tests/perf/context_times.sh
+++ b/tests/perf/context_times.sh
@@ -4,10 +4,11 @@
 set -e
 
 time_gef_context() {
-    # Run twice to minimize jitter
-    gdb -ex 'start' -ex 'pi import profile' -ex "pi profile.run(\"gdb.execute('context')\", sort=\"cumtime\")" -ex 'quit' \
-        /tmp/pattern.out >/dev/null 2>&1
-    gdb -ex 'start' -ex 'pi import profile' -ex "pi profile.run(\"gdb.execute('context')\", sort=\"cumtime\")" -ex 'quit' \
+    gdb -ex 'start' \
+	-ex 'pi import profile' \
+	-ex 'pi reset_all_caches()' \
+	-ex "pi profile.run(\"gdb.execute('context')\", sort=\"cumtime\")" \
+	-ex 'quit' \
         /tmp/pattern.out 2>&1 | get_context_time
 }
 


### PR DESCRIPTION
Aggressively cache functions.

Use `lru_cache` a lot more. I noticed that we spent most of our time calling `get_register`, `gef_disassemble`, and `dereference`.

For example, on EACH line of the stack context we get the value of each register, but obviously this shouldn't change within one one context. So let's cache.

The risk here is that we get stale values, but I (hopefully) remediate this by clearing the cache more often: I hook reg changed and mem changed events and clear all caches in that case.

This offers HUGE per improvements:

with:
```
        1    0.000    0.000    0.008    0.008 profile:0(gdb.execute('context'))
```

Granted, this is with a 'hot' cache.  If I clear the caches first I get a more reasonable speedup:
```
        1    0.000    0.000    0.026    0.026 profile:0(gdb.execute('context'))q
```

vs. without

```
        1    0.000    0.000    0.038    0.038 profile:0(gdb.execute('context'))
```

A lot of this time was `get_register` alone!
```
      203    0.001    0.000    0.009    0.000 gef.py:2570(get_register)
```

203 calls to get the value of 26 registers obviously is wasteful :)

```
       26    0.000    0.000    0.002    0.000 gef.py:2571(get_register)
```

26 calls is much more reasonable!