### PR TITLE
Better GEF Aliases Functionality

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,7 +10,7 @@ improve it.
 
 | Command    | Description |
 |:-----------|----------------:|
-|aliases                   | GEF defined aliases|
+|aliases                   | Base command to add, remove, and list GEF defined aliases.|
 |aslr                      | View/modify GDB ASLR behavior.|
 |assemble                  | Inline code assemble. Architecture can be set in GEF runtime config (default is x86).  (alias: asm) |
 |capstone-disassemble      | Use capstone disassembly framework to disassemble code. (alias: cs-dis) |

--- a/docs/commands/aliases.md
+++ b/docs/commands/aliases.md
@@ -25,7 +25,7 @@ aliases rm [alias]
 
 ### Listing Aliases
 
-One can list aliases by using the `aliases list` command. Some sample output of this
+One can list aliases by using the `aliases ls` command. Some sample output of this
 command is seen below.
 
 ```

--- a/docs/commands/aliases.md
+++ b/docs/commands/aliases.md
@@ -1,9 +1,34 @@
 ## Command aliases ##
 
-List the aliases defined by `GEF`.
+Base command to add, remove, and list `GEF` defined aliases.
 
 ```
 gef➤  aliases
+aliases (add|rm|list)
+```
+
+### Adding/Removing Aliases
+
+`GEF` defines its own aliasing mechanism which overrides the traditional
+alias that GDB provides through the built-in command `alias`. To add a new alias,
+simply use the `aliases add` command. The "command" parameter may contain spaces.
+
+```
+aliases add [alias] [command]
+```
+
+To remove an alias, simply use the `aliases rm` command.
+
+```
+aliases rm [alias]
+```
+
+### Listing Aliases
+
+One can list aliases by using the `aliases list` command. Some sample output of this
+command is seen below.
+
+```
 [+] Aliases defined:
 fmtstr-helper                   →  format-string-helper
 telescope                       →  dereference
