### PR TITLE
Restore selected frame after context_threads

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8233,6 +8233,7 @@ class ContextCommand(GenericCommand):
             return
 
         selected_thread = gdb.selected_thread()
+        selected_frame = gdb.selected_frame()
 
         for i, thread in enumerate(threads):
             line = """[{:s}] Id {:d}, """.format(Color.colorify("#{:d}".format(i), "bold green" if thread == selected_thread  else "bold pink"), thread.num)
@@ -8252,6 +8253,7 @@ class ContextCommand(GenericCommand):
             i += 1
 
         selected_thread.switch()
+        selected_frame.select()
         return
 
     def context_additional_information(self):


### PR DESCRIPTION
## Restore selected frame after context_threads ##

### Description/Motivation/Screenshots ###
Restore selected frame after switching threads in context_threads. 

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_check_mark: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [] My change includes a change to the documentation, if required.
- [] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
