### PR TITLE
gef.sh is now works on Ubuntu 21.04 (Hirsute Hippo)

### DIFF
--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -9,16 +9,35 @@ if [ "$1" = "dev" ]; then
     echo "set branch to dev"
 fi
 
+# check dependencies
+if [ `which curl` ]; then
+	curl_found=1
+elif [ `which wget` ]; then
+	wget_found=1
+else
+	echo "Please install cURL or wget and run again"
+	exit 1
+fi
+
 # Backup gdbinit if any
 if [ -f "${HOME}/.gdbinit" ]; then
     mv "${HOME}/.gdbinit" "${HOME}/.gdbinit.old"
 fi
 
-# Get the hash of the commit
-ref=$(wget -q -O- https://api.github.com/repos/hugsy/gef/git/ref/heads/${branch} | grep '"sha"' | tr -s ' ' | cut -d ' ' -f 3 | tr -d "," | tr -d '"')
+if [ $wget_found -eq 1 ]; then
+    # Get the hash of the commit
+    ref=$(wget -q -O- https://api.github.com/repos/hugsy/gef/git/ref/heads/${branch} | grep '"sha"' | tr -s ' ' | cut -d ' ' -f 3 | tr -d "," | tr -d '"')
 
-# Download the file
-wget -q "https://github.com/hugsy/gef/raw/${branch}/gef.py" -O "${HOME}/.gef-${ref}.py"
+    # Download the file
+    wget -q "https://github.com/hugsy/gef/raw/${branch}/gef.py" -O "${HOME}/.gef-${ref}.py"
+elif [ $curl_found -eq 1 ]; then
+    # Get the hash of the commit
+    ref=$(curl --silent https://api.github.com/repos/hugsy/gef/git/ref/heads/${branch} | grep '"sha"' | tr -s ' ' | cut -d ' ' -f 3 | tr -d "," | tr -d '"')
+
+    # Download the file
+    curl --silent --location --output "${HOME}/.gef-${ref}.py" "https://github.com/hugsy/gef/raw/${branch}/gef.py"
+fi
+
 # Create the new gdbinit
 echo "source ~/.gef-${ref}.py" > ~/.gdbinit
 

--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -3,17 +3,22 @@
 set -e
 
 branch="master"
-test "$1" == "dev" && branch="dev"
+
+if [ "$1" = "dev" ]; then
+    branch="dev"
+    echo "set branch to dev"
+fi
 
 # Backup gdbinit if any
-test -f "${HOME}/.gdbinit" && mv "${HOME}/.gdbinit" "${HOME}/.gdbinit.old"
+if [ -f "${HOME}/.gdbinit" ]; then
+    mv "${HOME}/.gdbinit" "${HOME}/.gdbinit.old"
+fi
 
 # Get the hash of the commit
-ref=$(curl --silent https://api.github.com/repos/hugsy/gef/git/ref/heads/${branch} | grep '"sha"' | tr -s ' ' | cut -d ' ' -f 3 | tr -d "," | tr -d '"')
+ref=$(wget -q -O- https://api.github.com/repos/hugsy/gef/git/ref/heads/${branch} | grep '"sha"' | tr -s ' ' | cut -d ' ' -f 3 | tr -d "," | tr -d '"')
 
 # Download the file
-curl --silent --location --output "${HOME}/.gef-${ref}.py" "https://github.com/hugsy/gef/raw/${branch}/gef.py"
-
+wget -q "https://github.com/hugsy/gef/raw/${branch}/gef.py" -O "${HOME}/.gef-${ref}.py"
 # Create the new gdbinit
 echo "source ~/.gef-${ref}.py" > ~/.gdbinit
 


### PR DESCRIPTION
## gef.sh is now works on Ubuntu 21.04 (Hirsute Hippo) ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->

Fixing those errors:
* test: unexpected operator
* curl: not found

<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