@@ -19,12 +44,9 @@ ps                              →  process-search
 [...]
 ```
 
-### Creating/deleting aliases
+### Using the Configuration File
 
-`GEF` defines its own aliasing mechanism which overrides the traditional
-alias that GDB provides through the built-in command `alias`.
-
-Users can create/modify/delete aliases by editing the `GEF` configuration file,
+Users can also create/modify/delete aliases by editing the `GEF` configuration file,
 by default located at `~/.gef.rc`. The aliases must be in the `aliases` section
 of the configuration file.
 

--- a/gef.py
+++ b/gef.py
@@ -10532,10 +10532,15 @@ class AliasesRmCommand(GenericCommand):
         if (len(argv) != 1):
             self.rm_usage()
             return
-        if not (alias := [__aliases__.index(a) for a in __aliases__ if a._alias == argv[0]]):
+        found = False
+        for idx, obj in enumerate(__aliases__):
+            if (obj._alias == argv[0]):
+                del __aliases__[idx]
+                found = True
+                break
+        if not found:
             err("{0} not found in aliases.".format(argv[0]))
             return
-        del __aliases__[alias[0]]
         GefSaveCommand().invoke(None, False)
         # TODO: reload GEF so that the alias no longer works in the current session?
         return

--- a/gef.py
+++ b/gef.py
@@ -10484,10 +10484,10 @@ class GefAlias(gdb.Command):
 
 @register_command
 class AliasesCommand(GenericCommand):
-    """Base command to add, remove, or list aliases"""
+    """Base command to add, remove, or list aliases."""
 
     _cmdline_ = "aliases"
-    _syntax_  = "{:s} (add|rm|list)".format(_cmdline_)
+    _syntax_  = "{:s} (add|rm|ls)".format(_cmdline_)
 
     def __init__(self):
         super().__init__(prefix=True)
@@ -10499,7 +10499,7 @@ class AliasesCommand(GenericCommand):
 
 @register_command
 class AliasesAddCommand(AliasesCommand):
-    """Command to add aliases"""
+    """Command to add aliases."""
 
     _cmdline_ = "aliases add"
     _syntax_  = "{0} [ALIAS] [COMMAND]".format(_cmdline_)
@@ -10519,7 +10519,7 @@ class AliasesAddCommand(AliasesCommand):
 
 @register_command
 class AliasesRmCommand(AliasesCommand):
-    """Command to remove aliases"""
+    """Command to remove aliases."""
 
     _cmdline_ = "aliases rm"
     _syntax_ = "{0} [ALIAS]".format(_cmdline_)
@@ -10530,23 +10530,24 @@ class AliasesRmCommand(AliasesCommand):
 
     def do_invoke(self, argv):
         global __aliases__
-        if (len(argv) != 1):
+        if len(argv) != 1:
             self.rm_usage()
             return
-        numaliases = len(__aliases__)
-        __aliases__ = [alias for alias in __aliases__ if alias._alias != argv[0]]
-        if numaliases == len(__aliases__):
-             err("{0} not found in aliases.".format(argv[0]))
-             return
+        try:
+            alias_to_remove = next(filter(lambda x: x._alias == argv[0], __aliases__))
+            __aliases__.remove(alias_to_remove)
+        except (ValueError, StopIteration) as e:
+            err("{0} not found in aliases.".format(argv[0]))
+            return
         GefSaveCommand().invoke(None, False)
-        # TODO: reload GEF so that the alias no longer works in the current session?
+        gef_print("You must reload GEF for alias removals to apply.")
         return
 
 @register_command
 class AliasesListCommand(AliasesCommand):
-    """Command to list aliases"""
+    """Command to list aliases."""
 
-    _cmdline_ = "aliases list"
+    _cmdline_ = "aliases ls"
     _syntax_ = _cmdline_
 
     def __init__(self):
@@ -10555,8 +10556,8 @@ class AliasesListCommand(AliasesCommand):
 
     def do_invoke(self, argv):
         ok("Aliases defined:")
-        for _alias in __aliases__:
-            gef_print("{:30s} {} {}".format(_alias._alias, RIGHT_ARROW, _alias._command))
+        for a in __aliases__:
+            gef_print("{:30s} {} {}".format(a._alias, RIGHT_ARROW, a._command))
         return
 
 class GefTmuxSetup(gdb.Command):

--- a/gef.py
+++ b/gef.py
@@ -10498,7 +10498,7 @@ class AliasesCommand(GenericCommand):
         return
 
 @register_command
-class AliasesAddCommand(GenericCommand):
+class AliasesAddCommand(AliasesCommand):
     """Command to add aliases"""
 
     _cmdline_ = "aliases add"
@@ -10506,7 +10506,7 @@ class AliasesAddCommand(GenericCommand):
     _example_ = "{0} scope telescope".format(_cmdline_)
 
     def __init__(self):
-        super().__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__()
         return
 
     def do_invoke(self, argv):
@@ -10518,42 +10518,39 @@ class AliasesAddCommand(GenericCommand):
         return
 
 @register_command
-class AliasesRmCommand(GenericCommand):
+class AliasesRmCommand(AliasesCommand):
     """Command to remove aliases"""
 
     _cmdline_ = "aliases rm"
     _syntax_ = "{0} [ALIAS]".format(_cmdline_)
 
     def __init__(self):
-        super().__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__()
         return
 
     def do_invoke(self, argv):
+        global __aliases__
         if (len(argv) != 1):
             self.rm_usage()
             return
-        found = False
-        for idx, obj in enumerate(__aliases__):
-            if (obj._alias == argv[0]):
-                del __aliases__[idx]
-                found = True
-                break
-        if not found:
-            err("{0} not found in aliases.".format(argv[0]))
-            return
+        numaliases = len(__aliases__)
+        __aliases__ = [alias for alias in __aliases__ if alias._alias != argv[0]]
+        if numaliases == len(__aliases__):
+             err("{0} not found in aliases.".format(argv[0]))
+             return
         GefSaveCommand().invoke(None, False)
         # TODO: reload GEF so that the alias no longer works in the current session?
         return
 
 @register_command
-class AliasesListCommand(GenericCommand):
+class AliasesListCommand(AliasesCommand):
     """Command to list aliases"""
 
     _cmdline_ = "aliases list"
     _syntax_ = _cmdline_
 
     def __init__(self):
-        super().__init__(complete=gdb.COMPLETE_LOCATION)
+        super().__init__()
         return
 
     def do_invoke(self, argv):

--- a/gef.py
+++ b/gef.py
@@ -10514,7 +10514,6 @@ class AliasesAddCommand(AliasesCommand):
             self.usage()
             return
         GefAlias(argv[0], " ".join(argv[1:]))
-        GefSaveCommand().invoke(None, False)
         return
 
 @register_command
@@ -10531,7 +10530,7 @@ class AliasesRmCommand(AliasesCommand):
     def do_invoke(self, argv):
         global __aliases__
         if len(argv) != 1:
-            self.rm_usage()
+            self.usage()
             return
         try:
             alias_to_remove = next(filter(lambda x: x._alias == argv[0], __aliases__))
@@ -10539,7 +10538,6 @@ class AliasesRmCommand(AliasesCommand):
         except (ValueError, StopIteration) as e:
             err("{0} not found in aliases.".format(argv[0]))
             return
-        GefSaveCommand().invoke(None, False)
         gef_print("You must reload GEF for alias removals to apply.")
         return
 

--- a/gef.py
+++ b/gef.py
@@ -10491,7 +10491,7 @@ class GefAliases(gdb.Command):
         return
 
     def usage(self):
-        gef_print("aAliasesliases (add|rm|list)")
+        gef_print("aliases (add|rm|list)")
         return
 
     def add_usage(self):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -518,6 +518,21 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         self.assertIn("\x1b[35m44444444\x1b[0m", res)
         return
 
+    def test_cmd_aliases(self):
+        # test add functionality
+        add_res = gdb_start_silent_cmd("aliases add a b")
+        self.assertNoException(add_res)
+        # test list functionality
+        list_res = gdb_start_silent_cmd("aliases list")
+        self.assertNoException(list_res)
+        self.assertIn("a                               →  b", list_res)
+        # test rm functionality
+        rm_res = gdb_start_silent_cmd("aliases rm a")
+        self.assertNoException(rm_res)
+        rm_list_res = gdb_start_silent_cmd("aliases list")
+        self.assertNotIn("a                               →  b", rm_list_res)
+        return
+
 
 class TestGefFunctions(GefUnitTestGeneric):
     """Tests GEF internal functions."""

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -523,14 +523,13 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         add_res = gdb_start_silent_cmd("aliases add alias_function_test example")
         self.assertNoException(add_res)
         # test list functionality
-        list_res = gdb_start_silent_cmd("aliases ls")
+        list_res = gdb_start_silent_cmd("aliases ls", before=["aliases add alias_function_test example"])
         self.assertNoException(list_res)
         self.assertIn("alias_function_test", list_res)
         # test rm functionality
-        rm_res = gdb_start_silent_cmd("aliases rm alias_function_test")
+        rm_res = gdb_start_silent_cmd("aliases ls", before=["aliases add alias_function_test example", "aliases rm alias_function_test"])
         self.assertNoException(rm_res)
-        rm_list_res = gdb_start_silent_cmd("aliases ls")
-        self.assertNotIn("alias_function_test", rm_list_res)
+        self.assertNotIn("alias_function_test", rm_res)
         return
 
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -520,17 +520,17 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
 
     def test_cmd_aliases(self):
         # test add functionality
-        add_res = gdb_start_silent_cmd("aliases add a b")
+        add_res = gdb_start_silent_cmd("aliases add alias_function_test example")
         self.assertNoException(add_res)
         # test list functionality
-        list_res = gdb_start_silent_cmd("aliases list")
+        list_res = gdb_start_silent_cmd("aliases ls")
         self.assertNoException(list_res)
-        self.assertIn("a                               →  b", list_res)
+        self.assertIn("alias_function_test", list_res)
         # test rm functionality
-        rm_res = gdb_start_silent_cmd("aliases rm a")
+        rm_res = gdb_start_silent_cmd("aliases rm alias_function_test")
         self.assertNoException(rm_res)
-        rm_list_res = gdb_start_silent_cmd("aliases list")
-        self.assertNotIn("a                               →  b", rm_list_res)
+        rm_list_res = gdb_start_silent_cmd("aliases ls")
+        self.assertNotIn("alias_function_test", rm_list_res)
         return
 
 


### PR DESCRIPTION
## Better GEF Aliases Functionality ##

### Description/Motivation/Screenshots ###

Adds better functionality to the `aliases` command. This closes Issue #636. Examples below.

Adding an alias... (command can contain spaces)
```
aliases add [alias] [command]
```

Removing an alias...
```
aliases rm [alias]
```

Listing aliases...
```
aliases list
```

Any aliases added will be automatically added to the `~/.gef.rc` file, and the removed aliases will be removed. I have also updated the docs with the new usage of the command.

### How Has This Been Tested? ###

I have tested this patch across several machines running Debian and Arch based distros.

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
