### PR TITLE
x86-64: Preserve RCX and R11 when calling mprotect_asm (syscall)

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2098,13 +2098,25 @@ class X86_64(X86):
     @classmethod
     def mprotect_asm(cls, addr, size, perm):
         _NR_mprotect = 10
-        insns = ["push rax", "push rdi", "push rsi", "push rdx",
-                 "mov rax, {:d}".format(_NR_mprotect),
-                 "mov rdi, {:d}".format(addr),
-                 "mov rsi, {:d}".format(size),
-                 "mov rdx, {:d}".format(perm),
-                 "syscall",
-                 "pop rdx", "pop rsi", "pop rdi", "pop rax"]
+        insns = [
+            "push rax",
+            "push rdi",
+            "push rsi",
+            "push rdx",
+            "push rcx",
+            "push r11",
+            "mov rax, {:d}".format(_NR_mprotect),
+            "mov rdi, {:d}".format(addr),
+            "mov rsi, {:d}".format(size),
+            "mov rdx, {:d}".format(perm),
+            "syscall",
+            "pop r11",
+            "pop rcx",
+            "pop rdx",
+            "pop rsi",
+            "pop rdi",
+            "pop rax",
+        ]
         return "; ".join(insns)
 
 


### PR DESCRIPTION
## x86-64: Preserve RCX and R11 when calling mprotect_asm (syscall) ##
```
x86-64: Preserve RCX and R11 when calling mprotect_asm (syscall)

On x86-64, the syscall instruction will clobber RCX and R11. It uses
RCX to save the return address and uses R11 to save the RFLAGS.

This means we will lose our old RCX and R11 value after the syscall
returns to userspace.

Bug reproduction steps (see how RCX and R11 change):
  $ gdb any-program

  # Run it inside the GDB
  starti

  # Set RCX and R11 before set-permission
  p $rcx=0
  p $r11=0

  # Do mprotect syscall
  set-permission $sp

  # Now the value of RCX and R11 have changed
  p $rcx
  p $r11

This commit fixes the bug by preserving RCX and R11.

Signed-off-by: Ammar Faizi <ammarfaizi2@gmail.com>
```

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                           |
| x86-64       | :heavy_check_mark:       |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark:       |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
