### PR TITLE
Mimic glibc's MALLOC_ALIGNMENT for heap chunks

### DIFF
--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -9,10 +9,6 @@ for `malloc` structure information). Syntax to the subcommands is straight forwa
 gef➤ heap <sub_commands>
 ```
 
-Note that the LOCATION passed to a heap command that optionally accepts one
-needs to be aligned to your memory according to glibc's
-architecture-specific requirements (usually either 8 or 16 Bytes).
-
 ### `heap chunks` command ###
 
 Displays all the chunks from the `heap` section.

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -21,7 +21,7 @@ In some cases, the allocation will start immediately from start of the page. If
 so, specify the base address of the first chunk as follows:
 
 ```
-gef➤ heap chunks [LOCATION]
+gef➤ heap chunks [address]
 ```
 
 ![heap-chunks](https://i.imgur.com/2Ew2fA6.png)
@@ -38,7 +38,7 @@ provide the address to the user memory pointer of the chunk to show the
 information related to a specific chunk:
 
 ```
-gef➤ heap chunk [LOCATION]
+gef➤ heap chunk [address]
 ```
 
 ![heap-chunk](https://i.imgur.com/SAWNptW.png)
@@ -64,7 +64,7 @@ binary), it is possible to instruct GEF to find the `main_arena` at a different
 location with the command:
 
 ```
-gef➤ heap set-arena [LOCATION]
+gef➤ heap set-arena [address]
 ```
 
 If the arena address is correct, all `heap` commands will be functional, and use

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -9,6 +9,9 @@ for `malloc` structure information). Syntax to the subcommands is straight forwa
 gef➤ heap <sub_commands>
 ```
 
+Note that the LOCATION passed to a heap command that optionally accepts one
+needs to be aligned to your memory according to glibc's
+architecture-specific requirements (usually either 8 or 16 Bytes).
 
 ### `heap chunks` command ###
 
@@ -19,14 +22,18 @@ gef➤ heap chunks
 ```
 
 In some cases, the allocation will start immediately from start of the page. If
-so, specify the base address of the first chunk as follow:
+so, specify the base address of the first chunk as follows:
 
 ```
-gef➤ heap chunks <LOCATION>
+gef➤ heap chunks [LOCATION]
 ```
 
 ![heap-chunks](https://i.imgur.com/2Ew2fA6.png)
 
+Because usually the heap chunks are aligned to a certain number of bytes in
+memory GEF automatically re-aligns the chunks data start addresses to match
+Glibc's behavior. To be able to view unaligned chunks as well, you can
+disable this with the `--allow-unaligned` flag.
 
 ### `heap chunk` command ###
 
@@ -35,12 +42,15 @@ provide the address to the user memory pointer of the chunk to show the
 information related to a specific chunk:
 
 ```
-gef➤ heap chunk <LOCATION>
+gef➤ heap chunk [LOCATION]
 ```
 
 ![heap-chunk](https://i.imgur.com/SAWNptW.png)
 
-
+Because usually the heap chunks are aligned to a certain number of bytes in
+memory GEF automatically re-aligns the chunks data start addresses to match
+Glibc's behavior. To be able to view unaligned chunks as well, you can
+disable this with the `--allow-unaligned` flag.
 
 ### `heap arenas` command ###
 
@@ -51,8 +61,6 @@ call the command**.
 
 ![heap-arenas](https://i.imgur.com/ajbLiCF.png)
 
-
-
 ### `heap set-arena` command ###
 
 In cases where the debug symbol are not present (e.g. statically stripped
@@ -60,12 +68,11 @@ binary), it is possible to instruct GEF to find the `main_arena` at a different
 location with the command:
 
 ```
-gef➤ heap set-arena <LOCATION>
+gef➤ heap set-arena [LOCATION]
 ```
 
 If the arena address is correct, all `heap` commands will be functional, and use
 the specified address for `main_arena`.
-
 
 ### `heap bins` command ###
 
@@ -77,13 +84,12 @@ single or doubly linked list, I found that quite painful to always interrogate
 I decided to implement the `heap bins` sub-command, which allows to get info
 on:
 
-   - `fastbins`
-   - `bins`
-      - `unsorted`
-      - `small bins`
-      - `large bins`
-   - `tcachebins`
-
+- `fastbins`
+- `bins`
+  - `unsorted`
+  - `small bins`
+  - `large bins`
+- `tcachebins`
 
 #### `heap bins fast` command ####
 
@@ -110,14 +116,12 @@ Fastbin[8] 0x00
 Fastbin[9] 0x00
 ```
 
-
 #### Other `heap bins X` command ####
 
 All the other subcommands (with the exception of `tcache`) for the `heap bins`
 work the same way as `fast`. If no argument is provided, `gef` will fall back
 to `main_arena`. Otherwise, it will use the address pointed as the base of the
 `malloc_state` structure and print out information accordingly.
-
 
 #### `heap bins tcache` command ####
 

--- a/gef.py
+++ b/gef.py
@@ -963,7 +963,7 @@ class GlibcChunk:
 
     def __str__(self):
         msg = "{:s}(addr={:#x}, size={:#x}, flags={:s})".format(Color.colorify("Chunk", "yellow bold underline"),
-                                                                int(self.base_address),
+                                                                int(self.data_address),
                                                                 self.get_chunk_size(),
                                                                 self.flags_as_string())
         return msg

--- a/gef.py
+++ b/gef.py
@@ -799,13 +799,14 @@ class GlibcChunk:
     address pointed to as the chunk data. Setting from_base to True instead treats that data as the chunk header.
     Ref:  https://sploitfun.wordpress.com/2015/02/10/understanding-glibc-malloc/."""
 
-    def __init__(self, addr, from_base=False):
+    def __init__(self, addr, from_base=False, allow_unaligned=False):
         self.ptrsize = current_arch.ptrsize
         if from_base:
             self.data_address = addr + 2 * self.ptrsize
         else:
             self.data_address = addr
-        self.align_data_address()
+        if not allow_unaligned:
+            self.align_data_address()
         self.base_address = addr - 2 * self.ptrsize
 
         self.size_addr = int(self.data_address - self.ptrsize)


### PR DESCRIPTION
## Mimic glibc's MALLOC_ALIGNMENT for heap chunks##

### Description/Motivation/Screenshots ###

see #689

I added some comments and references, renamed the `address` variables to `data_address` and `base_address` to be more concise (at least imo) and mimicked the behavior of glibc (before and since version 2.26) to calculate `MALLOC_ALIGNMENT` and then used that to re-align the `data_address` of the chunk.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |      |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
