### PR TITLE
Remove caching from get_main_arena

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -969,7 +969,6 @@ def get_libc_version():
     return 0, 0
 
 
-@lru_cache()
 def get_main_arena():
     try:
         return GlibcArena(__gef_default_main_arena__)


### PR DESCRIPTION
## Remove caching from get_main_arena ##

### Description/Motivation/Screenshots ###

Caching the results of `get_main_arena` resulted in inconsistent data
when trying to print fastbins from non-main arenas. If the user printed
fastbin lists in the main arena, then switched to a different arena and
printed fastbin lists, gef would show output from the main arena rather
than the new arena because `get_main_arena` would return a cached
result.

**Before**

![before](https://user-images.githubusercontent.com/22407135/113494676-8e772b80-94b8-11eb-8b1d-e7e3cbffe4c3.png)

**After**

![after](https://user-images.githubusercontent.com/22407135/113494685-9f27a180-94b8-11eb-8bbe-c02d884f4873.png)

### How Has This Been Tested? ###

Only tested on x86-64, but should be architecture agnostic. Used the `heap-non-main-arena.out` binary for testing (disabling the tcache in order to focus on fastbin results).

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       |  :heavy_check_mark:     |                              |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` |  :heavy_check_mark:     |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
