### PR TITLE
Proper command argument parsing

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -233,6 +233,14 @@ Checks if the GDB version is higher or equal to the MAJOR and MINOR providedas a
 
 This decorator aims to facilitate the argument passing to a command. If added, it will use the `argparse` module to parse arguments, and will store them in the `kwargs["arguments"]` of the calling function (therefore the function **must** have `*args, **kwargs` added to its signature). Argument type is inferred directly from the default value **except** for boolean, where a value of `True` corresponds to `argparse`'s `store_true` action. For more details on `argparse`, refer to its Python documentation.
 
+Values given for the parameters also allow list of arguments being past. This can be useful in the case where the number of exact option values is known in advance. This can be achieved simply by using a type of `tuple` or `list` for the default value. `parse_arguments` will determine the type of what to expect based on the first default value of the iterable, so make sure it's not empty. For instance:
+
+
+```python
+@parse_arguments( {"instructions": ["nop", "int3", "hlt"], }, {"--arch": "x64", } )
+```
+
+
 Argument flags are also supported, allowing to write simpler version of the flag such as
 
 ```python
@@ -245,7 +253,7 @@ A basic example would be as follow:
 class MyCommand(GenericCommand):
     [...]
 
-    @parse_arguments({"foo": 1}, {"--bleh": "", ("--blah", "-l): True})
+    @parse_arguments({"foo": [1,]}, {"--bleh": "", ("--blah", "-l): True})
     def do_invoke(self, argv, *args, **kwargs):
       args = kwargs["arguments"]
       if args.foo == 1: ...
@@ -255,16 +263,17 @@ class MyCommand(GenericCommand):
 When the user enters the following command:
 
 ```
-gef➤ mycommand --blah 42
+gef➤ mycommand --blah 3 14 159 2653
 ```
 
 The function `MyCommand!do_invoke()` can use the command line argument value
 
 ```python
-args.foo --> 42 # from user input
-args.bleh --> "" # default value
-args.blah --> True # from user input
+args.foo --> [3, 14, 159, 2653] # a List(int) from user input
+args.bleh --> "" # the default value
+args.blah --> True # set to True because user input declared the option (would have been False otherwise)
 ```
+
 
 
 ### Classes ###

--- a/docs/api.md
+++ b/docs/api.md
@@ -212,6 +212,17 @@ gef_on_exit_unhook
 > GDB are only present in the very latest version of GDB.
 
 
+```
+@parse_arguments( {"required_argument_1": DefaultValue1, ...}, {"--optional-argument-1": DefaultValue1, ...} )
+```
+> This decorator aims to facilitate the argument passing to a command. If added, it will use
+> the `argparse` module to parse arguments, and will store them in the `kwargs["arguments"]` of
+> the calling function (therefore the function **must** have `*args, **kwargs` added to its
+> signature). Argument type is inferred directly from the default value **except** for boolean,
+> where a value of `True` corresponds to `argparse`'s `store_true` action. For more details on
+> `argparse`, refer to its Python doc.
+
+
 ### Classes ###
 
 For exhaustive documentation, run

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,11 +62,11 @@ section of the script, by invoking the global function
 `register_external_command()`.
 
 Now you have a new GEF command which you can load, either from cli:
-```
+```bash
 gef➤  source /path/to/newcmd.py
 ```
 or add to your `~/.gdbinit`:
-```
+```bash
 $ echo source /path/to/newcmd.py >> ~/.gdbinit
 ```
 
@@ -77,7 +77,7 @@ mentioned (but not limited to) below. To see the full help of a function, open
 GDB and GEF, and use the embedded Python interpreter's `help` command. For
 example:
 
-```
+```bash
 gef➤  pi help(Architecture)
 ```
 
@@ -90,137 +90,181 @@ $ gdb -q -ex 'pi help(hexdump)' -ex quit
 
 ### Globals ###
 
-```
+```python
 register_external_command()
 ```
-> Procedure to add the new GEF command
+Procedure to add the new GEF command
 
+---
 
-```
+```python
 current_arch
 ```
-> Global variable associated with the architecture of the currently debugged
-> process. The variable is an instance of the `Architecture` class (see below).
+Global variable associated with the architecture of the currently debugged process. The variable is an instance of the `Architecture` class (see below).
 
-```
+---
+
+```python
 read_memory(addr, length=0x10)
 ```
-> Returns a `length` long byte array with a copy of the process memory read
-> from `addr`.
+Returns a `length` long byte array with a copy of the process memory read from `addr`.
 
-```
+---
+
+```python
 write_memory(addr, buffer, length=0x10)
 ```
-> Writes `buffer` to memory at address `addr`.
+Writes `buffer` to memory at address `addr`.
 
