### PR TITLE
fix(docs): corrects common typos in various documentation files

### DIFF
--- a/docs/commands/name-break.md
+++ b/docs/commands/name-break.md
@@ -3,7 +3,7 @@
 The command `name-break` (alias `nb`) can be used to set a breakpoint on 
 a location with a name assigned to it.
 
-Everytime this breakpoint is hit, the specified name will also be shown
+Every time this breakpoint is hit, the specified name will also be shown
 in the `extra` section to make it easier to keep an overview when using
 multiple breakpoints in a stripped binary.
 

--- a/docs/commands/pcustom.md
+++ b/docs/commands/pcustom.md
@@ -2,7 +2,7 @@
 
 `gef` provides a way to create and apply to the currently debugged environment, any new structure (in the C-struct way). On top of simply displaying known and user-defined structures, it also allows to apply those structures to the current context. It intends to mimic the very useful [WinDBG `dt`](https://msdn.microsoft.com/en-us/library/windows/hardware/ff542772(v=vs.85).aspx) command.
 
-This is achieved via the command `pcustom` (for `print custom`), or you can use its alias, `dt` (in reference to the WinDBG command) as provided by the [`WinDbg compatiblity extension`](https://github.com/hugsy/gef-extras/blob/master/scripts/windbg.py)
+This is achieved via the command `pcustom` (for `print custom`), or you can use its alias, `dt` (in reference to the WinDBG command) as provided by the [`WinDbg compatibility extension`](https://github.com/hugsy/gef-extras/blob/master/scripts/windbg.py)
 
 
 ### Configuration

--- a/docs/commands/print-format.md
+++ b/docs/commands/print-format.md
@@ -13,8 +13,8 @@ specified. Currently, the output language supported are
 ```
 gef➤  print-format -h
 [+] print-format [-f FORMAT] [-b BITSIZE] [-l LENGTH] [-c] [-h] LOCATION
-        -f FORMAT specifies the output format for programming language, avaliable value is py, c, js, asm (default py).
-        -b BITSIZE sepecifies size of bit, avaliable values is 8, 16, 32, 64 (default is 8).
+        -f FORMAT specifies the output format for programming language, available value is py, c, js, asm (default py).
+        -b BITSIZE sepecifies size of bit, available values is 8, 16, 32, 64 (default is 8).
         -l LENGTH specifies length of array (default is 256).
         -c The result of data will copied to clipboard (requires xclip)
         LOCATION specifies where the address of bytes is stored.

--- a/docs/commands/search-pattern.md
+++ b/docs/commands/search-pattern.md
@@ -9,7 +9,7 @@ gef➤  search-pattern MyPattern
 
 ![grep](https://i.imgur.com/YNzsFvk.png)
 
-It will provide an easily understandable to spot occurences of the specified
+It will provide an easily understandable to spot occurrences of the specified
 pattern, including the section it/they was/were found, and the permission
 associated to that section.
 

--- a/docs/commands/syscall-args.md
+++ b/docs/commands/syscall-args.md
@@ -1,6 +1,6 @@
 ## Command syscall-args ##
 
-Often it is troublesome to have to refer to syscall tables everytime we encounter a system call instruction.
+Often it is troublesome to have to refer to syscall tables every time we encounter a system call instruction.
 `gef` can be used to determine the system call being invoked and the arguments being passed to it. Requires [gef-extras](http://github.com/hugsy/gef-extras).
 
 To use it, simply run


### PR DESCRIPTION
## <Typo correction> ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->
Scope of change is restricted to docs only.
Corrected several typos in markdown documents.

### How Has This Been Tested? ###

Tests n/a. Corrections match Standard English. Second set of eyes suggested.

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
