### PR TITLE
capstone-disassemble: Remove requirement for gdb to be running

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6448,7 +6448,6 @@ class CapstoneDisassembleCommand(GenericCommand):
         super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
-    @only_if_gdb_running
     def do_invoke(self, argv):
         location = None
         show_opcodes = False


### PR DESCRIPTION
## capstone-disassemble: Remove requirement for gdb to be running ##

Remove the need for the program to be running to get the disassembly with `cs`.

Before pushing to dev, I want to make sure if there's something I missed.
