### PR TITLE
Update and fix heap command

### DIFF
--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -99,17 +99,14 @@ can easily find using `heap arenas`).
 
 ```
 gef➤ heap bins fast
-[+] FastbinsY of arena 0x7ffff7dd5b20
-Fastbin[0] 0x00
-Fastbin[1]  →  FreeChunk(0x600310)  →  FreeChunk(0x600350)
-Fastbin[2] 0x00
-Fastbin[3] 0x00
-Fastbin[4] 0x00
-Fastbin[5] 0x00
-Fastbin[6] 0x00
-Fastbin[7] 0x00
-Fastbin[8] 0x00
-Fastbin[9] 0x00
+──────────────────────── Fastbins for arena 0x7ffff7fb8b80 ────────────────────────
+Fastbins[idx=0, size=0x20]  ←  Chunk(addr=0x555555559380, size=0x20, flags=PREV_INUSE)
+Fastbins[idx=1, size=0x30] 0x00
+Fastbins[idx=2, size=0x40] 0x00
+Fastbins[idx=3, size=0x50] 0x00
+Fastbins[idx=4, size=0x60] 0x00
+Fastbins[idx=5, size=0x70] 0x00
+Fastbins[idx=6, size=0x80] 0x00
 ```
 
 #### Other `heap bins X` command ####

--- a/gef.py
+++ b/gef.py
@@ -6553,7 +6553,7 @@ class GlibcHeapCommand(GenericCommand):
     """Base command to get information about the Glibc heap structure."""
 
     _cmdline_ = "heap"
-    _syntax_  = "{:s} (chunk|chunks|bins|arenas)".format(_cmdline_)
+    _syntax_  = "{:s} (chunk|chunks|bins|arenas|set-arena)".format(_cmdline_)
 
     def __init__(self):
         super().__init__(prefix=True)
@@ -6657,8 +6657,8 @@ class GlibcHeapChunkCommand(GenericCommand):
 
 @register_command
 class GlibcHeapChunksCommand(GenericCommand):
-    """Display information all chunks from main_arena heap. If a location is passed,
-    it must correspond to the base address of the first chunk."""
+    """Display information all chunks from main_arena heap. If a location is
+    passed, it must correspond to the base address of the first chunk."""
 
     _cmdline_ = "heap chunks"
     _syntax_  = "{0} [-h] [--allow-unaligned] [address]".format(_cmdline_)

--- a/gef.py
+++ b/gef.py
@@ -6680,7 +6680,7 @@ class GlibcHeapChunksCommand(GenericCommand):
                 err("Heap not initialized")
                 return
         else:
-            heap_section = int(args.address, 0)
+            heap_section = parse_address(args.address)
 
         arena = get_main_arena()
         if arena is None:

--- a/tests/binaries/heap-fastbins.c
+++ b/tests/binaries/heap-fastbins.c
@@ -5,29 +5,23 @@
  * heap-fastbins.c
  *
  * @author: @_hugsy_
