### PR TITLE
Update break commands

### DIFF
--- a/docs/commands/name-break.md
+++ b/docs/commands/name-break.md
@@ -1,17 +1,17 @@
 ## Command name-break ##
 
-The command `name-break` (alias `nb`) can be used to set a breakpoint on 
+The command `name-break` (alias `nb`) can be used to set a breakpoint on
 a location with a name assigned to it.
 
 Every time this breakpoint is hit, the specified name will also be shown
 in the `extra` section to make it easier to keep an overview when using
 multiple breakpoints in a stripped binary.
 
-`name-break <NAME> [LOCATION]`
+`name-break name [address]`
 
-`LOCATION` may be a linespec, address, or explicit location, same as specified
-for `break`. If `LOCATION` isn't specified, it will create the breakpoint at the current
-instruction pointer address.
+`address` may be a linespec, address, or explicit location, same as specified
+for `break`. If `address` isn't specified, it will create the breakpoint at the
+current instruction pointer address.
 
 Examples:
 
@@ -26,7 +26,7 @@ Example output:
 ─────────────────────────────────────────────────────────────────────────── code:x86:64 ────
      0x400e04                  add    eax, 0xfffbe6e8
      0x400e09                  dec    ecx
-     0x400e0b                  ret    
+     0x400e0b                  ret
  →   0x400e0c                  push   rbp
      0x400e0d                  mov    rbp, rsp
      0x400e10                  sub    rsp, 0x50
@@ -43,5 +43,5 @@ Example output:
 ───────────────────────────────────────────────────────────────────────────────── extra ────
 [+] Hit breakpoint *0x400e0c (check_entry)
 ────────────────────────────────────────────────────────────────────────────────────────────
-gef➤  
+gef➤
 ```

--- a/docs/commands/pie.md
+++ b/docs/commands/pie.md
@@ -1,82 +1,85 @@
 ## Command pie ##
 
-The `pie` command provides a useful way to set breakpoint to a PIE enabled binary.
-`pie` command then provides what we call "PIE breakpoint". A PIE breakpoint is just
-a virtual breakpoint which will be set to real breakpoint when the process is attaching.
-A PIE breakpoint's address is the offset from binary base address.
+The `pie` command provides a useful way to set breakpoint to a PIE enabled
+binary. `pie` command then provides what we call "PIE breakpoints". A PIE
+breakpoint is just a virtual breakpoint which will be turned to a real
+breakpoint at runtime. A PIE breakpoint's address is the offset from
+the base address of the binary.
 
-Note that you need to use ENTIRE PIE COMMAND SERIES to support PIE breakpoint, especially the
-"attaching" commands provided by `pie` command, like `pie attach`, `pie run`, etc.
-
-Usage is just:
-```
-gef➤ pie <sub_commands>
-```
-
+Note that you need to use the **entire `pie` command series** to support PIE
+breakpoints, especially the "`pie` run commands", like `pie attach`, `pie run`,
+etc.
 
 ### `pie breakpoint` command ###
 
-This command sets a new PIE breakpoint. It can be used like normal `breakpoint` command
-in gdb. The location is just the offset from the base address. Breakpoint will not be
-set immediately after this command. Instead, it will be set when you use `pie attach`,
-`pie run`, `pie remote` to actually attach to a process, so it can resolve the right base
+This command sets a new PIE breakpoint. It can be used like the normal
+`breakpoint` command in gdb. The argument for the command is the offset from
+the base address. The breakpoints will not be set immediately after this
+command. Instead, it will be set when you use `pie attach`, `pie run`, `pie
+remote` to actually attach to a process, so it can resolve the right base
 address.
 
 Usage:
+
 ```
-gef➤ pie breakpoint <LOCATION>
+gef➤ pie breakpoint OFFSET
 ```
 
 ### `pie info` command ###
 
-Since PIE breakpoint is not real breakpoint, this command provide a way to observe the
-state of all PIE breakpoints.
+Since a PIE breakpoint is not a real breakpoint, this command provide a way to
+observe the state of all PIE breakpoints.
 
-This is just like `info breakpoint` in gdb.
+This works just like `info breakpoint` in gdb.
+
 ```
 gef➤  pie info