+---
 
-```
+```python
 read_int_from_memory(addr)
 ```
-> Reads the size of an integer from `addr`, and unpacks it correctly (based on
-> the current arch's endianness)
 
-```
+Reads the size of an integer from `addr`, and unpacks it correctly (based on the current arch's endianness)
+
+---
+
+```python
 read_cstring_from_memory(addr)
 ```
-> Return a NULL-terminated array of bytes, from `addr`.
+Return a NULL-terminated array of bytes, from `addr`.
 
+---
 
-```
+```python
 get_register(register_name)
 ```
-> Returns the value of given register.
 
+Returns the value of given register.
 
-```
+---
+
+```python
 get_process_maps()
 ```
-> Returns an array of Section objects (see below) corresponding to the current
-> memory layout of the process.
+Returns an array of Section objects (see below) corresponding to the current memory layout of the process.
 
+---
 
-```
+```python
 gef_disassemble(addr, nb_insn, from_top=False)
 ```
-> Disassemble `nb_insn` instructions after `addr`. If `from_top` is False
-> (default), it will also disassemble the `nb_insn` instructions before `addr`.
-> Return an iterator of Instruction objects (see below).
+Disassemble `nb_insn` instructions after `addr`. If `from_top` is False (default), it will also disassemble the `nb_insn` instructions before `addr`. Return an iterator of Instruction objects (see below).
 
+---
 
-```
+```python
 ok(msg)
 info(msg)
 warn(msg)
 err(msg)
 ```
-> Logging functions
 
+Logging functions
 
-```
+---
+
+```python
 gef_on_continue_hook
 gef_on_continue_unhook
 ```
-> Takes a callback function FUNC as parameter: add/remove a call to FUNC
-> when GDB continues execution.
+Takes a callback function FUNC as parameter: add/remove a call to `FUNC` when GDB continues execution.
 
-```
+---
+
+```python
 gef_on_stop_hook
 gef_on_stop_unhook
 ```
-> Takes a callback function FUNC as parameter: add/remove a call to FUNC
-> when GDB stops execution (breakpoints, watchpoints, interrupt, signal, etc.).
 
-```
+Takes a callback function FUNC as parameter: add/remove a call to `FUNC` when GDB stops execution (breakpoints, watchpoints, interrupt, signal, etc.).
+
+---
+
+```python
 gef_on_new_hook
 gef_on_new_unhook
 ```
-> Takes a callback function FUNC as parameter: add/remove a call to FUNC
-> when GDB loads a new binary.
 
-```
+Takes a callback function FUNC as parameter: add/remove a call to `FUNC` when GDB loads a new binary.
+
+---
+
+```python
 gef_on_exit_hook
 gef_on_exit_unhook
 ```
-> Takes a callback function FUNC as parameter: add/remove a call to FUNC
-> when GDB exits an inferior.
+
+Takes a callback function FUNC as parameter: add/remove a call to `FUNC` when GDB exits an inferior.
 
 
 ### Decorators ###
 
-```
+```python
 @only_if_gdb_running
 ```
-> Modifies a function to only execute if a GDB session is running. A GDB
-> session is running if:
->
-> * a PID exists for the targeted binary
-> * GDB is running on a coredump of a binary
 
+Modifies a function to only execute if a GDB session is running. A GDB session is running if:
+* a PID exists for the targeted binary
+* GDB is running on a coredump of a binary
 
-```
+---
+
+```python
 @only_if_gdb_target_local
 ```
-> Checks if the current GDB session is local i.e. not debugging using GDB
-> `remote`.
+Checks if the current GDB session is local i.e. not debugging using GDB `remote`.
 
+---
 
-```
+```python
 @only_if_gdb_version_higher_than( (MAJOR, MINOR) )
 ```
-> Checks if the GDB version is higher or equal to the MAJOR and MINOR provided
-> as arguments (both as Integers). This is required since some commands/API of
-> GDB are only present in the very latest version of GDB.
 
+Checks if the GDB version is higher or equal to the MAJOR and MINOR providedas arguments (both as Integers). This is required since some commands/API ofGDB are only present in the very latest version of GDB.
 
-```
+---
+
+```python
 @parse_arguments( {"required_argument_1": DefaultValue1, ...}, {"--optional-argument-1": DefaultValue1, ...} )
 ```
-> This decorator aims to facilitate the argument passing to a command. If added, it will use
-> the `argparse` module to parse arguments, and will store them in the `kwargs["arguments"]` of
-> the calling function (therefore the function **must** have `*args, **kwargs` added to its
-> signature). Argument type is inferred directly from the default value **except** for boolean,
-> where a value of `True` corresponds to `argparse`'s `store_true` action. For more details on
-> `argparse`, refer to its Python doc.
+
+This decorator aims to facilitate the argument passing to a command. If added, it will use the `argparse` module to parse arguments, and will store them in the `kwargs["arguments"]` of the calling function (therefore the function **must** have `*args, **kwargs` added to its signature). Argument type is inferred directly from the default value **except** for boolean, where a value of `True` corresponds to `argparse`'s `store_true` action. For more details on `argparse`, refer to its Python documentation.
+
+Argument flags are also supported, allowing to write simpler version of the flag such as
+
+```python
+@parse_arguments( {}, {("--long-argument", "-l"): value, } )
+```
+
+A basic example would be as follow:
+
+```python
+class MyCommand(GenericCommand):
+    [...]
+
+    @parse_arguments({"foo": 1}, {"--bleh": "", ("--blah", "-l): True})
+    def do_invoke(self, argv, *args, **kwargs):
+      args = kwargs["arguments"]
+      if args.foo == 1: ...
+      if args.blah == True: ...
+```
+
+When the user enters the following command:
+
+```
+gef➤ mycommand --blah 42
+```
+
+The function `MyCommand!do_invoke()` can use the command line argument value
+
+```python
+args.foo --> 42 # from user input
+args.bleh --> "" # default value
+args.blah --> True # from user input
+```
 
 
 ### Classes ###

--- a/gef.py
+++ b/gef.py
@@ -4327,7 +4327,7 @@ class PrintFormatCommand(GenericCommand):
 
     _cmdline_ = "print-format"
     _aliases_ = ["pf",]
-    _syntax_  = """{} [--lang LANG] [--bitlen SIZE] [--length LENGTH] [--clip] LOCATION
+    _syntax_  = """{} [--lang LANG] [--bitlen SIZE] [(--length,-l) LENGTH] [--clip] LOCATION
 \t--lang LANG specifies the output format for programming language (available: {}, default 'py').
 \t--bitlen SIZE specifies size of bit (possible values: {}, default is 8).
 \t--length LENGTH specifies length of array (default is 256).

--- a/gef.py
+++ b/gef.py
@@ -4371,7 +4371,7 @@ class PrintFormatCommand(GenericCommand):
             out = "buf = [{}]".format(sdata)
         elif args.lang == "c":
             c_type = self.format_matrix[args.bitlen][1]
-            out = "unsigned {0} buf[{1}] = {{{2}}};".format(c_type, length, sdata)
+            out = "unsigned {0} buf[{1}] = {{{2}}};".format(c_type, args.length, sdata)
         elif args.lang == "js":
             out = "var buf = [{}]".format(sdata)
         elif args.lang == "asm":

--- a/gef.py
+++ b/gef.py
@@ -2660,7 +2660,7 @@ def copy_to_clipboard(data):
         pbcopy = which("pbcopy")
         prog = [pbcopy]
     else:
-        raise NotImplementedError("paste: Unsupported OS")
+        raise NotImplementedError("copy: Unsupported OS")
 
     p = subprocess.Popen(prog, stdin=subprocess.PIPE)
     p.stdin.write(data)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -355,6 +355,20 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         self.assertIn("No open connections", res)
         return
 
+    def test_cmd_process_search(self):
+        res = gdb_start_silent_cmd("process-search", target="/tmp/pattern.out", before=["set args w00tw00t", ])
+        self.assertNoException(res)
+        self.assertIn("/tmp/pattern.out", res)
+
+        res = gdb_start_silent_cmd("process-search gdb.*fakefake", target="/tmp/pattern.out", before=["set args w00tw00t", ])
+        self.assertNoException(res)
+        self.assertIn("gdb", res)
+
+        res = gdb_start_silent_cmd("process-search --smart-scan gdb.*fakefake", target="/tmp/pattern.out", before=["set args w00tw00t", ])
+        self.assertNoException(res)
+        self.assertNotIn("gdb", res)
+        return
+
     def test_cmd_registers(self):
         self.assertFailIfInactiveSession(gdb_run_cmd("registers"))
         res = gdb_start_silent_cmd("registers")

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -305,14 +305,28 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         self.assertIn("Gef!Gef!Gef!Gef!", res)
         return
 
-    def test_cmd_pattern(self):
+    def test_cmd_pattern_create(self):
         cmd = "pattern create 32"
         target = "/tmp/pattern.out"
         res = gdb_run_cmd(cmd, target=target)
         self.assertNoException(res)
-        self.assertIn("aaaaaaaabaaaaaaacaaaaaaadaaaaaaa", res)
+        self.assertIn("aaaabaaacaaadaaaeaaaf", res)
 
+        cmd = "pattern create --period 8 32"
+        target = "/tmp/pattern.out"
+        res = gdb_run_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertIn("aaaaaaaabaaaaaaacaaaaaaadaaaaaaa", res)
+        return
+
+    def test_cmd_pattern_search(self):
         cmd = "pattern search $rbp"
+        target = "/tmp/pattern.out"
+        res = gdb_run_cmd(cmd, before=["set args aaaabaaacaaadaaaeaaafaaagaaahaaa", "run"], target=target)
+        self.assertNoException(res)
+        self.assertIn("Found at offset", res)
+
+        cmd = "pattern search --period 8 $rbp"
         target = "/tmp/pattern.out"
         res = gdb_run_cmd(cmd, before=["set args aaaaaaaabaaaaaaacaaaaaaadaaaaaaa", "run"], target=target)
         self.assertNoException(res)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -324,12 +324,12 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         res = gdb_start_silent_cmd("print-format $rsp")
         self.assertNoException(res)
         self.assertTrue("buf = [" in res)
-        res = gdb_start_silent_cmd("print-format -f js $rsp")
+        res = gdb_start_silent_cmd("print-format --lang js $rsp")
         self.assertNoException(res)
         self.assertTrue("var buf = [" in res)
-        res = gdb_start_silent_cmd("print-format -f iDontExist $rsp")
+        res = gdb_start_silent_cmd("print-format --lang iDontExist $rsp")
         self.assertNoException(res)
-        self.assertTrue("Language must be :" in res)
+        self.assertTrue("Language must be in:" in res)
         return
 
     def test_cmd_process_status(self):
@@ -465,7 +465,7 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
         return
 
     def test_cmd_unicorn_emulate(self):
-        cmd = "emu -n 1"
+        cmd = "emu 10"
         res = gdb_run_cmd(cmd)
         self.assertFailIfInactiveSession(res)
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -249,11 +249,11 @@ class TestGefCommands(GefUnitTestGeneric): #pylint: disable=too-many-public-meth
 
     def test_cmd_keystone_assemble(self):
         valid_cmds = [
-            "assemble nop; xor eax, eax; int 0x80",
-            "assemble -a arm -m arm add r0, r1, r2",
-            "assemble -a mips -m mips32 add $v0, 1",
-            "assemble -a sparc -m sparc32  set 0, %o0",
-            "assemble -a arm64 -m little_endian add x29, sp, 0; mov  w0, 0; ret"
+            "assemble nop; xor eax, eax; syscall",
+            "assemble --arch arm   --mode arm add  r0, r1, r2",
+            "assemble --arch mips  --mode mips32   add $v0, 1",
+            "assemble --arch sparc --mode sparc32  set 0, %o0",
+            "assemble --arch arm64 --mode arm add x29, sp, 0; mov  w0, 0; ret"
         ]
         for cmd in valid_cmds:
             res = gdb_start_silent_cmd(cmd)


### PR DESCRIPTION

### Description/Motivation/Screenshots ###

Use `argparse` module to provide a lightweight way to parse command line arguments, instead of the hackish `getopt` we used so far.

This PR adds a new decorator, `@parse_arguments()` that takes 2 arguments: a `dict` of the required arguments, and another of optional non-positional arguments. Items of those `dict`s have the format `{ "argument_name" : default_value }`: the type expected is inferred from the default value (therefore avoid using `None`, for strings prefer `""`, for ints prefer `0`, etc.)

Positional (required) arguments also allow to pass a list of default values:

```python
@parse_arguments({"foo": ["bar", "baz"]}, {"--plop": 1})
def do_invoke()...
```

Note that the argparsing is optional, *but* if we use it we must change the signature of the decorated `do_invoke`. Doing so allows us to retrieve the parsed arguments in `kwargs["arguments"]` . It is done as such

```python
@parse_arguments({"foo": 1}, {"--bleh": ""})
def do_invoke(self, argv, *args, **kwargs):
  args = kwargs["arguments"]
  if args.foo == 1: ...
```

The only exception to the type inferrence comes for boolean values: doing 
```python
@parse_arguments({}, {"--plop": True})
def do_invoke()...
```
will **not** mean that `kwargs["arguments"] == True` by default : boolean behaves as `store_true` items for `argparse` . Therefore only their presence on the command line will set the value to True (meaning here, `args.plop` will be `False` by default, unless `mycmd --plop` is entered). The other way goes for `@parse_arguments({}, {"--plop": False})` with `store_false`.


This was done on purpose to not break the existing API for `do_invoke`, and therefore break internal or external gef commands.

This PR closes #659 (and also closes #658 by extension).

Cheers,

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |                                           |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_check_mark: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                           |

This is a pure Python change, I don't expect tests would go wrong on any other arch (still tested successfully aarch64 though).

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
