### PR TITLE
Fix heap commands when the glibc arena has not set all expected members

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -750,12 +750,14 @@ class GlibcArena:
         except:
             self.__arena = MallocStateStruct(addr)
             self.__addr = self.__arena.addr
-        finally:
+        try:
             self.top             = int(self.top)
             self.last_remainder  = int(self.last_remainder)
             self.n               = int(self.next)
             self.nfree           = int(self.next_free)
             self.sysmem          = int(self.system_mem)
+        except gdb.error as e:
+            err("Glibc arena: {}".format(e))
         return
 
     def __getitem__(self, item):


### PR DESCRIPTION
## Fix heap commands when the glibc arena has not set all expected members ##

### Description/Motivation/Screenshots ###

see #646

We probably should add tests that make sure ignoring some members of the heap arena does not cause other issues. This should be done before merging. 

Also the now displayed error message might not be the best? It is
```bash
[!] Glibc arena: There is no member named next_free.
```

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test` | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
