### PR TITLE
Fix gef-extras directory location

### DIFF
--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -2,19 +2,24 @@
 
 set -e
 
+NAME="gef-extras"
+
 if [ $# -ge 1 ]; then
   DIR="$(realpath $1)"
   test -d ${DIR} || exit 1
+elif [ -d ${HOME}/.config ]; then
+  DIR=${HOME}/.config
 else
   DIR=${HOME}
+  NAME=".gef-extras"
 fi
 
-git clone https://github.com/hugsy/gef-extras.git ${DIR}/gef-extras
-gdb -q -ex "gef config gef.extra_plugins_dir '${DIR}/gef-extras/scripts'" \
-       -ex "gef config pcustom.struct_path '${DIR}/gef-extras/structs'" \
-       -ex "gef config syscall-args.path '${DIR}/gef-extras/syscall-tables'" \
+git clone https://github.com/hugsy/gef-extras.git ${DIR}/${NAME}
+gdb -q -ex "gef config gef.extra_plugins_dir '${DIR}/${NAME}/scripts'" \
+       -ex "gef config pcustom.struct_path '${DIR}/${NAME}/structs'" \
+       -ex "gef config syscall-args.path '${DIR}/${NAME}/syscall-tables'" \
        -ex "gef config libc_args True" \
-       -ex "gef config libc_args_path '${DIR}/gef-extras/glibc-function-args'" \
+       -ex "gef config libc_args_path '${DIR}/${NAME}/glibc-function-args'" \
        -ex 'gef save' \
        -ex quit
 

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -9,7 +9,7 @@ if [ $# -ge 1 ]; then
 elif [ -d ${HOME}/.config ]; then
   DIR="${HOME}/.config/gef-extras"
 else
-  DIR=${HOME}
+  DIR="${HOME}/.gef-extras"
 fi
 
 git clone https://github.com/hugsy/gef-extras.git ${DIR}/${NAME}

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-NAME="gef-extras"
 
 if [ $# -ge 1 ]; then
   DIR="$(realpath $1)/gef-extras"

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -10,7 +10,6 @@ elif [ -d ${HOME}/.config ]; then
   DIR="${HOME}/.config/gef-extras"
 else
   DIR=${HOME}
-  NAME=".gef-extras"
 fi
 
 git clone https://github.com/hugsy/gef-extras.git ${DIR}/${NAME}

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-
 if [ $# -ge 1 ]; then
   DIR="$(realpath $1)/gef-extras"
   test -d ${DIR} || exit 1

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -11,12 +11,12 @@ else
   DIR="${HOME}/.gef-extras"
 fi
 
-git clone https://github.com/hugsy/gef-extras.git ${DIR}/${NAME}
-gdb -q -ex "gef config gef.extra_plugins_dir '${DIR}/${NAME}/scripts'" \
-       -ex "gef config pcustom.struct_path '${DIR}/${NAME}/structs'" \
-       -ex "gef config syscall-args.path '${DIR}/${NAME}/syscall-tables'" \
+git clone https://github.com/hugsy/gef-extras.git ${DIR}
+gdb -q -ex "gef config gef.extra_plugins_dir '${DIR}/scripts'" \
+       -ex "gef config pcustom.struct_path '${DIR}/structs'" \
+       -ex "gef config syscall-args.path '${DIR}/syscall-tables'" \
        -ex "gef config libc_args True" \
-       -ex "gef config libc_args_path '${DIR}/${NAME}/glibc-function-args'" \
+       -ex "gef config libc_args_path '${DIR}/glibc-function-args'" \
        -ex 'gef save' \
        -ex quit
 

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ]; then
   DIR="$(realpath $1)/gef-extras"
   test -d ${DIR} || exit 1
 elif [ -d ${HOME}/.config ]; then
-  DIR=${HOME}/.config
+  DIR="${HOME}/.config/gef-extras"
 else
   DIR=${HOME}
   NAME=".gef-extras"

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -5,7 +5,7 @@ set -e
 NAME="gef-extras"
 
 if [ $# -ge 1 ]; then
-  DIR="$(realpath $1)"
+  DIR="$(realpath $1)/gef-extras"
   test -d ${DIR} || exit 1
 elif [ -d ${HOME}/.config ]; then
   DIR=${HOME}/.config


### PR DESCRIPTION
## Better location for gef-extras ##

### Description/Motivation/Screenshots ###
Moves the `~/gef-extras` folder to `~/.config/gef-extras` if it exists, or to `~/.gef-extras` otherwise. This will help de-clutter the home folder. The gef installer already does this but the gef-extras installer does not.

### How Has This Been Tested? ###
I ran several tests with different `$HOME` values to verify that the installer still works. 

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
