### PR TITLE
Fix capstone-disassemble command and documentation

### DIFF
--- a/docs/commands/capstone-disassemble.md
+++ b/docs/commands/capstone-disassemble.md
@@ -9,22 +9,18 @@ You can use its alias `cs-disassemble` or just `cs` with the location to
 disassemble at. If not specified, it will use `$pc`.
 
 ```
-gef➤ cs main
+gef➤ cs main+0x10
 ```
 
-![cs-disassemble](https://i.imgur.com/wypt7Fo.png)
+![cs-disassemble](https://i.imgur.com/JG7aVRP.png)
 
 Disassemble more instructions
-```
-gef➤ cs length=20
-```
 
-Show instructions before $pc
 ```
-gef➤ cs nb_prev=3
+gef➤ cs --length 20
 ```
 
 Show opcodes next to disassembly
 ```
-gef➤ cs op
+gef➤ cs --show-opcodes
 ```

--- a/gef.py
+++ b/gef.py
@@ -3621,9 +3621,10 @@ def parse_string_range(s):
 
 @lru_cache()
 def gef_get_auxiliary_values():
-    """Retrieves the ELF auxiliary values of the current execution. This information is provided by
-    the operating system to transfer some kernel level information to the user process. Returns
-    None if not found, or a dict() of values as: {aux_vect_name: int(aux_vect_value)}."""
+    """Retrieve the ELF auxiliary values of the current execution. This
+    information is provided by the operating system to transfer some kernel
+    level information to the user process. Return None if not found, or a
+    dict() of values as: {aux_vect_name: int(aux_vect_value)}."""
     if not is_alive():
         return None
 

--- a/gef.py
+++ b/gef.py
@@ -6452,7 +6452,7 @@ class CapstoneDisassembleCommand(GenericCommand):
     _cmdline_ = "capstone-disassemble"
     _syntax_  = "{:s} [-h] [--show-opcodes] [--length LENGTH] [LOCATION]".format(_cmdline_)
     _aliases_ = ["cs-dis"]
-    _example_ = "{:s} --location $pc --length 50".format(_cmdline_)
+    _example_ = "{:s} --length 50 $pc".format(_cmdline_)
 
     def pre_load(self):
         try:

--- a/gef.py
+++ b/gef.py
@@ -3592,7 +3592,7 @@ def parse_location(value):
     """GEF wrapper for gdb.parse_and_eval() spezialied to resolve LOCATIONs like
     '$pc' or 'main+5' """
     try:
-        location = gdb.parse_and_eval(value)
+        location = gdb.parse_and_eval(str(value))
         ltype = location.dynamic_type.code
         if ltype == 1 or ltype == 8:
             return int(location)

--- a/gef.py
+++ b/gef.py
@@ -3639,7 +3639,6 @@ def gef_get_auxiliary_values():
             continue  # a valid entry should have at least 4 columns
         __av_type = line[1]
         __av_value = line[-1]
-        info(__av_value)
         __auxiliary_vector[__av_type] = int(__av_value, base=0)
     return __auxiliary_vector
 

--- a/gef.py
+++ b/gef.py
@@ -1010,7 +1010,7 @@ def titlify(text, color=None, msg_color=None):
     return "".join(msg)
 
 
-def err(msg):   return gef_print("{} {}".format(Color.colorify("[!]", "bold red"), m
+def err(msg):   return gef_print("{} {}".format(Color.colorify("[!]", "bold red"), msg))
 def warn(msg):  return gef_print("{} {}".format(Color.colorify("[*]", "bold yellow"), msg))
 def ok(msg):    return gef_print("{} {}".format(Color.colorify("[+]", "bold green"), msg))
 def info(msg):  return gef_print("{} {}".format(Color.colorify("[+]", "bold blue"), msg))
@@ -3586,22 +3586,6 @@ def safe_parse_and_eval(value):
     return None
 
 
-def parse_location(value):
-    """GEF wrapper for gdb.parse_and_eval() specialized to resolve LOCATIONs like
-    '$pc' or 'main+5'. """
-    # GDBs type codes: https://sourceware.org/gdb/current/onlinedocs/gdb/Types-In-Python.html#Types-In-Python
-    try:
-        location = gdb.parse_and_eval(str(value))
-        ptype = location.type.code
-        if ptype == gdb.TYPE_CODE_PTR or ptype == gdb.TYPE_CODE_INT:
-            return int(location)
-        elif ptype == gdb.TYPE_CODE_FUNC:
-            return int(location.address)
-    except gdb.error as e:
-        err(e)
-    return None
-
-
 @lru_cache()
 def dereference(addr):
     """GEF wrapper for gdb dereference function."""
@@ -3654,7 +3638,8 @@ def gef_get_auxiliary_values():
         if len(line) < 4:
             continue  # a valid entry should have at least 4 columns
         __av_type = line[1]
-        __av_value = line[:-1]
+        __av_value = line[-1]
+        info(__av_value)
         __auxiliary_vector[__av_type] = int(__av_value, base=0)
     return __auxiliary_vector
 
@@ -6473,7 +6458,7 @@ class CapstoneDisassembleCommand(GenericCommand):
         args = kwargs["arguments"]
         show_opcodes = args.show_opcodes
         length = args.length or get_gef_setting("context.nb_lines_code")
-        location = parse_location(args.location)
+        location = parse_address(args.location)
         if not location:
             info("Can't find address for {}".format(args.location))
             return

--- a/gef.py
+++ b/gef.py
@@ -3636,9 +3636,8 @@ def parse_string_range(s):
 @lru_cache()
 def gef_get_auxiliary_values():
     """Retrieves the ELF auxiliary values of the current execution. This information is provided by
-    the operating system to transfer some kernel level information to the user process."""
-    """Retrieves the auxiliary values of the current execution. This information is provided by the operationg system
-    at program startup. Returns None if not running, or a dict() of values as: {aux_vect_name: int(aux_vect_value)}."""
+    the operating system to transfer some kernel level information to the user process. Returns
+    None is not running, or a dict() of values as: {aux_vect_name: int(aux_vect_value)}."""
     if not is_alive():
         return None
 

--- a/gef.py
+++ b/gef.py
@@ -3639,7 +3639,7 @@ def parse_string_range(s):
 def gef_get_auxiliary_values():
     """Retrieves the ELF auxiliary values of the current execution. This information is provided by
     the operating system to transfer some kernel level information to the user process. Returns
-    None is not running, or a dict() of values as: {aux_vect_name: int(aux_vect_value)}."""
+    None if not found, or a dict() of values as: {aux_vect_name: int(aux_vect_value)}."""
     if not is_alive():
         return None
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -52,12 +52,14 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertTrue(len(res.splitlines()) > 1)
 
         self.assertFailIfInactiveSession(gdb_run_cmd("cs --show-opcodes"))
-        res = gdb_start_silent_cmd("cs --show-opcodes")
+        res = gdb_start_silent_cmd("cs --show-opcodes $pc")
         self.assertNoException(res)
         self.assertTrue(len(res.splitlines()) > 1)
         # match the following pattern
         # 0x5555555546b2 897dec      <main+8>         mov    DWORD PTR [rbp-0x14], edi
         self.assertRegex(res, r"0x.{12}\s([0-9a-f]{2})+\s+.*")
+        res = gdb_start_silent_cmd("cs --show-opcodes main")
+        self.assertNoException(res)
         return
 
     def test_cmd_checksec(self):


### PR DESCRIPTION
## Fix capstone-disassemble command and documentation ##

### Description/Motivation/Screenshots ###

As part of #693 this PR fixes the documentation and help messages for the `capstone-disassemble` command. Furthermore  the command was not working in use cases like emulating aarch64 inside qemu. This was due to an uncaught exception caused in `gef_get_auxiliary_values` when gdb's `info auxv` doesn't return useful results. This bug has been fixed. Also resolving of `LOCATION`s has been fixed.

With this PR I also propose changing the syntax for the `location` argument back to how it was before argparse: as a positional argument.

During this PR I introduced a new convenience wrapper function around gdb's `parse_and_eval` to specifically resolve `LOCATION`s. This way other commands can rely on it without having to handle the different possible cases neccessary (because e.g. gdb resolves registers different from symbols and for symbols a simple conversion to `int` does not work directly). This new function does not aim at replacing `gef_safe_parse_and_eval` at this point because too many commands rely currently rely on it and there might be use cases that don't resolve locations.

I also added a unit test that checks if resolving a symbol (e.g. "main") works for the command.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |     |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_check_mark: |                                           |
| AARCH64      | :heavy_check_mark: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test` | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
