### PR TITLE
Fix name-break address parsing (#707)

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -4206,10 +4206,10 @@ class NamedBreakpoint(gdb.Breakpoint):
     """Breakpoint which shows a specified name, when hit."""
 
     def __init__(self, location, name):
-        super().__init__(spec=location, type=gdb.BP_BREAKPOINT, internal=False, temporary=False)
+        address = "*{}".format(parse_address(location))
+        super().__init__(spec=address, type=gdb.BP_BREAKPOINT, internal=False, temporary=False)
         self.name = name
         self.loc = location
-
         return
 
     def stop(self):
@@ -7755,15 +7755,14 @@ class NamedBreakpointCommand(GenericCommand):
         return
 
     @parse_arguments({"name": "", "address": "$pc"}, {})
-    def do_invoke(self, argv, *args, **kwargs):
+    def do_invoke(self, *args, **kwargs):
         args = kwargs["arguments"]
         if not args.name:
             err("Missing name for breakpoint")
             self.usage()
             return
 
-        location = parse_address(args.address)
-        NamedBreakpoint(location, args.name)
+        NamedBreakpoint(args.address, args.name)
         return
 
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -311,6 +311,11 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         res = gdb_start_silent_cmd("memory reset")
         self.assertNoException(res)
 
+    def test_cmd_name_break(self):
+        res = gdb_run_cmd("nb foobar *main+10")
+        self.assertNoException(res)
+        return
+
     def test_cmd_keystone_assemble(self):
         valid_cmds = [
             "assemble nop; xor eax, eax; syscall",


### PR DESCRIPTION
## Fix name-break address parsing (#707) ##

### Description/Motivation/Screenshots ###

see #707

My proposed solution is to move the address parsing to `NamedBreakpoint` so the original user input will be displayed when hitting the breakpoint but the location will be converted to an address and given to GDBs `Breakpoint` as a string with a prefixed `*`. 

I also added a test (which was missing previously) to check if the `name-break` command throws an exception.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###


- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
