### PR TITLE
Use python3-style super() calls

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -4793,7 +4793,7 @@ class GefThemeCommand(GenericCommand):
     _syntax_ = "{:s} [KEY [VALUE]]".format(_cmdline_)
 
     def __init__(self, *args, **kwargs):
-        super().__init__(GefThemeCommand._cmdline_)
+        super().__init__(self._cmdline_)
         self.add_setting("context_title_line", "gray", "Color of the borders in context window")
         self.add_setting("context_title_message", "cyan", "Color of the title in context window")
         self.add_setting("default_title_line", "gray", "Default color of borders")
@@ -9934,7 +9934,7 @@ class GefCommand(gdb.Command):
     _syntax_  = "{:s} (missing|config|save|restore|set|run)".format(_cmdline_)
 
     def __init__(self):
-        super().__init__(GefCommand._cmdline_, gdb.COMMAND_SUPPORT, gdb.COMPLETE_NONE, True)
+        super().__init__(self._cmdline_, gdb.COMMAND_SUPPORT, gdb.COMPLETE_NONE, True)
         set_gef_setting("gef.follow_child", True, bool, "Automatically set GDB to follow child when forking")
         set_gef_setting("gef.readline_compat", False, bool, "Workaround for readline SOH/ETX issue (SEGV)")
         set_gef_setting("gef.debug", False, bool, "Enable debug mode for gef")
@@ -10078,10 +10078,7 @@ class GefHelpCommand(gdb.Command):
     _syntax_  = _cmdline_
 
     def __init__(self, commands, *args, **kwargs):
-        super().__init__(GefHelpCommand._cmdline_,
-                                             gdb.COMMAND_SUPPORT,
-                                             gdb.COMPLETE_NONE,
-                                             False)
+        super().__init__(self._cmdline_, gdb.COMMAND_SUPPORT, gdb.COMPLETE_NONE, False)
         self.docs = []
         self.generate_help(commands)
         self.refresh()
@@ -10129,7 +10126,7 @@ class GefConfigCommand(gdb.Command):
     _syntax_  = "{:s} [setting_name] [setting_value]".format(_cmdline_)
 
     def __init__(self, loaded_commands, *args, **kwargs):
-        super().__init__(GefConfigCommand._cmdline_, gdb.COMMAND_NONE, prefix=False)
+        super().__init__(self._cmdline_, gdb.COMMAND_NONE, prefix=False)
         self.loaded_commands = loaded_commands
         return
 
@@ -10244,8 +10241,7 @@ class GefSaveCommand(gdb.Command):
     _syntax_  = _cmdline_
 
     def __init__(self, *args, **kwargs):
-        super().__init__(GefSaveCommand._cmdline_, gdb.COMMAND_SUPPORT,
-                                             gdb.COMPLETE_NONE, False)
+        super().__init__(self._cmdline_, gdb.COMMAND_SUPPORT, gdb.COMPLETE_NONE, False)
         return
 
     def invoke(self, args, from_tty):
@@ -10284,10 +10280,7 @@ class GefRestoreCommand(gdb.Command):
     _syntax_  = _cmdline_
 
     def __init__(self, *args, **kwargs):
-        super().__init__(GefRestoreCommand._cmdline_,
-                                                gdb.COMMAND_SUPPORT,
-                                                gdb.COMPLETE_NONE,
-                                                False)
+        super().__init__(self._cmdline_, gdb.COMMAND_SUPPORT, gdb.COMPLETE_NONE, False)
         return
 
     def invoke(self, args, from_tty):
@@ -10340,10 +10333,7 @@ class GefMissingCommand(gdb.Command):
     _syntax_  = _cmdline_
 
     def __init__(self, *args, **kwargs):
-        super().__init__(GefMissingCommand._cmdline_,
-                                                gdb.COMMAND_SUPPORT,
-                                                gdb.COMPLETE_NONE,
-                                                False)
+        super().__init__(self._cmdline_, gdb.COMMAND_SUPPORT, gdb.COMPLETE_NONE, False)
         return
 
     def invoke(self, args, from_tty):
@@ -10365,10 +10355,7 @@ class GefSetCommand(gdb.Command):
     _syntax_  = "{:s} [GDB_SET_ARGUMENTS]".format(_cmdline_)
 
     def __init__(self, *args, **kwargs):
-        super().__init__(GefSetCommand._cmdline_,
-                                            gdb.COMMAND_SUPPORT,
-                                            gdb.COMPLETE_SYMBOL,
-                                            False)
+        super().__init__(self._cmdline_, gdb.COMMAND_SUPPORT, gdb.COMPLETE_SYMBOL, False)
         return
 
     def invoke(self, args, from_tty):
@@ -10393,10 +10380,7 @@ class GefRunCommand(gdb.Command):
     _syntax_  = "{:s} [GDB_RUN_ARGUMENTS]".format(_cmdline_)
 
     def __init__(self, *args, **kwargs):
-        super().__init__(GefRunCommand._cmdline_,
-                                            gdb.COMMAND_SUPPORT,
-                                            gdb.COMPLETE_FILENAME,
-                                            False)
+        super().__init__(self._cmdline_, gdb.COMMAND_SUPPORT, gdb.COMPLETE_FILENAME, False)
         return
 
     def invoke(self, args, from_tty):

