### PR TITLE
Add ARM Cortex-M support

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1854,6 +1854,13 @@ class ARM(Architecture):
         return "; ".join(insns)
 
 
+class ARM_M(ARM):
+    arch = "ARM-M"
+
+    all_registers = ARM.all_registers[:-1] + ["$xpsr",]
+    flag_register = "$xpsr"
+
+
 class AARCH64(ARM):
     arch = "ARM64"
     mode = "ARM"
@@ -3298,6 +3305,7 @@ def set_arch(arch=None, default=None):
     """
     arches = {
         "ARM": ARM, Elf.ARM: ARM,
+        "ARM-M": ARM_M,
         "AARCH64": AARCH64, "ARM64": AARCH64, Elf.AARCH64: AARCH64,
         "X86": X86, Elf.X86_32: X86,
         "X86_64": X86_64, Elf.X86_64: X86_64, "i386:x86-64": X86_64,
@@ -7320,6 +7328,7 @@ class AssembleCommand(GenericCommand):
         super().__init__(complete=gdb.COMPLETE_LOCATION)
         self.valid_arch_modes = {
             "ARM": ["ARM", "THUMB"],
+            "ARM-M": ["ARM", "THUMB"],
             "ARM64": ["ARM", "THUMB", "V5", "V8", ],
             "MIPS": ["MICRO", "MIPS3", "MIPS32", "MIPS32R6", "MIPS64",],
             "PPC": ["PPC32", "PPC64", "QPX",],


### PR DESCRIPTION
## Add ARM Cortex-M support

### Description/Motivation/Screenshots ###
Add a `ARM-M` architecture as outlined in #571.

I used `ARM-M` instead of `mARM` as the later was turned into uppercase which makes it hard to see the relation to `ARM`.
There is probably a way to auto detect the arch and don't relay on `python set_arch('ARM-M')`, but I'm not into the gef code base.

This is more or less my workaround and in the "works for me"-state. I'm happy to help test further improvements, but I don't want to spend to much time polishing this.

![image](https://user-images.githubusercontent.com/1280142/118988117-33729880-b981-11eb-84ec-6fddc8621d98.png)

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |   |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