-VNum	Num	Addr
-1	N/A	0xdeadbeef
+VNum    Num     Addr
+1       N/A     0xdeadbeef
 ```
 
-The VNum is the virtual number, which is the number of the PIE breakpoint. The Num is the
-number of the according real breakpoint number in gdb. Address is the PIE breakpoint's
-address.
+VNum stands for virtual number and is used to numerate the PIE breakpoints and
+Num is the number of the associated real breakpoint at runtime in GDB.
 
-You can ignore VNum argument to get info of all PIE breakpoints.
+You can ommit the VNum argument to get the info on all PIE breakpoints.
 
 Usage:
+
 ```
 gef➤  pie info [VNum]
 
 ```
-
 
 ### `pie delete` command ###
 
 This command deletes a PIE breakpoint given a VNum of that PIE breakpoint.
 
 Usage:
-```
-gef➤  pie delete <VNum>
-```
 
+```
+gef➤  pie delete [VNum]
+```
 
 ### `pie attach` command ###
 
-The same as gdb's `attach` command. Always use this command instead of raw `attach` 
-if you have PIE breakpoint. This will set real breakpoint when attaching.
+This command behaves like GDB's `attach` command. Always use this command
+instead of `attach` if you have PIE breakpoints. This will convert the PIE
+breakpoints to real breakpoints at runtime.
 
 The usage is just the same as `attach`.
 
 ### `pie remote` command ###
-The same as gdb's `remote` command. Always use this command instead of raw `remote`
-if you have PIE breakpoint. This will set real breakpoint when attaching.
+
+This command behaves like GDB's `remote` command. Always use this command
+instead of `remote` if you have PIE breakpoints. This will convert the PIE
+breakpoints to real breakpoints at runtime.
 
 The usage is just the same as `remote`.
 
 ### `pie run` command ###
-The same as gdb's `run` command. Always use the command instead of raw `run` if you 
-have PIE breakpoint. This will set real breakpoint when attaching.
+
+This command behaves like GDB's `run` command. Always use this command instead
+of `run` if you have PIE breakpoints. This will convert the PIE breakpoints to
+real breakpoints at runtime.
 
 The usage is just the same as `run`.

--- a/docs/commands/pie.md
+++ b/docs/commands/pie.md
@@ -13,7 +13,7 @@ etc.
 This command sets a new PIE breakpoint. It can be used like the normal
 `breakpoint` command in gdb. The argument for the command is the offset from
 the base address or a symbol. The breakpoints will not be set immediately after
-this command. Instead, it will be set when you use `pie attach`, `pie run`,
+this command. Instead, it will be set when you use `pie attach`, `pie run` or
 `pie remote` to actually attach to a process, so it can resolve the right base
 address.
 
@@ -36,10 +36,10 @@ VNum    Num     Addr
 1       N/A     0xdeadbeef
 ```
 
-VNum stands for virtual number and is used to numerate the PIE breakpoints and
-Num is the number of the associated real breakpoint at runtime in GDB.
+VNum stands for virtual number and is used to enumerate the PIE breakpoints.
+Num is the number of the associated real breakpoints at runtime in GDB.
 
-You can omit the VNum argument to get the info on all PIE breakpoints.
+You can omit the VNum argument to get info on all PIE breakpoints.
 
 Usage:
 
@@ -50,7 +50,7 @@ gef➤  pie info [VNum]
 
 ### `pie delete` command ###
 
-This command deletes a PIE breakpoint given a VNum of that PIE breakpoint.
+This command deletes a PIE breakpoint given its VNum.
 
 Usage:
 

--- a/docs/commands/pie.md
+++ b/docs/commands/pie.md
@@ -4,7 +4,7 @@ The `pie` command provides a useful way to set breakpoint to a PIE enabled
 binary. `pie` command then provides what we call "PIE breakpoints". A PIE
 breakpoint is just a virtual breakpoint which will be turned to a real
 breakpoint at runtime. A PIE breakpoint's address is the offset from
-the base address of the binary.
+the base address of the binary or a symbol of the binary.
 
 Note that you need to use the **entire `pie` command series** to support PIE
 breakpoints, especially the "`pie` run commands", like `pie attach`, `pie run`,
@@ -14,9 +14,9 @@ etc.
 
 This command sets a new PIE breakpoint. It can be used like the normal
 `breakpoint` command in gdb. The argument for the command is the offset from
-the base address. The breakpoints will not be set immediately after this
-command. Instead, it will be set when you use `pie attach`, `pie run`, `pie
-remote` to actually attach to a process, so it can resolve the right base
+the base address or a symbol. The breakpoints will not be set immediately after
+this command. Instead, it will be set when you use `pie attach`, `pie run`,
+`pie remote` to actually attach to a process, so it can resolve the right base
 address.
 
 Usage:

--- a/docs/commands/pie.md
+++ b/docs/commands/pie.md
@@ -1,10 +1,8 @@
 ## Command pie ##
 
-The `pie` command provides a useful way to set breakpoint to a PIE enabled
-binary. `pie` command then provides what we call "PIE breakpoints". A PIE
-breakpoint is just a virtual breakpoint which will be turned to a real
-breakpoint at runtime. A PIE breakpoint's address is the offset from
-the base address of the binary or a symbol of the binary.
+The `pie` command is handy when working with position-independent executables.
+At runtime, it can automatically resolve addresses for breakpoints that are not
+static.
 
 Note that you need to use the **entire `pie` command series** to support PIE
 breakpoints, especially the "`pie` run commands", like `pie attach`, `pie run`,
@@ -27,7 +25,7 @@ gef➤ pie breakpoint OFFSET
 
 ### `pie info` command ###
 
-Since a PIE breakpoint is not a real breakpoint, this command provide a way to
+Since a PIE breakpoint is not a real breakpoint, this command provides a way to
 observe the state of all PIE breakpoints.
 
 This works just like `info breakpoint` in gdb.