--- a/gef.py
+++ b/gef.py
@@ -606,7 +606,7 @@ def search_for_main_arena():
     return addr
 
 
-class MallocStateStruct(object):
+class MallocStateStruct:
     """GEF representation of malloc_state from https://github.com/bminor/glibc/blob/glibc-2.28/malloc/malloc.c#L1658"""
 
     def __init__(self, addr):
@@ -1541,7 +1541,7 @@ def flags_to_human(reg_value, value_table):
     return "[{}]".format(" ".join(flags))
 
 
-class Architecture(object):
+class Architecture:
     """Generic metaclass for the architecture supported by GEF."""
     __metaclass__ = abc.ABCMeta
 
@@ -3641,7 +3641,7 @@ def gef_on_regchanged_unhook(func):
 #
 
 
-class PieVirtualBreakpoint(object):
+class PieVirtualBreakpoint:
     """PIE virtual breakpoint (not real breakpoint)."""
 
     def __init__(self, set_func, vbp_num, addr):

--- a/gef.py
+++ b/gef.py
@@ -1933,7 +1933,7 @@ class AARCH64(ARM):
                 else: taken, reason = False, "{}&1<<{}!=0".format(reg, i)
 
         if not reason:
-            taken, reason = super(AARCH64, self).is_branch_taken(insn)
+            taken, reason = super().is_branch_taken(insn)
         return taken, reason
 
 
@@ -3693,7 +3693,7 @@ class PieVirtualBreakpoint(object):
 class FormatStringBreakpoint(gdb.Breakpoint):
     """Inspect stack for format string."""
     def __init__(self, spec, num_args):
-        super(FormatStringBreakpoint, self).__init__(spec, type=gdb.BP_BREAKPOINT, internal=False)
+        super().__init__(spec, type=gdb.BP_BREAKPOINT, internal=False)
         self.num_args = num_args
         self.enabled = True
         return
@@ -3724,7 +3724,7 @@ class StubBreakpoint(gdb.Breakpoint):
     """Create a breakpoint to permanently disable a call (fork/alarm/signal/etc.)."""
 
     def __init__(self, func, retval):
-        super(StubBreakpoint, self).__init__(func, gdb.BP_BREAKPOINT, internal=False)
+        super().__init__(func, gdb.BP_BREAKPOINT, internal=False)
         self.func = func
         self.retval = retval
 
