### PR TITLE
deref: added option to use reference address for offset calculation

### DIFF
--- a/docs/commands/dereference.md
+++ b/docs/commands/dereference.md
@@ -7,9 +7,9 @@ actually points to.
 It is a useful convienence function to spare to process of manually tracking
 values with successive `x/x` in GDB.
 
-`dereference` takes two optional arguments, an address (or symbol or register, etc)
-to dereference (by default, `$sp`) and the number of consecutive addresses to
-dereference (by default, `10`):
+`dereference` takes three optional arguments, an start address (or symbol or register, etc)
+to dereference (by default, `$sp`) , the number of consecutive addresses to
+dereference (by default, `10`) and the base location for offset calculation(by default the same as the start address):
 
 ```
 gef➤  dereference
@@ -54,4 +54,17 @@ gef➤  dereference 5
 0x00007fffffffe180│+0x0010: 0x00007fffffffe270  →  0x1
 0x00007fffffffe188│+0x0018: 0x1
 0x00007fffffffe190│+0x0020: 0x0000000000400690  →  push r15        ← $rbp
+```
+
+It is possible to change the offset calculation to use a different address then the start address:
+
+```
+gef➤  dereference $sp l7 r$rbp
+0x00007ffe6ddaa3e0│-0x0030: 0x0000000000000000    ← $rsp
+0x00007ffe6ddaa3e8│-0x0028: 0x0000000000400970  →  <__libc_csu_init+0> push r15
+0x00007ffe6ddaa3f0│-0x0020: 0x0000000000000000
+0x00007ffe6ddaa3f8│-0x0018: 0x00000000004006e0  →  <_start+0> xor ebp, ebp
+0x00007ffe6ddaa400│-0x0010: 0x00007ffe6ddaa500  →  0x0000000000000001
+0x00007ffe6ddaa408│-0x0008: 0xa42456b3ee465800
+0x00007ffe6ddaa410│+0x0000: 0x0000000000000000    ← $rbp
 ```

--- a/docs/commands/dereference.md
+++ b/docs/commands/dereference.md
@@ -10,7 +10,7 @@ values with successive `x/x` in GDB.
 `dereference` takes three optional arguments, a start address (or symbol or 
 register, etc) to dereference (by default, `$sp`), the number of consecutive 
 addresses to dereference (by default, `10`) and the base location for offset 
-calculation(by default the same as the start address):
+calculation (by default the same as the start address):
 
 ```
 gef➤  dereference

--- a/docs/commands/dereference.md
+++ b/docs/commands/dereference.md
@@ -7,9 +7,9 @@ actually points to.
 It is a useful convienence function to spare to process of manually tracking
 values with successive `x/x` in GDB.
 
-`dereference` takes three optional arguments, a start address (or symbol or 
-register, etc) to dereference (by default, `$sp`), the number of consecutive 
-addresses to dereference (by default, `10`) and the base location for offset 
+`dereference` takes three optional arguments, a start address (or symbol or
+register, etc) to dereference (by default, `$sp`), the number of consecutive
+addresses to dereference (by default, `10`) and the base location for offset
 calculation (by default the same as the start address):
 
 ```

--- a/docs/commands/dereference.md
+++ b/docs/commands/dereference.md
@@ -7,9 +7,10 @@ actually points to.
 It is a useful convienence function to spare to process of manually tracking
 values with successive `x/x` in GDB.
 
-`dereference` takes three optional arguments, an start address (or symbol or register, etc)
-to dereference (by default, `$sp`) , the number of consecutive addresses to
-dereference (by default, `10`) and the base location for offset calculation(by default the same as the start address):
+`dereference` takes three optional arguments, a start address (or symbol or 
+register, etc) to dereference (by default, `$sp`), the number of consecutive 
+addresses to dereference (by default, `10`) and the base location for offset 
+calculation(by default the same as the start address):
 
 ```
 gef➤  dereference
@@ -56,7 +57,8 @@ gef➤  dereference 5
 0x00007fffffffe190│+0x0020: 0x0000000000400690  →  push r15        ← $rbp
 ```
 
