### PR TITLE
add onegadget plugin to gef

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,6 +34,7 @@ improve it.
 |ksymaddr                  | Solve kernel symbols from kallsyms table.|
 |memory                    | Add memory watches to the context view.|
 |nop                       | Patch the instruction pointed by parameters with NOP. If the return option is specified, it will set the return register to the specific value.|
+|onegadget                 | one gadget (<https://github.com/david942j/one_gadget>) plugin |
 |patch                     | Write specified values to the specified address.|
 |pattern                   | This command will create or search a De Bruijn cyclic pattern to facilitate determining the offset in memory. The algorithm used is the same as the one used by pwntools, and can therefore be used in conjunction.|
 |pcustom                   | Dump user defined structure. This command attempts to reproduce WinDBG awesome `dt` command for GDB and allows to apply structures (from symbols or custom) directly to an address. Custom structures can be defined in pure Python using ctypes, and should be stored in a specific directory, whose path must be stored in the `pcustom.struct_path` configuration setting. (alias: dt)|

--- a/docs/commands/onegadget.md
+++ b/docs/commands/onegadget.md
@@ -1,0 +1,77 @@
+## Command onegadget
+
+`one_gadget` is a gadget finding tool, easily installable via `gem`. It finds
+single gadgets in the libc to spawn a shell without the need to chain multiple
+ROP gadgets.
+
+```
+gef➤ onegadget
+```
+
+```
+0xe6c7e execve("/bin/sh", r15, r12)
+constraints:
+  [r15] == NULL || r15 == NULL
+  [r12] == NULL || r12 == NULL
+
+0xe6c81 execve("/bin/sh", r15, rdx)
+constraints:
+  [r15] == NULL || r15 == NULL
+  [rdx] == NULL || rdx == NULL
+
+0xe6c84 execve("/bin/sh", rsi, rdx)
+constraints:
+  [rsi] == NULL || rsi == NULL
+  [rdx] == NULL || rdx == NULL
+
+0xe6e73 execve("/bin/sh", r10, r12)
+constraints:
+  address rbp-0x78 is writable
+  [r10] == NULL || r10 == NULL
+  [r12] == NULL || r12 == NULL
+
+0xe6e76 execve("/bin/sh", r10, rdx)
+constraints:
+  address rbp-0x78 is writable
+  [r10] == NULL || r10 == NULL
+  [rdx] == NULL || rdx == NULL
+```
+
+The offsets in the above output are relative to the beginning of libc. They
+can also be rebased to fit the currently loaded libc:
+
+```
+gef➤ onegadget rebase
+```
+
+```
+0x7ffff7e8bc7e execve("/bin/sh", r15, r12)
+constraints:
+  [r15] == NULL || r15 == NULL
+  [r12] == NULL || r12 == NULL
+
+0x7ffff7e8bc81 execve("/bin/sh", r15, rdx)
+constraints:
+  [r15] == NULL || r15 == NULL
+  [rdx] == NULL || rdx == NULL
+
+0x7ffff7e8bc84 execve("/bin/sh", rsi, rdx)
+constraints:
+  [rsi] == NULL || rsi == NULL
+  [rdx] == NULL || rdx == NULL
+
+0x7ffff7e8be73 execve("/bin/sh", r10, r12)
+constraints:
+  address rbp-0x78 is writable
+  [r10] == NULL || r10 == NULL
+  [r12] == NULL || r12 == NULL
+
+0x7ffff7e8be76 execve("/bin/sh", r10, rdx)
+constraints:
+  address rbp-0x78 is writable
+  [r10] == NULL || r10 == NULL
+  [rdx] == NULL || rdx == NULL
+```
+
+Have in mind that these rebased addresses can change between executions if
+the executable has randomization features enabled.

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,6 +120,7 @@ to install:
 - [`keystone`](https://github.com/keystone-engine/keystone)
 - [`unicorn`](https://github.com/unicorn-engine/unicorn)
 - [`Ropper`](https://github.com/sashs/ropper)
+- [`one_gadget`](https://github.com/david942j/one_gadget)
 
 
 For a quick installation, simply use the `pip` packaged version:
@@ -137,6 +138,13 @@ your GDB was compiled with. If you are experiencing issues installing them,
 post an issue on the GitHub of the respective projects. If your bug is not
 related to `GEF`, you will not get an answer.
 
+For `one_gadget` the Ruby language has to be installed on the machine. The
+recommended installation method is to use the package manager of your
+distribution. Then install `one_gadget like this:
+
+```bash
+gem install one_gadget
+```
 
 ## Additional commands ##
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -392,6 +392,14 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertTrue(len(res.splitlines()) > 2)
         return
 
+    def test_cmd_onegadget(self):
+        cmd = "onegadget"
+        res = gdb_run_silent_cmd(cmd)
+        self.assertFailIfInactiveSession(res)
+        self.assertNoException(res)
+        self.assertTrue(len(res.splitlines()) > 2)
+        return
+
     def test_cmd_scan(self):
         cmd = "scan libc stack"
         target = "/tmp/checksec-no-pie.out"


### PR DESCRIPTION
## add onegadget plugin to gef ##

### Description/Motivation/Screenshots ###

One of the features from `bata24/gef` repository referenced in issue #667 with some small adjustments and including tests and documentation.

This patch adds the new `one_gadget` feature directly to `gef`. It searches the dynamically linked `libc` for single gadgets that spawn a shell without the need to craft a whole rop gadget chain. As an additional feature the found gadgets can directly be rebased to fit the memory addresses of the currently loaded `libc`.

Including this plugin makes exploit development more comfortable - similar to the inclusion of `ropper` into `gef`.

#### Example Usage ####

```
gef➤ onegadget rebase
```

```
0x7ffff7e8bc7e execve("/bin/sh", r15, r12)
constraints:
  [r15] == NULL || r15 == NULL
  [r12] == NULL || r12 == NULL

0x7ffff7e8bc81 execve("/bin/sh", r15, rdx)
constraints:
  [r15] == NULL || r15 == NULL
  [rdx] == NULL || rdx == NULL

0x7ffff7e8bc84 execve("/bin/sh", rsi, rdx)
constraints:
  [rsi] == NULL || rsi == NULL
  [rdx] == NULL || rdx == NULL

0x7ffff7e8be73 execve("/bin/sh", r10, r12)
constraints:
  address rbp-0x78 is writable
  [r10] == NULL || r10 == NULL
  [r12] == NULL || r12 == NULL

0x7ffff7e8be76 execve("/bin/sh", r10, rdx)
constraints:
  address rbp-0x78 is writable
  [r10] == NULL || r10 == NULL
  [rdx] == NULL || rdx == NULL
```



### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |    |
| x86-64       | :heavy_check_mark: | manual testing                                          |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark:  | note: it's actually `make test` and not `make tests` ||

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.

### Credits ###

Credits for `one_gadget` plugin to @bata24.
