### PR TITLE
Fix context registers order

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7032,7 +7032,8 @@ class DetailRegistersCommand(GenericCommand):
 
         args = kwargs["arguments"]
         if args.registers and args.registers[0]:
-            valid_regs = list(set(current_arch.all_registers) & set(args.registers))
+            required_regs = set(args.registers)
+            valid_regs = [reg for reg in current_arch.all_registers if reg in required_regs]
             if valid_regs:
                 regs = valid_regs
 


### PR DESCRIPTION
## Fix context registers order ##

### Description/Motivation/Screenshots ###
Context registers order was broken
![regs_disorder](https://user-images.githubusercontent.com/5591440/123706055-72451980-d870-11eb-8af8-59a2cb3dc019.png)
Now it is fixed
![regs_order](https://user-images.githubusercontent.com/5591440/123706121-89840700-d870-11eb-8d74-9808554abce0.png)

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_check_mark: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [] My change includes a change to the documentation, if required.
- [] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