-It is possible to change the offset calculation to use a different address then the start address:
+It is possible to change the offset calculation to use a different address than
+the start address:
 
 ```
 gef➤  dereference $sp l7 r$rbp

--- a/gef.py
+++ b/gef.py
@@ -8864,7 +8864,7 @@ class DereferenceCommand(GenericCommand):
 
         ref_addr = int(ref_addr)
         if process_lookup_address(ref_addr) is None:
-            err("Unmapped address: '{}'".format(ref_addr))
+            err("Unmapped address: '{}'".format(reference))
             return
 
         if get_gef_setting("context.grow_stack_down") is True:

--- a/gef.py
+++ b/gef.py
@@ -8864,7 +8864,7 @@ class DereferenceCommand(GenericCommand):
 
         ref_addr = int(ref_addr)
         if process_lookup_address(ref_addr) is None:
-            err("Unmapped address: reference")
+            err("Unmapped address: '{}'".format(ref_addr))
             return
 
         if get_gef_setting("context.grow_stack_down") is True:

--- a/gef.py
+++ b/gef.py
@@ -8859,12 +8859,12 @@ class DereferenceCommand(GenericCommand):
 
         ref_addr = safe_parse_and_eval(reference)
         if ref_addr is None:
-            err("Invalid reference")
+            err("Invalid address: reference")
             return
 
         ref_addr = int(ref_addr)
         if process_lookup_address(ref_addr) is None:
-            err("Unmapped reference")
+            err("Unmapped address: reference")
             return
 
         if get_gef_setting("context.grow_stack_down") is True:
@@ -8878,7 +8878,7 @@ class DereferenceCommand(GenericCommand):
 
         start_address = align_address(addr)
         ref_address = align_address(ref_addr)
-        base_offset = start_address-ref_address
+        base_offset = start_address - ref_address
 
         for i in range(from_insnum, to_insnum, insnum_step):
             gef_print(DereferenceCommand.pprint_dereferenced(start_address, i, base_offset))

--- a/gef.py
+++ b/gef.py
@@ -8857,9 +8857,14 @@ class DereferenceCommand(GenericCommand):
             err("Unmapped address")
             return
 
-        ref_addr = int(safe_parse_and_eval(reference))
+        ref_addr = safe_parse_and_eval(reference)
         if ref_addr is None:
             err("Invalid address: '{}'".format(reference))
+            return
+
+        ref_addr = int(ref_addr)
+        if process_lookup_address(ref_addr) is None:
+            err("Unmapped address: reference")
             return
 
         if get_gef_setting("context.grow_stack_down") is True:

--- a/gef.py
+++ b/gef.py
@@ -8872,8 +8872,7 @@ class DereferenceCommand(GenericCommand):
             insnum_step = 1
 
         start_address = align_address(addr)
-        ref_address = align_address(ref_addr)
-        base_offset = start_address - ref_address
+        base_offset = start_address - align_address(ref_addr)
 
         for i in range(from_insnum, to_insnum, insnum_step):
             gef_print(DereferenceCommand.pprint_dereferenced(start_address, i, base_offset))

--- a/gef.py
+++ b/gef.py
@@ -8810,7 +8810,7 @@ class DereferenceCommand(GenericCommand):
         addrs = dereference_from(current_address)
         l = ""
         addr_l = format_address(int(addrs[0], 16))
-        l += "{:s}{:s}{:+#06x}: {:{ma}s}".format(Color.colorify(addr_l, base_address_color),
+        l += "{:s}{:s}{:+#07x}: {:{ma}s}".format(Color.colorify(addr_l, base_address_color),
                                                  VERTICAL_LINE, base_offset+offset,
                                                  sep.join(addrs[1:]), ma=(memalign*2 + 2))
 

--- a/gef.py
+++ b/gef.py
@@ -8857,14 +8857,9 @@ class DereferenceCommand(GenericCommand):
             err("Unmapped address")
             return
 
-        ref_addr = safe_parse_and_eval(reference)
+        ref_addr = int(safe_parse_and_eval(reference))
         if ref_addr is None:
             err("Invalid address: '{}'".format(reference))
-            return
-
-        ref_addr = int(ref_addr)
-        if process_lookup_address(ref_addr) is None:
-            err("Unmapped address: reference")
             return
 
         if get_gef_setting("context.grow_stack_down") is True:

--- a/gef.py
+++ b/gef.py
@@ -8859,7 +8859,7 @@ class DereferenceCommand(GenericCommand):
 
         ref_addr = safe_parse_and_eval(reference)
         if ref_addr is None:
-            err("Invalid address: reference")
+            err("Invalid address: '{}'".format(reference))
             return
 
         ref_addr = int(ref_addr)


### PR DESCRIPTION
## Added Option for custom offset calculations for `deref` command ##

### Description/Motivation/Screenshots ###

This patch allows to set a different base address for offset calculation for the `dereference` command while not breaking previous usage. This allows quicker identification of relevant memory addresses in some cases. A common use case is using `ebp`/`rbp` as a reference on the stack in `x86` architecture (see e.g the very old issue #67): That way `gef`s `dereference` command output can e.g. be compared easier to most, if not all, disassembler and decompiler outputs for stack variables.

This is how the new usage looks like:
```sh
gef> dereference $rsp l7 r$rbp
0x00007ffe6ddaa3e0│-0x0030: 0x0000000000000000    ← $rsp
0x00007ffe6ddaa3e8│-0x0028: 0x0000000000400970  →  <__libc_csu_init+0> push r15
0x00007ffe6ddaa3f0│-0x0020: 0x0000000000000000
0x00007ffe6ddaa3f8│-0x0018: 0x00000000004006e0  →  <_start+0> xor ebp, ebp
0x00007ffe6ddaa400│-0x0010: 0x00007ffe6ddaa500  →  0x0000000000000001
0x00007ffe6ddaa408│-0x0008: 0xa42456b3ee465800
0x00007ffe6ddaa410│+0x0000: 0x0000000000000000    ← $rbp
```

The new offset reference starts with a `r`-prefix followed by a `LOCATION`.

Technically the patch just adds an reference argument to the `dereference` command that is used to calculate the difference to the start_address and this difference is added/subtracted to the outputted offset.


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                      |
| x86-64       | :heavy_check_mark: |  manual testing of the new feature                  |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_multiplication_x: |                                           |

No testing has been done because no other features of `gef` have been touched and also the new base address is an optional argument to `pprint_dereferenced()`.

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate. (IMO no additional tests necessary but I can still do that if needed?)
- [x] I have read and agree to the **CONTRIBUTING** document.

EDIT:
An important change to the earlier version in terms of having offsets on the stack reference `rbp`/`ebp` is that now also negative offsets are possible as usual with disassemblers/decompilers as well. Also the command can be used in other places than the stack and is not tied to the architecture (as it would be in the solution suggested in the above linked issue)