@@ -41,7 +39,7 @@ VNum    Num     Addr
 VNum stands for virtual number and is used to numerate the PIE breakpoints and
 Num is the number of the associated real breakpoint at runtime in GDB.
 
-You can ommit the VNum argument to get the info on all PIE breakpoints.
+You can omit the VNum argument to get the info on all PIE breakpoints.
 
 Usage:
 
@@ -71,7 +69,8 @@ The usage is just the same as `attach`.
 ### `pie remote` command ###
 
 This command behaves like GDB's `remote` command. Always use this command
-instead of `remote` if you have PIE breakpoints. This will convert the PIE
+instead of `remote` if you have PIE breakpoints. Behind the scenes this will
+connect to the remote target using `gef remote` and then convert the PIE
 breakpoints to real breakpoints at runtime.
 
 The usage is just the same as `remote`.

--- a/gef.py
+++ b/gef.py
@@ -4499,21 +4499,20 @@ class PieCommand(GenericCommand):
 
 @register_command
 class PieBreakpointCommand(GenericCommand):
-    """Set a PIE breakpoint."""
+    """Set a PIE breakpoint at an offset to the target binaries base address."""
 
     _cmdline_ = "pie breakpoint"
-    _syntax_ = "{:s} BREAKPOINT".format(_cmdline_)
+    _syntax_ = "{:s} OFFSET".format(_cmdline_)
 
-    @parse_arguments({"expression": ""}, {})
+    @parse_arguments({"offset": ""}, {})
     def do_invoke(self, argv, *args, **kwargs):
         global __pie_counter__, __pie_breakpoints__
-        if len(argv) < 1:
+        args = kwargs["arguments"]
+        if not args.offset:
             self.usage()
             return
 
-        args = kwargs["arguments"]
-        bp_expr = args.expression[1:] if args.expression[0] == "*" else "&{}".format(args.expression)
-        addr = int(gdb.parse_and_eval(bp_expr))
+        addr = parse_address(args.offset)
         self.set_pie_breakpoint(lambda base: "b *{}".format(base + addr), addr)
 
         # When the process is already on, set real breakpoints immediately

--- a/gef.py
+++ b/gef.py
@@ -7754,7 +7754,7 @@ class NamedBreakpointCommand(GenericCommand):
         super().__init__()
         return
 
-    @parse_arguments({"name": "", "location": "$pc"}, {})
+    @parse_arguments({"name": "", "address": "$pc"}, {})
     def do_invoke(self, argv, *args, **kwargs):
         args = kwargs["arguments"]
         if not args.name:
@@ -7762,7 +7762,7 @@ class NamedBreakpointCommand(GenericCommand):
             self.usage()
             return
 
-        location = parse_address(args.location)
+        location = parse_address(args.address)
         NamedBreakpoint(location, args.name)
         return
 

--- a/gef.py
+++ b/gef.py
@@ -4499,7 +4499,7 @@ class PieCommand(GenericCommand):
 
 @register_command
 class PieBreakpointCommand(GenericCommand):
-    """Set a PIE breakpoint at an offset to the target binaries base address."""
+    """Set a PIE breakpoint at an offset from the target binaries base address."""
 
     _cmdline_ = "pie breakpoint"
     _syntax_ = "{:s} OFFSET".format(_cmdline_)

--- a/gef.py
+++ b/gef.py
@@ -7746,7 +7746,7 @@ class NamedBreakpointCommand(GenericCommand):
     """Sets a breakpoint and assigns a name to it, which will be shown, when it's hit."""
 
     _cmdline_ = "name-break"
-    _syntax_  = "{:s} NAME [LOCATION]".format(_cmdline_)
+    _syntax_  = "{:s} name [address]".format(_cmdline_)
     _aliases_ = ["nb",]
     _example  = "{:s} main *0x4008a9"
 
@@ -7754,7 +7754,7 @@ class NamedBreakpointCommand(GenericCommand):
         super().__init__()
         return
 
-    @parse_arguments({"name": "", "location": ""}, {})
+    @parse_arguments({"name": "", "location": "$pc"}, {})
     def do_invoke(self, argv, *args, **kwargs):
         args = kwargs["arguments"]
         if not args.name:
@@ -7762,7 +7762,7 @@ class NamedBreakpointCommand(GenericCommand):
             self.usage()
             return
 
-        location = args.location or "*{:#x}".format(current_arch.pc)
+        location = parse_address(args.location)
         NamedBreakpoint(location, args.name)
         return
 


### PR DESCRIPTION
## Update break commands ##

### Description/Motivation/Screenshots ###

This PR is part of #693 and covers the following points:
- Fix address parsing for `name-break` cmd by using `parse_address()` now.
- Update `name-break` docs.
- Rename "location" argument to "address".
- Clarify that `pie breakpoint` takes an offset (or symbol) as an argument and not an absolute address.
- Fix address parsing for `pie breakpoint`.
- Update `pie` commands documentation and usage instructions.


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |   |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
