### PR TITLE
Print stack

### DIFF
--- a/docs/commands/stack.md
+++ b/docs/commands/stack.md
@@ -3,3 +3,16 @@
 The `stack` command will print the current stack frame and dereference any
 pointers. It does not take any argument.
 
+Example:
+```
+gef➤  stack
+0x00007fffffffddb0│+0x0040: 0x0000000000000000   ← $rbp
+0x00007fffffffdda8│+0x0038: 0x0000000000000000
+0x00007fffffffdda0│+0x0030: 0x00007fffffffdea0  →  0x0000000000000001
+0x00007fffffffdd98│+0x0028: 0x0000000000401050  →  <_start+0> endbr64 
+0x00007fffffffdd90│+0x0020: 0x0000000000000000
+0x00007fffffffdd88│+0x0018: 0x0000000000401170  →  <__libc_csu_init+0> endbr64 
+0x00007fffffffdd80│+0x0010: 0x0000000000000000
+0x00007fffffffdd78│+0x0008: 0x00000000004011bd  →  <__libc_csu_init+77> add rbx, 0x1
+0x00007fffffffdd70│+0x0000: 0x0000000000000000   ← $rax, $rsp, $rdi
+```

--- a/docs/commands/stack.md
+++ b/docs/commands/stack.md
@@ -1,0 +1,5 @@
+## Command stack
+
+The `stack` command will print the current stack frame and dereference any
+pointers. It does not take any argument.
+

--- a/gef.py
+++ b/gef.py
@@ -8274,6 +8274,41 @@ class ContextCommand(GenericCommand):
 
 
 @register_command
+class StackCommand(GenericCommand):
+    """Print the current stack frame"""
+
+    _cmdline_ = "stack"
+    _syntax_  = "{:s}".format(_cmdline_)
+    _aliases_ = []
+
+    old_registers = {}
+
+    def __init__(self):
+        super().__init__()
+        return
+
+    @only_if_gdb_running
+    def do_invoke(self, argv):
+
+        try:
+            sp = current_arch.sp
+            bp = current_arch.fp
+            if bp >= sp:
+                num_lines = int((bp - sp) / current_arch.ptrsize) + 1
+                gdb.execute("dereference {:#x} l{:d}".format(sp, num_lines))
+            else:
+                err("Stack base is less than stack top (stack frame is corrupted?)")
+
+        except gdb.MemoryError:
+            err("Cannot read memory from $SP (corrupted stack pointer?)")
+
+        return
+
+        return
+
+
+
+@register_command
 class MemoryCommand(GenericCommand):
     """Add or remove address ranges to the memory view."""
     _cmdline_ = "memory"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
 - Command search-pattern: commands/search-pattern.md
 - Command set-permission: commands/set-permission.md
 - Command shellcode: commands/shellcode.md
+- Command stack: commands/stack.md
 - Command stub: commands/stub.md
 - Command syscall-args: commands/syscall-args.md
 - Command theme: commands/theme.md


### PR DESCRIPTION
## Print stack command ##

### Description/Motivation/Screenshots ###
Prints the current stack frame. Inspired by the same command from pwndbg. This is useful when the context view of the stack isn't big enough, and you just want a quick look at the stack. This command is pretty much just an alias to `dereference ($rbp - $rsp)/8`

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
