### PR TITLE
Fixed: `memory watch` uses new argparse syntax of `hexdump` cmd

### DIFF
--- a/docs/commands/hexdump.md
+++ b/docs/commands/hexdump.md
@@ -22,7 +22,7 @@ is printable (similarly to the `hexdump -C` command on Linux).
 The syntax is as following:
 
 ```
-hexdump [qword|dword|word|byte] [LOCATION] [[L][SIZE]] [REVERSE]
+hexdump [qword|dword|word|byte] [LOCATION] [--size SIZE] [--reverse]
 ```
 
 Examples:
@@ -30,7 +30,7 @@ Examples:
    * Display 4 QWORD from `$pc`:
 
 ```
-gef➤  dq $pc l4
+gef➤  dq $pc --size 4
 0x7ffff7a5c1c0+0000 │ 0x4855544155415641
 0x7ffff7a5c1c0+0008 │ 0x0090ec814853cd89
 0x7ffff7a5c1c0+0010 │ 0x377d6f058b480000
@@ -40,14 +40,14 @@ gef➤  dq $pc l4
   * Display 32 bytes from a location in the stack:
 
 ```
-gef➤  db 0x00007fffffffe5e5 l32
+gef➤  db 0x00007fffffffe5e5 --size 32
 0x00007fffffffe5e5     2f 68 6f 6d 65 2f 68 75 67 73 79 2f 63 6f 64 65     /home/hugsy/code
 0x00007fffffffe5f5     2f 67 65 66 2f 74 65 73 74 73 2f 77 69 6e 00 41     /gef/tests/win.A
 ```
 
   * Display 8 WORD from `$sp` in reverse order:
 ```
-gef➤  dw 8 r
+gef➤  dw 8 --reverse
 0x00007fffffffe0ee│+0x000e   0x0000   
 0x00007fffffffe0ec│+0x000c   0x7fff   
 0x00007fffffffe0ea│+0x000a   0xffff   

--- a/docs/commands/hexdump.md
+++ b/docs/commands/hexdump.md
@@ -22,7 +22,7 @@ is printable (similarly to the `hexdump -C` command on Linux).
 The syntax is as following:
 
 ```
-hexdump [qword|dword|word|byte] [LOCATION] [--size SIZE] [--reverse]
+hexdump (qword|dword|word|byte) [LOCATION] [--size SIZE] [--reverse]
 ```
 
 Examples:

--- a/gef.py
+++ b/gef.py
@@ -8473,7 +8473,7 @@ class HexdumpCommand(GenericCommand):
     """Display SIZE lines of hexdump from the memory location pointed by LOCATION."""
 
     _cmdline_ = "hexdump"
-    _syntax_  = "{:s} [WORD_LENGTH] [LOCATION] [--size SIZE] [--reverse]".format(_cmdline_)
+    _syntax_  = "{:s} (qword|dword|word|byte) [LOCATION] [--size SIZE] [--reverse]".format(_cmdline_)
     _example_ = "{:s} byte $rsp --size 16 --reverse".format(_cmdline_)
 
     def __init__(self):

--- a/gef.py
+++ b/gef.py
@@ -8330,7 +8330,7 @@ class ContextCommand(GenericCommand):
                     size=sz,
                 ))
             else:
-                gdb.execute("hexdump {fmt:s} 0x{address:x} {size:d}".format(
+                gdb.execute("hexdump {fmt:s} 0x{address:x} -s {size:d}".format(
                     address=address,
                     size=sz,
                     fmt=fmt,
@@ -8470,11 +8470,11 @@ class MemoryWatchListCommand(GenericCommand):
 
 @register_command
 class HexdumpCommand(GenericCommand):
-    """Display SIZE lines of hexdump from the memory location pointed by ADDRESS."""
+    """Display SIZE lines of hexdump from the memory location pointed by LOCATION."""
 
     _cmdline_ = "hexdump"
-    _syntax_  = "{:s} [ADDRESS] [[L][SIZE]] [REVERSE]".format(_cmdline_)
-    _example_ = "{:s} byte $rsp L16 REVERSE".format(_cmdline_)
+    _syntax_  = "{:s} [WORD_LENGTH] [LOCATION] [--size SIZE] [--reverse]".format(_cmdline_)
+    _example_ = "{:s} byte $rsp --size 16 --reverse".format(_cmdline_)
 
     def __init__(self):
         super().__init__(complete=gdb.COMPLETE_LOCATION, prefix=True)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -247,6 +247,36 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertNoException(res)
         return
 
+    def test_cmd_memory_watch(self):
+        self.assertFailIfInactiveSession(gdb_run_cmd("memory watch $pc"))
+        res = gdb_start_silent_cmd("memory watch $pc 0x100 byte")
+        self.assertNoException(res)
+        res = gdb_start_silent_cmd("memory watch $pc 0x40 word")
+        self.assertNoException(res)
+        res = gdb_start_silent_cmd("memory watch $pc 0x30 dword")
+        self.assertNoException(res)
+        res = gdb_start_silent_cmd("memory watch $pc 0x20 qword")
+        self.assertNoException(res)
+        res = gdb_start_silent_cmd("memory watch $pc 0x8 pointers")
+        self.assertNoException(res)
+        res = gdb_start_silent_cmd("memory watch $pc")
+        self.assertNoException(res)
+
+    def test_cmd_memory_unwatch(self):
+        self.assertFailIfInactiveSession(gdb_run_cmd("memory unwatch $pc"))
+        res = gdb_start_silent_cmd("memory unwatch $pc")
+        self.assertNoException(res)
+
+    def test_cmd_memory_list(self):
+        self.assertFailIfInactiveSession(gdb_run_cmd("memory list"))
+        res = gdb_start_silent_cmd("memory list")
+        self.assertNoException(res)
+
+    def test_cmd_memory_reset(self):
+        self.assertFailIfInactiveSession(gdb_run_cmd("memory reset"))
+        res = gdb_start_silent_cmd("memory reset")
+        self.assertNoException(res)
+
     def test_cmd_keystone_assemble(self):
         valid_cmds = [
             "assemble nop; xor eax, eax; syscall",


### PR DESCRIPTION
## Fixed: `memory watch` uses new argparse syntax of `hexdump` cmd ##

### Description/Motivation/Screenshots ###

see #681

`memory watch` now uses the new argparse syntax of `hexdump`. Also fixed related `hexdump` usage instructions and documentation and added test to check for exceptions with the `memory` commands.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       |:heavy_check_mark:  |  |
| x86-64       |:heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make tests` | :heavy_check_mark: | note: its `make test` and not `make tests`, the template should be fixed                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
