### PR TITLE
fix python executable version in unicorn-emulate

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -125,10 +125,6 @@ to install:
 For a quick installation, simply use the `pip` packaged version:
 
 ```bash
-# for Python2.x
-$ pip2 install capstone unicorn keystone-engine ropper
-
-# for Python3.x
 $ pip3 install capstone unicorn keystone-engine ropper
 ```
 

--- a/gef.py
+++ b/gef.py
@@ -5960,8 +5960,6 @@ def set_fs(uc, addr):    return set_msr(uc, FSMSR, addr)
     set_gs(emu, SEGMENT_GS_ADDR)
 """
 
-        pythonbin = which("python3")
-
         content = """#!{pythonbin} -i
 #
 # Emulation script for "{fname}" from {start:#x} to {end:#x}
@@ -6016,7 +6014,7 @@ def reset():
     emu = unicorn.Uc({arch}, {mode})
 
 {context_block}
-""".format(pythonbin=pythonbin, fname=fname, start=start_insn_addr, end=end_insn_addr,
+""".format(pythonbin=PYTHONBIN, fname=fname, start=start_insn_addr, end=end_insn_addr,
            regs=",".join(["'%s': %s" % (k.strip(), unicorn_registers[k]) for k in unicorn_registers]),
            verbose="True" if verbose else "False",
            syscall_reg=current_arch.syscall_register,
@@ -6105,8 +6103,7 @@ emulate(uc, {start:#x}, {end:#x})
 
         ok("Starting emulation: {:#x} {} {:#x}".format(start_insn_addr, RIGHT_ARROW, end_insn_addr))
 
-        pythonbin = which("python3")
-        res = gef_execute_external([pythonbin, tmp_filename], as_list=True)
+        res = gef_execute_external([PYTHONBIN, tmp_filename], as_list=True)
         gef_print("\n".join(res))
 
         if not kwargs.get("to_file", None):
@@ -10681,11 +10678,11 @@ if __name__ == "__main__":
         # In order to fix it, from the shell with venv activated we run the python binary,
         # take and parse its path, add the path to the current python process using sys.path.extend
 
-        pythonbin = which("python3")
-        PREFIX = gef_pystring(subprocess.check_output([pythonbin, '-c', 'import os, sys;print((sys.prefix))'])).strip("\\n")
+        PYTHONBIN = which("python3")
+        PREFIX = gef_pystring(subprocess.check_output([PYTHONBIN, '-c', 'import os, sys;print((sys.prefix))'])).strip("\\n")
         if PREFIX != sys.base_prefix:
             SITE_PACKAGES_DIRS = subprocess.check_output(
-                [pythonbin, "-c", "import os, sys;print(os.linesep.join(sys.path).strip())"]).decode("utf-8").split()
+                [PYTHONBIN, "-c", "import os, sys;print(os.linesep.join(sys.path).strip())"]).decode("utf-8").split()
             sys.path.extend(SITE_PACKAGES_DIRS)
 
         # setup prompt

--- a/gef.py
+++ b/gef.py
@@ -5960,7 +5960,7 @@ def set_fs(uc, addr):    return set_msr(uc, FSMSR, addr)
     set_gs(emu, SEGMENT_GS_ADDR)
 """
 
-        pythonbin = which("python")
+        pythonbin = which("python3")
 
         content = """#!{pythonbin} -i
 #
@@ -6105,7 +6105,7 @@ emulate(uc, {start:#x}, {end:#x})
 
         ok("Starting emulation: {:#x} {} {:#x}".format(start_insn_addr, RIGHT_ARROW, end_insn_addr))
 
-        pythonbin = which("python")
+        pythonbin = which("python3")
         res = gef_execute_external([pythonbin, tmp_filename], as_list=True)
         gef_print("\n".join(res))
 


### PR DESCRIPTION
## fix python executable version in unicorn-emulate ##

### Description/Motivation/Screenshots ###

Changes `which("python")` to `which("python3")` in the `UnicornEmulateCommand`.

This is required on some Distros to work correctly.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                  |
| x86-64       | :heavy_check_mark: |  quick manual testing       |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: |   note: it is actually `make test` and not `make tests`     |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required. (not required!)
- [x] My change adds tests as appropriate. (not needed)
- [x] I have read and agree to the **CONTRIBUTING** document.

EDIT:
referencing #677