@@ -3747,7 +3747,7 @@ class ChangePermissionBreakpoint(gdb.Breakpoint):
     $pc correctly."""
 
     def __init__(self, loc, code, pc):
-        super(ChangePermissionBreakpoint, self).__init__(loc, gdb.BP_BREAKPOINT, internal=False)
+        super().__init__(loc, gdb.BP_BREAKPOINT, internal=False)
         self.original_code = code
         self.original_pc = pc
         return
@@ -3764,7 +3764,7 @@ class TraceMallocBreakpoint(gdb.Breakpoint):
     """Track allocations done with malloc() or calloc()."""
 
     def __init__(self, name):
-        super(TraceMallocBreakpoint, self).__init__(name, gdb.BP_BREAKPOINT, internal=True)
+        super().__init__(name, gdb.BP_BREAKPOINT, internal=True)
         self.silent = True
         self.name = name
         return
@@ -3780,7 +3780,7 @@ class TraceMallocRetBreakpoint(gdb.FinishBreakpoint):
     """Internal temporary breakpoint to retrieve the return value of malloc()."""
 
     def __init__(self, size, name):
-        super(TraceMallocRetBreakpoint, self).__init__(gdb.newest_frame(), internal=True)
+        super().__init__(gdb.newest_frame(), internal=True)
         self.size = size
         self.name = name
         self.silent = True
@@ -3851,7 +3851,7 @@ class TraceReallocBreakpoint(gdb.Breakpoint):
     """Track re-allocations done with realloc()."""
 
     def __init__(self):
-        super(TraceReallocBreakpoint, self).__init__("__libc_realloc", gdb.BP_BREAKPOINT, internal=True)
+        super().__init__("__libc_realloc", gdb.BP_BREAKPOINT, internal=True)
         self.silent = True
         return
 
@@ -3866,7 +3866,7 @@ class TraceReallocRetBreakpoint(gdb.FinishBreakpoint):
     """Internal temporary breakpoint to retrieve the return value of realloc()."""
 
     def __init__(self, ptr, size):
-        super(TraceReallocRetBreakpoint, self).__init__(gdb.newest_frame(), internal=True)
+        super().__init__(gdb.newest_frame(), internal=True)
         self.ptr = ptr
         self.size = size
         self.silent = True
@@ -3910,7 +3910,7 @@ class TraceFreeBreakpoint(gdb.Breakpoint):
     """Track calls to free() and attempts to detect inconsistencies."""
 
     def __init__(self):
-        super(TraceFreeBreakpoint, self).__init__("__libc_free", gdb.BP_BREAKPOINT, internal=True)
+        super().__init__("__libc_free", gdb.BP_BREAKPOINT, internal=True)
         self.silent = True
         return
 
@@ -3972,7 +3972,7 @@ class TraceFreeRetBreakpoint(gdb.FinishBreakpoint):
     """Internal temporary breakpoint to track free()d values."""
 
     def __init__(self, addr):
-        super(TraceFreeRetBreakpoint, self).__init__(gdb.newest_frame(), internal=True)
+        super().__init__(gdb.newest_frame(), internal=True)
         self.silent = True
         self.addr = addr
         return
@@ -3988,7 +3988,7 @@ class UafWatchpoint(gdb.Breakpoint):
     """Custom watchpoints set TraceFreeBreakpoint() to monitor free()d pointers being used."""
 
     def __init__(self, addr):
-        super(UafWatchpoint, self).__init__("*{:#x}".format(addr), gdb.BP_WATCHPOINT, internal=True)
+        super().__init__("*{:#x}".format(addr), gdb.BP_WATCHPOINT, internal=True)
         self.address = addr
         self.silent = True
         self.enabled = True
@@ -4018,7 +4018,7 @@ class EntryBreakBreakpoint(gdb.Breakpoint):
     """Breakpoint used internally to stop execution at the most convenient entry point."""
 
     def __init__(self, location):
-        super(EntryBreakBreakpoint, self).__init__(location, gdb.BP_BREAKPOINT, internal=True, temporary=True)
+        super().__init__(location, gdb.BP_BREAKPOINT, internal=True, temporary=True)
         self.silent = True
         return
 
@@ -4031,7 +4031,7 @@ class NamedBreakpoint(gdb.Breakpoint):
     """Breakpoint which shows a specified name, when hit."""
 
     def __init__(self, location, name):
-        super(NamedBreakpoint, self).__init__(spec=location, type=gdb.BP_BREAKPOINT, internal=False, temporary=False)
+        super().__init__(spec=location, type=gdb.BP_BREAKPOINT, internal=False, temporary=False)
         self.name = name
         self.loc = location
 
@@ -4097,7 +4097,7 @@ class GenericCommand(gdb.Command):
         command_type = kwargs.setdefault("command", gdb.COMMAND_OBSCURE)
         complete_type = kwargs.setdefault("complete", gdb.COMPLETE_NONE)
         prefix = kwargs.setdefault("prefix", False)
-        super(GenericCommand, self).__init__(self._cmdline_, command_type, complete_type, prefix)
+        super().__init__(self._cmdline_, command_type, complete_type, prefix)
         self.post_load()
         return
 
@@ -4192,7 +4192,7 @@ class GenericCommand(gdb.Command):
 #     _syntax_  = "{:s}".format(_cmdline_)
 #     _aliases_ = ["tpl-fk",]
 #     def __init__(self):
-#        super(TemplateCommand, self).__init__(complete=gdb.COMPLETE_FILENAME)
+#        super().__init__(complete=gdb.COMPLETE_FILENAME)
 #         return
 #     def do_invoke(self, argv):
 #         return
@@ -4241,7 +4241,7 @@ class PrintFormatCommand(GenericCommand):
     asm_type = {8: "db", 16: "dw", 32: "dd", 64: "dq"}
 
     def __init__(self):
-        super(PrintFormatCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     def usage(self):
@@ -4347,7 +4347,7 @@ class PieCommand(GenericCommand):
     _syntax_ = "{:s} (breakpoint|info|delete|run|attach|remote)".format(_cmdline_)
 
     def __init__(self):
-        super(PieCommand, self).__init__(prefix=True)
+        super().__init__(prefix=True)
         return
 
     def do_invoke(self, argv):
@@ -4637,7 +4637,7 @@ class ProcessStatusCommand(GenericCommand):
     _aliases_ = ["status", ]
 
     def __init__(self):
-        super(ProcessStatusCommand, self).__init__(complete=gdb.COMPLETE_NONE)
+        super().__init__(complete=gdb.COMPLETE_NONE)
         return
 
     @only_if_gdb_running
@@ -4793,7 +4793,7 @@ class GefThemeCommand(GenericCommand):
     _syntax_ = "{:s} [KEY [VALUE]]".format(_cmdline_)
 
     def __init__(self, *args, **kwargs):
-        super(GefThemeCommand, self).__init__(GefThemeCommand._cmdline_)
+        super().__init__(GefThemeCommand._cmdline_)
         self.add_setting("context_title_line", "gray", "Color of the borders in context window")
         self.add_setting("context_title_message", "cyan", "Color of the title in context window")
         self.add_setting("default_title_line", "gray", "Default color of borders")
@@ -4853,7 +4853,7 @@ class PCustomCommand(GenericCommand):
     _syntax_  = "{:s} [list|edit <StructureName>|show <StructureName>]|<StructureName> 0xADDRESS]".format(_cmdline_)
 
     def __init__(self):
-        super(PCustomCommand, self).__init__(prefix=True)
+        super().__init__(prefix=True)
         self.add_setting("struct_path", os.sep.join([get_gef_setting("gef.tempdir"), "structs"]), "Path to store/load the structure ctypes files")
         self.add_setting("max_depth", 4, "Maximum level of recursion supported")
         return
@@ -5035,7 +5035,7 @@ class PCustomListCommand(PCustomCommand):
     _syntax_ = "{:s}".format(_cmdline_)
 
     def __init__(self):
-        super(PCustomCommand, self).__init__(complete=gdb.COMPLETE_SYMBOL) #pylint: disable=bad-super-call
+        super().__init__(complete=gdb.COMPLETE_SYMBOL)
         return
 
     def do_invoke(self, argv):
@@ -5063,7 +5063,7 @@ class PCustomShowCommand(PCustomCommand):
     __aliases__ = ["pcustom create", "pcustom update"]
 
     def __init__(self):
-        super(PCustomCommand, self).__init__(complete=gdb.COMPLETE_FILENAME) #pylint: disable=bad-super-call
+        super().__init__(complete=gdb.COMPLETE_FILENAME)
         return
 
     def do_invoke(self, argv):
@@ -5113,7 +5113,7 @@ class PCustomEditCommand(PCustomCommand):
     __aliases__ = ["pcustom create", "pcustom new", "pcustom update"]
 
     def __init__(self):
-        super(PCustomCommand, self).__init__(complete=gdb.COMPLETE_FILENAME) #pylint: disable=bad-super-call
+        super().__init__(complete=gdb.COMPLETE_FILENAME)
         return
 
     def do_invoke(self, argv):
@@ -5244,7 +5244,7 @@ class IdaInteractCommand(GenericCommand):
     _example_ = "\n{0:s} Jump $pc\n{0:s} SetColor $pc ff00ff".format(_cmdline_)
 
     def __init__(self):
-        super(IdaInteractCommand, self).__init__(prefix=False)
+        super().__init__(prefix=False)
         host, port = "127.0.0.1", 1337
         self.add_setting("host", host, "IP address to use connect to IDA/Binary Ninja script")
         self.add_setting("port", port, "Port to use connect to IDA/Binary Ninja script")
@@ -5701,7 +5701,7 @@ class ChangePermissionCommand(GenericCommand):
     _example_ = "{:s} $sp 7".format(_cmdline_)
 
     def __init__(self):
-        super(ChangePermissionCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     def pre_load(self):
@@ -5779,7 +5779,7 @@ class UnicornEmulateCommand(GenericCommand):
     _example_ = "{0:s} -f $pc -n 10 -o /tmp/my-gef-emulation.py".format(_cmdline_)
 
     def __init__(self):
-        super(UnicornEmulateCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         self.add_setting("verbose", False, "Set unicorn-engine in verbose mode")
         self.add_setting("show_disassembly", False, "Show every instruction executed")
         return
@@ -6078,7 +6078,7 @@ class RemoteCommand(GenericCommand):
     _example_  = "\n{0:s} -p 6789 localhost:1234\n{0:s} -q localhost:4444 # when using qemu-user".format(_cmdline_)
 
     def __init__(self):
-        super(RemoteCommand, self).__init__(prefix=False)
+        super().__init__(prefix=False)
         self.handler_connected = False
         self.add_setting("clean_on_exit", False, "Clean the temporary data downloaded when the session exits.")
         return
@@ -6297,7 +6297,7 @@ class NopCommand(GenericCommand):
     _example_ = "{:s} $pc".format(_cmdline_)
 
     def __init__(self):
-        super(NopCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     def get_insn_size(self, addr):
@@ -6370,7 +6370,7 @@ class StubCommand(GenericCommand):
     _example_ = "{:s} -r 0 fork".format(_cmdline_)
 
     def __init__(self):
-        super(StubCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -6408,7 +6408,7 @@ class CapstoneDisassembleCommand(GenericCommand):
         return
 
     def __init__(self):
-        super(CapstoneDisassembleCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -6473,7 +6473,7 @@ class GlibcHeapCommand(GenericCommand):
     _syntax_  = "{:s} (chunk|chunks|bins|arenas)".format(_cmdline_)
 
     def __init__(self):
-        super(GlibcHeapCommand, self).__init__(prefix=True)
+        super().__init__(prefix=True)
         return
 
     @only_if_gdb_running
@@ -6491,7 +6491,7 @@ class GlibcHeapSetArenaCommand(GenericCommand):
     _example_ = "{:s} 0x001337001337".format(_cmdline_)
 
     def __init__(self):
-        super(GlibcHeapSetArenaCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -6551,7 +6551,7 @@ class GlibcHeapChunkCommand(GenericCommand):
     _syntax_  = "{:s} LOCATION".format(_cmdline_)
 
     def __init__(self):
-        super(GlibcHeapChunkCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -6580,7 +6580,7 @@ class GlibcHeapChunksCommand(GenericCommand):
     _example_ = "\n{0}\n{0} 0x555555775000".format(_cmdline_)
 
     def __init__(self):
-        super(GlibcHeapChunksCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         self.add_setting("peek_nb_byte", 16, "Hexdump N first byte(s) inside the chunk data (0 to disable)")
         return
 
@@ -6642,7 +6642,7 @@ class GlibcHeapBinsCommand(GenericCommand):
     _syntax_ = "{:s} [{:s}]".format(_cmdline_, "|".join(_bin_types_))
 
     def __init__(self):
-        super(GlibcHeapBinsCommand, self).__init__(prefix=True, complete=gdb.COMPLETE_LOCATION)
+        super().__init__(prefix=True, complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -6697,7 +6697,7 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
     _syntax_  = "{:s} [ARENA_ADDRESS]".format(_cmdline_)
 
     def __init__(self):
-        super(GlibcHeapTcachebinsCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -6766,7 +6766,7 @@ class GlibcHeapFastbinsYCommand(GenericCommand):
     _syntax_  = "{:s} [ARENA_ADDRESS]".format(_cmdline_)
 
     def __init__(self):
-        super(GlibcHeapFastbinsYCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -6826,7 +6826,7 @@ class GlibcHeapUnsortedBinsCommand(GenericCommand):
     _syntax_  = "{:s} [ARENA_ADDRESS]".format(_cmdline_)
 
     def __init__(self):
-        super(GlibcHeapUnsortedBinsCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -6850,7 +6850,7 @@ class GlibcHeapSmallBinsCommand(GenericCommand):
     _syntax_  = "{:s} [ARENA_ADDRESS]".format(_cmdline_)
 
     def __init__(self):
-        super(GlibcHeapSmallBinsCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -6879,7 +6879,7 @@ class GlibcHeapLargeBinsCommand(GenericCommand):
     _syntax_  = "{:s} [ARENA_ADDRESS]".format(_cmdline_)
 
     def __init__(self):
-        super(GlibcHeapLargeBinsCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -7033,7 +7033,7 @@ class ShellcodeCommand(GenericCommand):
     _syntax_  = "{:s} (search|get)".format(_cmdline_)
 
     def __init__(self):
-        super(ShellcodeCommand, self).__init__(prefix=True)
+        super().__init__(prefix=True)
         return
 
     def do_invoke(self, argv):
@@ -7141,7 +7141,7 @@ class RopperCommand(GenericCommand):
     _syntax_  = "{:s} [ROPPER_OPTIONS]".format(_cmdline_)
 
     def __init__(self):
-        super(RopperCommand, self).__init__(complete=gdb.COMPLETE_NONE)
+        super().__init__(complete=gdb.COMPLETE_NONE)
         return
 
     def pre_load(self):
@@ -7183,7 +7183,7 @@ class AssembleCommand(GenericCommand):
     _example_ = "\n{0:s} -a x86 -m 32 nop ; nop ; inc eax ; int3\n{0:s} -a arm -m arm add r0, r0, 1".format(_cmdline_)
 
     def __init__(self, *args, **kwargs):
-        super(AssembleCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         self.valid_arch_modes = {
             "ARM": ["ARM", "THUMB"],
             "ARM64": ["ARM", "THUMB", "V5", "V8", ],
@@ -7204,7 +7204,7 @@ class AssembleCommand(GenericCommand):
         return
 
     def usage(self):
-        super(AssembleCommand, self).usage()
+        super().usage()
         gef_print("\nAvailable architectures/modes:")
         # for updates, see https://github.com/keystone-engine/keystone/blob/master/include/keystone/keystone.h
         for arch in self.valid_arch_modes:
@@ -7298,7 +7298,7 @@ class ProcessListingCommand(GenericCommand):
     _example_ = "{:s} gdb".format(_cmdline_)
 
     def __init__(self):
-        super(ProcessListingCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         ps = which("ps")
         self.add_setting("ps_command", "{:s} auxww".format(ps), "`ps` command to get process information")
         return
@@ -7366,7 +7366,7 @@ class ElfInfoCommand(GenericCommand):
     _example_  = "{:s} /bin/ls".format(_cmdline_)
 
     def __init__(self, *args, **kwargs):
-        super(ElfInfoCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     def do_invoke(self, argv):
@@ -7455,7 +7455,7 @@ class EntryPointBreakCommand(GenericCommand):
     _aliases_ = ["start",]
 
     def __init__(self, *args, **kwargs):
-        super(EntryPointBreakCommand, self).__init__()
+        super().__init__()
         self.add_setting("entrypoint_symbols", "main _main __libc_start_main __uClibc_main start _start", "Possible symbols for entry points")
         return
 
@@ -7536,7 +7536,7 @@ class NamedBreakpointCommand(GenericCommand):
     _example  = "{:s} main *0x4008a9"
 
     def __init__(self, *args, **kwargs):
-        super(NamedBreakpointCommand, self).__init__()
+        super().__init__()
         return
 
     def do_invoke(self, argv):
@@ -7566,7 +7566,7 @@ class ContextCommand(GenericCommand):
     old_registers = {}
 
     def __init__(self):
-        super(ContextCommand, self).__init__()
+        super().__init__()
         self.add_setting("enable", True, "Enable/disable printing the context when breaking")
         self.add_setting("show_source_code_variable_values", True, "Show extra PC context info in the source code")
         self.add_setting("show_stack_raw", False, "Show the stack pane as raw hexdump (no dereference)")
@@ -8232,7 +8232,7 @@ class MemoryCommand(GenericCommand):
     _syntax_  = "{:s} (watch|unwatch|reset|list)".format(_cmdline_)
 
     def __init__(self):
-        super(MemoryCommand, self).__init__(prefix=True)
+        super().__init__(prefix=True)
         return
 
     @only_if_gdb_running
@@ -8249,7 +8249,7 @@ class MemoryWatchCommand(GenericCommand):
     _example_ = "\n\t{0:s} 0x603000 0x100 byte\n\t{0:s} $sp".format(_cmdline_)
 
     def __init__(self):
-        super(MemoryWatchCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -8289,7 +8289,7 @@ class MemoryUnwatchCommand(GenericCommand):
     _example_ = "\n\t{0:s} 0x603000\n\t{0:s} $sp".format(_cmdline_)
 
     def __init__(self):
-        super(MemoryUnwatchCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -8351,7 +8351,7 @@ class HexdumpCommand(GenericCommand):
     _example_ = "{:s} byte $rsp L16 REVERSE".format(_cmdline_)
 
     def __init__(self):
-        super(HexdumpCommand, self).__init__(complete=gdb.COMPLETE_LOCATION, prefix=True)
+        super().__init__(complete=gdb.COMPLETE_LOCATION, prefix=True)
         self.add_setting("always_show_ascii", False, "If true, hexdump will always display the ASCII dump")
         self.format = None
         return
@@ -8455,7 +8455,7 @@ class HexdumpQwordCommand(HexdumpCommand):
     _example_ = "{:s} qword $rsp L16 REVERSE".format(_cmdline_)
 
     def __init__(self):
-        super(HexdumpCommand, self).__init__(complete=gdb.COMPLETE_LOCATION) #pylint: disable=bad-super-call
+        super().__init__()
         self.format = "qword"
         return
 
@@ -8469,7 +8469,7 @@ class HexdumpDwordCommand(HexdumpCommand):
     _example_ = "{:s} $esp L16 REVERSE".format(_cmdline_)
 
     def __init__(self):
-        super(HexdumpCommand, self).__init__(complete=gdb.COMPLETE_LOCATION) #pylint: disable=bad-super-call
+        super().__init__()
         self.format = "dword"
         return
 
@@ -8483,7 +8483,7 @@ class HexdumpWordCommand(HexdumpCommand):
     _example_ = "{:s} $esp L16 REVERSE".format(_cmdline_)
 
     def __init__(self):
-        super(HexdumpCommand, self).__init__(complete=gdb.COMPLETE_LOCATION) #pylint: disable=bad-super-call
+        super().__init__()
         self.format = "word"
         return
 
@@ -8497,10 +8497,9 @@ class HexdumpByteCommand(HexdumpCommand):
     _example_ = "{:s} $rsp L16".format(_cmdline_)
 
     def __init__(self):
-        super(HexdumpCommand, self).__init__(complete=gdb.COMPLETE_LOCATION) #pylint: disable=bad-super-call
+        super().__init__()
         self.format = "byte"
         return
-
 
 
 @register_command
@@ -8518,7 +8517,7 @@ class PatchCommand(GenericCommand):
     }
 
     def __init__(self):
-        super(PatchCommand, self).__init__(prefix=True, complete=gdb.COMPLETE_LOCATION)
+        super().__init__(prefix=True, complete=gdb.COMPLETE_LOCATION)
         self.format = None
         return
 
@@ -8560,10 +8559,9 @@ class PatchQwordCommand(PatchCommand):
     _example_ = "{:s} $rip 0x4141414141414141".format(_cmdline_)
 
     def __init__(self):
-        super(PatchCommand, self).__init__(complete=gdb.COMPLETE_LOCATION) #pylint: disable=bad-super-call
+        super().__init__()
         self.format = "qword"
         return
-
 
 
 @register_command
@@ -8575,7 +8573,7 @@ class PatchDwordCommand(PatchCommand):
     _example_ = "{:s} $rip 0x41414141".format(_cmdline_)
 
     def __init__(self):
-        super(PatchCommand, self).__init__(complete=gdb.COMPLETE_LOCATION) #pylint: disable=bad-super-call
+        super().__init__()
         self.format = "dword"
         return
 
@@ -8589,7 +8587,7 @@ class PatchWordCommand(PatchCommand):
     _example_ = "{:s} $rip 0x4141".format(_cmdline_)
 
     def __init__(self):
-        super(PatchCommand, self).__init__(complete=gdb.COMPLETE_LOCATION) #pylint: disable=bad-super-call
+        super().__init__()
         self.format = "word"
         return
 
@@ -8603,7 +8601,7 @@ class PatchByteCommand(PatchCommand):
     _example_ = "{:s} $rip 0x41 0x41 0x41 0x41 0x41".format(_cmdline_)
 
     def __init__(self):
-        super(PatchCommand, self).__init__(complete=gdb.COMPLETE_LOCATION) #pylint: disable=bad-super-call
+        super().__init__()
         self.format = "byte"
         return
 
@@ -8709,7 +8707,7 @@ class DereferenceCommand(GenericCommand):
     _example_ = "{:s} $sp l20".format(_cmdline_)
 
     def __init__(self):
-        super(DereferenceCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         self.add_setting("max_recursion", 7, "Maximum level of pointer recursion")
         return
 
@@ -8964,7 +8962,7 @@ class XAddressInfoCommand(GenericCommand):
     _example_ = "{:s} $pc".format(_cmdline_)
 
     def __init__(self):
-        super(XAddressInfoCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
     @only_if_gdb_running
@@ -9029,7 +9027,7 @@ class XorMemoryCommand(GenericCommand):
     _syntax_  = "{:s} (display|patch) ADDRESS SIZE KEY".format(_cmdline_)
 
     def __init__(self):
-        super(XorMemoryCommand, self).__init__(prefix=True)
+        super().__init__(prefix=True)
         return
 
     def do_invoke(self, argv):
@@ -9102,7 +9100,7 @@ class TraceRunCommand(GenericCommand):
     _example_ = "{:s} 0x555555554610".format(_cmdline_)
 
     def __init__(self):
-        super(TraceRunCommand, self).__init__(self._cmdline_, complete=gdb.COMPLETE_LOCATION)
+        super().__init__(self._cmdline_, complete=gdb.COMPLETE_LOCATION)
         self.add_setting("max_tracing_recursion", 1, "Maximum depth of tracing")
         self.add_setting("tracefile_prefix", "./gef-trace-", "Specify the tracing output file prefix")
         return
@@ -9192,7 +9190,7 @@ class PatternCommand(GenericCommand):
     _syntax_  = "{:s} (create|search) ARGS".format(_cmdline_)
 
     def __init__(self, *args, **kwargs):
-        super(PatternCommand, self).__init__(prefix=True)
+        super().__init__(prefix=True)
         self.add_setting("length", 1024, "Initial length of a cyclic buffer to generate")
         return
 
@@ -9318,7 +9316,7 @@ class ChecksecCommand(GenericCommand):
     _example_ = "{} /bin/ls".format(_cmdline_)
 
     def __init__(self):
-        super(ChecksecCommand, self).__init__(complete=gdb.COMPLETE_FILENAME)
+        super().__init__(complete=gdb.COMPLETE_FILENAME)
         return
 
     def pre_load(self):
@@ -9376,7 +9374,7 @@ class GotCommand(GenericCommand):
     _example_ = "got read printf exit"
 
     def __init__(self, *args, **kwargs):
-        super(GotCommand, self).__init__()
+        super().__init__()
         self.add_setting("function_resolved", "green", "Line color of the got command output if the function has "
                                                        "been resolved")
         self.add_setting("function_not_resolved", "yellow", "Line color of the got command output if the function has "
@@ -9472,7 +9470,7 @@ class HighlightCommand(GenericCommand):
     _aliases_ = ["hl"]
 
     def __init__(self):
-        super(HighlightCommand, self).__init__(prefix=True)
+        super().__init__(prefix=True)
         self.add_setting("regex", False, "Enable regex highlighting")
 
     def do_invoke(self, argv):
@@ -9592,7 +9590,7 @@ class HeapAnalysisCommand(GenericCommand):
     _syntax_ = _cmdline_
 
     def __init__(self, *args, **kwargs):
-        super(HeapAnalysisCommand, self).__init__(complete=gdb.COMPLETE_NONE)
+        super().__init__(complete=gdb.COMPLETE_NONE)
         self.add_setting("check_free_null", False, "Break execution when a free(NULL) is encountered")
         self.add_setting("check_double_free", True, "Break execution when a double free is encountered")
         self.add_setting("check_weird_free", True, "Break execution when free() is called against a non-tracked pointer")
@@ -9704,7 +9702,7 @@ class SyscallArgsCommand(GenericCommand):
     _syntax_ = _cmdline_
 
     def __init__(self):
-        super(SyscallArgsCommand, self).__init__()
+        super().__init__()
         self.add_setting("path", os.path.join(get_gef_setting("gef.tempdir"), "syscall-tables"),
                          "Path to store/load the syscall tables files")
         return
@@ -9801,7 +9799,7 @@ class GenericFunction(gdb.Function):
         return "${}([offset])".format(self._function_)
 
     def __init__ (self):
-        super(GenericFunction, self).__init__(self._function_)
+        super().__init__(self._function_)
 
     def invoke(self, *args):
         if not is_alive():
@@ -9898,7 +9896,7 @@ class GefFunctionsCommand(GenericCommand):
     _syntax_ = _cmdline_
 
     def __init__(self):
-        super(GefFunctionsCommand, self).__init__()
+        super().__init__()
         self.docs = []
         self.setup()
         return
@@ -9936,10 +9934,7 @@ class GefCommand(gdb.Command):
     _syntax_  = "{:s} (missing|config|save|restore|set|run)".format(_cmdline_)
 
     def __init__(self):
-        super(GefCommand, self).__init__(GefCommand._cmdline_,
-                                         gdb.COMMAND_SUPPORT,
-                                         gdb.COMPLETE_NONE,
-                                         True)
+        super().__init__(GefCommand._cmdline_, gdb.COMMAND_SUPPORT, gdb.COMPLETE_NONE, True)
         set_gef_setting("gef.follow_child", True, bool, "Automatically set GDB to follow child when forking")
         set_gef_setting("gef.readline_compat", False, bool, "Workaround for readline SOH/ETX issue (SEGV)")
         set_gef_setting("gef.debug", False, bool, "Enable debug mode for gef")
@@ -10083,7 +10078,7 @@ class GefHelpCommand(gdb.Command):
     _syntax_  = _cmdline_
 
     def __init__(self, commands, *args, **kwargs):
-        super(GefHelpCommand, self).__init__(GefHelpCommand._cmdline_,
+        super().__init__(GefHelpCommand._cmdline_,
                                              gdb.COMMAND_SUPPORT,
                                              gdb.COMPLETE_NONE,
                                              False)
@@ -10134,7 +10129,7 @@ class GefConfigCommand(gdb.Command):
     _syntax_  = "{:s} [setting_name] [setting_value]".format(_cmdline_)
 
     def __init__(self, loaded_commands, *args, **kwargs):
-        super(GefConfigCommand, self).__init__(GefConfigCommand._cmdline_, gdb.COMMAND_NONE, prefix=False)
+        super().__init__(GefConfigCommand._cmdline_, gdb.COMMAND_NONE, prefix=False)
         self.loaded_commands = loaded_commands
         return
 
@@ -10249,7 +10244,7 @@ class GefSaveCommand(gdb.Command):
     _syntax_  = _cmdline_
 
     def __init__(self, *args, **kwargs):
-        super(GefSaveCommand, self).__init__(GefSaveCommand._cmdline_, gdb.COMMAND_SUPPORT,
+        super().__init__(GefSaveCommand._cmdline_, gdb.COMMAND_SUPPORT,
                                              gdb.COMPLETE_NONE, False)
         return
 
@@ -10289,7 +10284,7 @@ class GefRestoreCommand(gdb.Command):
     _syntax_  = _cmdline_
 
     def __init__(self, *args, **kwargs):
-        super(GefRestoreCommand, self).__init__(GefRestoreCommand._cmdline_,
+        super().__init__(GefRestoreCommand._cmdline_,
                                                 gdb.COMMAND_SUPPORT,
                                                 gdb.COMPLETE_NONE,
                                                 False)
@@ -10345,7 +10340,7 @@ class GefMissingCommand(gdb.Command):
     _syntax_  = _cmdline_
 
     def __init__(self, *args, **kwargs):
-        super(GefMissingCommand, self).__init__(GefMissingCommand._cmdline_,
+        super().__init__(GefMissingCommand._cmdline_,
                                                 gdb.COMMAND_SUPPORT,
                                                 gdb.COMPLETE_NONE,
                                                 False)
@@ -10370,7 +10365,7 @@ class GefSetCommand(gdb.Command):
     _syntax_  = "{:s} [GDB_SET_ARGUMENTS]".format(_cmdline_)
 
     def __init__(self, *args, **kwargs):
-        super(GefSetCommand, self).__init__(GefSetCommand._cmdline_,
+        super().__init__(GefSetCommand._cmdline_,
                                             gdb.COMMAND_SUPPORT,
                                             gdb.COMPLETE_SYMBOL,
                                             False)
@@ -10398,7 +10393,7 @@ class GefRunCommand(gdb.Command):
     _syntax_  = "{:s} [GDB_RUN_ARGUMENTS]".format(_cmdline_)
 
     def __init__(self, *args, **kwargs):
-        super(GefRunCommand, self).__init__(GefRunCommand._cmdline_,
+        super().__init__(GefRunCommand._cmdline_,
                                             gdb.COMMAND_SUPPORT,
                                             gdb.COMPLETE_FILENAME,
                                             False)
@@ -10439,7 +10434,7 @@ class GefAlias(gdb.Command):
             if hasattr(_instance,  "complete"):
                 self.complete = _instance.complete
 
-        super(GefAlias, self).__init__(alias, command_class, completer_class=completer_class)
+        super().__init__(alias, command_class, completer_class=completer_class)
         __aliases__.append(self)
         return
 
@@ -10460,7 +10455,7 @@ class GefAliases(gdb.Command):
     """List all custom aliases."""
 
     def __init__(self):
-        super(GefAliases, self).__init__("aliases", gdb.COMMAND_OBSCURE, gdb.COMPLETE_NONE)
+        super().__init__("aliases", gdb.COMMAND_OBSCURE, gdb.COMPLETE_NONE)
         return
 
     def invoke(self, args, from_tty):
@@ -10475,7 +10470,7 @@ class GefTmuxSetup(gdb.Command):
     """Setup a confortable tmux debugging environment."""
 
     def __init__(self):
-        super(GefTmuxSetup, self).__init__("tmux-setup", gdb.COMMAND_NONE, gdb.COMPLETE_NONE)
+        super().__init__("tmux-setup", gdb.COMMAND_NONE, gdb.COMPLETE_NONE)
         GefAlias("screen-setup", "tmux-setup")
         return
 


### PR DESCRIPTION
Since we don't use python2 we should be able to clean up the super calls.

Also, we don't lint bad super calls so we can remove the pylint comment.