- * @author: @_theguy147_
  * @licence: WTFPL v.2
  */
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
-void break_here() {
-	// GDB: `br *break_here`
-}
-
-int main(int argc, char** argv, char** envp) {
-	// allocate some chunks that have a suitable size for a fastbin
-	void* ptrs[10];
-	for (int i = 0; i < 10; i++) {
-		ptrs[i] = malloc(0x10);
-	}
-	// free 7 chunks to fill the tcache
-	for (int i = 0; i < 7; i++) {
-		free(ptrs[i]);
-	}
-	// now free our fastbin
-	free(ptrs[7]);
-
-	break_here(); // break here to check the `fastbinY` structure
+int main() {
+    void* p1 = malloc(0x10);
+    void* p2 = malloc(0x20);
+    void* p3 = malloc(0x30);
+    memset(p1, 'A', 0x10);
+    memset(p2, 'B', 0x20);
+    memset(p3, 'C', 0x30);
+    free(p2);
+    __builtin_trap();
+    (void)p1;
+    (void)p3;
+    return EXIT_SUCCESS;
 }

--- a/tests/binaries/heap-fastbins.c
+++ b/tests/binaries/heap-fastbins.c
@@ -2,29 +2,32 @@
  * -*- mode: c -*-
  * -*- coding: utf-8 -*-
  *
- * heap.c
+ * heap-fastbins.c
  *
  * @author: @_hugsy_
+ * @author: @_theguy147_
  * @licence: WTFPL v.2
  */
 
 #include <stdio.h>
-#include <stdint.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
 
-int main(int argc, char** argv, char** envp)
-{
-        void* p1 = malloc(0x10);
-        void* p2 = malloc(0x20);
-        void* p3 = malloc(0x30);
-        memset(p1, 'A', 0x10);
-        memset(p2, 'B', 0x20);
-        memset(p3, 'C', 0x30);
-        free(p2);
-        __builtin_trap();
-        (void)p1;
-        (void)p3;
-        return EXIT_SUCCESS;
+void break_here() {
+	// GDB: `br *break_here`
+}
+
+int main(int argc, char** argv, char** envp) {
+	// allocate some chunks that have a suitable size for a fastbin
+	void* ptrs[10];
+	for (int i = 0; i < 10; i++) {
+		ptrs[i] = malloc(0x10);
+	}
+	// free 7 chunks to fill the tcache
+	for (int i = 0; i < 7; i++) {
+		free(ptrs[i]);
+	}
+	// now free our fastbin
+	free(ptrs[7]);
+
+	break_here(); // break here to check the `fastbinY` structure
 }

--- a/tests/binaries/heap-fastbins.c
+++ b/tests/binaries/heap-fastbins.c
@@ -6,6 +6,9 @@
  *
  * @author: @_hugsy_
  * @licence: WTFPL v.2
+ *
+ * to test the fastbins the tcache has to be disabled through the environment in GDB:
+ * `set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0`
  */
 
 #include <stdio.h>

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -204,9 +204,10 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_heap_bins_fast(self):
         cmd = "heap bins fast"
+        before = ['set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0']
         target = "/tmp/heap-fastbins.out"
-        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
-        res = gdb_run_silent_cmd(cmd, before=["br *break_here", "c"], target=target)
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, before=before, target=target))
+        res = gdb_run_silent_cmd(cmd, before=before, target=target)
         self.assertNoException(res)
         self.assertIn("Fastbins[idx=0, size=0x20]", res)
         self.assertIn("Chunk(addr=", res)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -204,7 +204,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_heap_bins_fast(self):
         cmd = "heap bins fast"
-        before = ['set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0']
+        before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]
         target = "/tmp/heap-fastbins.out"
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, before=before, target=target))
         res = gdb_run_silent_cmd(cmd, before=before, target=target)
@@ -214,8 +214,8 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_heap_bins_non_main(self):
-        cmd = 'python gdb.execute("heap bins fast {}".format(get_main_arena().next))'
-        before = ['set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0']
+        cmd = "python gdb.execute('heap bins fast {}'.format(get_main_arena().next))"
+        before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]
         target = "/tmp/heap-non-main.out"
         res = gdb_run_silent_cmd(cmd, before=before, target=target)
         self.assertNoException(res)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -206,9 +206,10 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         cmd = "heap bins fast"
         target = "/tmp/heap-fastbins.out"
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
-        res = gdb_run_silent_cmd(cmd, target=target)
+        res = gdb_run_silent_cmd(cmd, before=["br *break_here", "c"], target=target)
         self.assertNoException(res)
         self.assertIn("Fastbins[idx=0, size=0x20]", res)
+        self.assertIn("Chunk(addr=", res)
         return
 
     def test_cmd_heap_bins_non_main(self):


### PR DESCRIPTION
## Update and fix `heap` command ##

### Description/Motivation/Screenshots ###

This PR is part of #693 and covers the following points:
- Add the missing `set-arena` subcommand to the `heap` help message.
- Fix address parsing for `heap chunks` command from a simple conversion to `int` to use `parse_address()` instead.
- Update `heap bins fast` command output in documentation.
- Fix `test_cmd_heap_bins_fast` test to actually look for a fastbin in the output. To do this the `heap-fastbins.c` had to be changed to first fill all 7 tcache bins before freeing the actual fastbin to look for.
EDIT: `heap-fastbins.c` doesn't need to be udpated when disabling tcache via the environment in GDB: `set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0` (as pointed out to me by @irontigran )

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |   |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
