### PR TITLE
memory watch unit tests for checking memory content

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8495,15 +8495,16 @@ class HexdumpCommand(GenericCommand):
 
         args = kwargs["arguments"]
         target = args.address or self.__last_target
-        read_len = args.size or 0x40 if self.format == "byte" else 0x10
         start_addr = to_unsigned_long(gdb.parse_and_eval(target))
         read_from = align_address(start_addr)
 
         if self.format == "byte":
+            read_len = args.size or 0x40
             read_from += self.repeat_count * read_len
             mem = read_memory(read_from, read_len)
             lines = hexdump(mem, base=read_from).splitlines()
         else:
+            read_len = args.size or 0x10
             lines = self._hexdump(read_from, read_len, self.format, self.repeat_count * read_len)
 
         if args.reverse:

--- a/tests/binaries/memwatch.c
+++ b/tests/binaries/memwatch.c
@@ -1,0 +1,11 @@
+#include<stdio.h>
+
+int myglobal = 1;
+
+int main() {
+    // breakpoints hardcoded for convenience
+    asm("int3");
+    scanf("%d", &myglobal);
+    asm("int3");
+    return 0;
+}

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -261,6 +261,17 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertNoException(res)
         res = gdb_start_silent_cmd("memory watch $pc")
         self.assertNoException(res)
+        target = "/tmp/memwatch.out"
+        res = gdb_run_cmd("memory watch &myglobal",
+                before=["gef config context.layout 'memory'", "r <<< $((0xdeadbeef))"],
+                after=["c", "q"], target=target)
+        self.assertIn("deadbeef", res)
+        self.assertNotIn("cafebabe", res)
+        res = gdb_run_cmd("memory watch &myglobal",
+                before=["gef config context.layout 'memory'", "r <<< $((0xcafebabe))"],
+                after=["c", "q"], target=target)
+        self.assertIn("cafebabe", res)
+        self.assertNotIn("deadbeef", res)
 
     def test_cmd_memory_unwatch(self):
         self.assertFailIfInactiveSession(gdb_run_cmd("memory unwatch $pc"))


### PR DESCRIPTION
## memory watch unit tests for checking memory content ##

### Description/Motivation/Screenshots ###

see  #687

This is an idea for `memory watch` unit tests that check the actual content of the memory.  The `memwatch.c` file could also be used to unit test memory for other commands such as `deref` and `hexdump`. It reads in an integer from stdin to a global variable. Before and after the write breakpoints are hardcoded as assembly instructions for convenience. The first one e.g. while setting the unit test up and the second one to check the result of the write.

I added two tests: 
1. write `0xdeadbeef` and check for it at the variables memory address (and check that `0xcafebabe` is not found)
2. write `0xcafebabe` and check for it at the variables memory address (and check that `0xdeadbeef` is not found)

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |     |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test` | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
