### PR TITLE
Fix address underflow on disassemble (Fixed-length ABI)

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1303,7 +1303,7 @@ def gdb_get_nth_previous_instruction_address(addr, n):
     """Return the address (Integer) of the `n`-th instruction before `addr`."""
     # fixed-length ABI
     if current_arch.instruction_length:
-        return addr - n * current_arch.instruction_length
+        return max(0, addr - n * current_arch.instruction_length)
 
     # variable-length ABI
     cur_insn_addr = gef_current_instruction(addr).address


### PR DESCRIPTION
## Fix context disassemble near 0x0

### Description/Motivation/Screenshots ###
Firmware execution may start at address `0x0`. Disassembling instruction before addresses near `0x0` leads to an address underflow and therefore an `gdb.MemoryError` exception during `context`.

NOTE: An unmapped page may still be reached with the unchecked `addr - n * instruction_length` location calculation, so maybe removing the special case for fixed-sized ABI's may be the better solution.

unfixed:
![image](https://user-images.githubusercontent.com/1280142/119148422-c3314900-ba4c-11eb-815a-ff38c91c3e56.png)
fixed:
![image](https://user-images.githubusercontent.com/1280142/119148539-dd6b2700-ba4c-11eb-90ba-6c9437719d8e.png)


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_check_mark: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
