### PR TITLE
search-pattern: Don't stop searching when read_memory fails

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -430,18 +430,19 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
         # Make sure set-permission command doesn't clobber any register
         before = [
-            "starti",
-            "si",
+            "gef config context.clear_screen False",
+            "gef config context.layout '-code -stack'",
+            "entry-break",
             "printf \"match_before\\n\"",
-            "info registers",
+            "info registers all",
             "printf \"match_before\\n\""
         ]
         after = [
             "printf \"match_after\\n\"",
-            "info registers",
+            "info registers all",
             "printf \"match_after\\n\""
         ]
-        res = gdb_start_silent_cmd("set-permission $sp", before=before, after=after, target=target)
+        res = gdb_run_cmd("set-permission $sp", before=before, after=after, target=target)
         regs_before = re.match(r"(?:.*match_before)(.+)(?:match_before.*)", res, flags=re.DOTALL)[1]
         regs_after = re.match(r"(?:.*match_after)(.+)(?:match_after.*)", res, flags=re.DOTALL)[1]
         self.assertEqual(regs_before, regs_after)


### PR DESCRIPTION
## search-pattern: Don't stop searching when read_memory fails
```
Komori Kuzuyu <komori.kzy@gmail.com> wrote:
> search-pattern command stop finding string pattern after error "Cannot
> access memory at address xxxxxxxxxxxx". Checking /proc/$pid/maps the
> address mentioned in error is readable but cannot be read from gdb.
>
> The memory is a mapped file to /dev/dri/renderD128
>

Do not assume virtual memory that has read bit is always directly
readable from userspace. We have a special case where /proc/$pid/maps
shows virtual memory address with a read bit, but it cannot be read from
the GDB.

This commit adds an exception handler for read_memory on search-pattern
command when such a special case occurs.

Before this commit, the search-pattern command stops when it meets the
above case (unhandled exception).

After this commit, the search-pattern command continues the scan when
read_memory fails. We still of course, show the error message indicates
that the read_memory fails.

The special case after this commit looks like this:
    gef➤  search-pattern "However"
    [+] Searching 'However' in memory
    [+] In '/usr/lib/x86_64-linux-gnu/dri/radeonsi_dri.so'(0x7fffe5576000-0x7fffe59b6000), permission=r--
      0x7fffe55f8ec6 - 0x7fffe55f8efd  →   "However, if the abstract value is too large, the o[...]"
      0x7fffe55ff01b - 0x7fffe55ff052  →   "However, if the abstract value is too large, the o[...]"
    [!] Cannot access memory at address 0x7fffeb00b000
    [!] Cannot access memory at address 0x7fffeb0d4000
    [!] Cannot access memory at address 0x7fffef49f000
    [+] In '/usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.0.9'(0x7ffff72ab000-0x7ffff72ca000), permission=r--
      0x7ffff72bb287 - 0x7ffff72bb2be  →   "However, compositionclear:both;cooperationwithin t[...]"
      0x7ffff72bd4ae - 0x7ffff72bd4e5  →   "However, inprogrammersat least inapproximatealthou[...]"
      0x7ffff72bd834 - 0x7ffff72bd867  →   "However thelead to the\t<a href="/was grantedpeople"
      0x7ffff72be10f - 0x7ffff72be146  →   "However, intelligence" tabindex="float:right;Commo[...]"
      0x7ffff72c1c99 - 0x7ffff72c1cd0  →   "However, the An example ofcompared withquantities [...]"
      0x7ffff72c1f4a - 0x7ffff72c1f81  →   "However, thisDepartment ofthe remainingeffect on t[...]"
      0x7ffff72c2451 - 0x7ffff72c2488  →   "However, manythe presidentHowever, someis thought [...]"
      0x7ffff72c246b - 0x7ffff72c24a2  →   "However, someis thought tountil the endwas announc[...]"
      0x7ffff72c2ff8 - 0x7ffff72c302a  →   "However, theand eventuallyAt the end of because of"
      0x7ffff72c3c36 - 0x7ffff72c3c6d  →   "However, it isbecame part ofin relation topopular [...]"
      0x7ffff72c66da - 0x7ffff72c670c  →   "However, there aresrc="http://staticsuggested that"
      0x7ffff72c6c32 - 0x7ffff72c6c69  →   "However, since the/div>\n</div>\n<div left; margin[...]"
    gef➤

Fixes: https://github.com/hugsy/gef/issues/674
Reported-by: Komori Kuzuyu <komori.kzy@gmail.com>
Signed-off-by: Ammar Faizi <ammarfaizi2@gmail.com>
Signed-off-by: Komori Kuzuyu <komori.kzy@gmail.com>
```

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                           |
| x86-64       | :heavy_check_mark:       |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark:       |                                           |

### Checklist ###
<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.

Fixes: https://github.com/hugsy/gef/issues/674
