### PR TITLE
Fix incorrect lru_cache usage

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1368,7 +1368,6 @@ def gef_next_instruction(addr):
     return gef_instruction_n(addr, 1)
 
 
-@lru_cache()
 def gef_disassemble(addr, nb_insn, nb_prev=0):
     """Disassemble `nb_insn` instructions after `addr` and `nb_prev` before `addr`.
     Return an iterator of Instruction objects."""
@@ -2699,9 +2698,13 @@ def to_unsigned_long(v):
     return int(v.cast(gdb.Value(mask).type)) & mask
 
 
-@lru_cache()
 def get_register(regname):
     """Return a register's value."""
+    return get_register_for_selected_frame(id(gdb.selected_frame()), regname)
+
+
+@lru_cache()
+def get_register_for_selected_frame(selected_frame_id, regname):
     try:
         value = gdb.parse_and_eval(regname)
         return to_unsigned_long(value) if value.type.code == gdb.TYPE_CODE_INT else int(value)


### PR DESCRIPTION
## Fix incorrect lru_cache usage ##

### Description/Motivation/Screenshots ###
- Removed `@lru_cache` for `gef_disassemble` since it returns generator and repetitive `context_code` shows empty code
- Added `get_register_for_selected_frame` to correctly cache register values depending on selected frame.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [] My change includes a change to the documentation, if required.
- [] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
