### PR TITLE
Correct have_fastchunks arena adjustment

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -648,7 +648,10 @@ class MallocStateStruct:
             ptr_type = "unsigned long" if current_arch.ptrsize == 8 else "unsigned int"
             self.size_t = cached_lookup_type(ptr_type)
 
-        if get_libc_version() >= (2, 26):
+        # Account for separation of have_fastchunks flag into its own field within the malloc_state struct in GLIBC >= 2.27
+        # https://sourceware.org/git/?p=glibc.git;a=commit;h=e956075a5a2044d05ce48b905b10270ed4a63e87
+        # Be aware you could see this change backported into GLIBC release branches.
+        if get_libc_version() >= (2, 27):
             self.fastbin_offset = align_address_to_size(self.int_size * 3, 8)
         else:
             self.fastbin_offset = self.int_size * 2

--- a/gef.py
+++ b/gef.py
@@ -648,9 +648,11 @@ class MallocStateStruct:
             ptr_type = "unsigned long" if current_arch.ptrsize == 8 else "unsigned int"
             self.size_t = cached_lookup_type(ptr_type)
 
-        # Account for separation of have_fastchunks flag into its own field within the malloc_state struct in GLIBC >= 2.27
+        # Account for separation of have_fastchunks flag into its own field
+        # within the malloc_state struct in GLIBC >= 2.27
         # https://sourceware.org/git/?p=glibc.git;a=commit;h=e956075a5a2044d05ce48b905b10270ed4a63e87
-        # Be aware you could see this change backported into GLIBC release branches.
+        # Be aware you could see this change backported into GLIBC release
+        # branches.
         if get_libc_version() >= (2, 27):
             self.fastbin_offset = align_address_to_size(self.int_size * 3, 8)
         else:


### PR DESCRIPTION
## Correct have_fastchunks arena adjustment ##

Patches a check that (though uncommented) appears to have been introduced to compensate for the `have_fastchunks` flag being moved from an arena's `flags` into its own field in GLIBC 2.27. The code in question is used to parse arenas when the linked GLIBC build has no debug symbols available. The only thing I've changed is the version number, it should read >= 2.27 rather that 2.26. In its current state, if you try to debug a program linked to a GLIBC 2.26 build without debug symbols, the arena layout is misinterpreted and heap commands will hang or give incorrect information.

Only tested on x86_64 hardware.