### PR TITLE
Fix 'heap chunks' command for non-main arenas (#706)

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -747,6 +747,7 @@ class GlibcArena:
             malloc_state_t = cached_lookup_type("struct malloc_state")
             self.__arena = arena.cast(malloc_state_t)
             self.__addr = int(arena.address)
+            self.struct_size = malloc_state_t.sizeof
         except:
             self.__arena = MallocStateStruct(addr)
             self.__addr = self.__arena.addr
@@ -791,13 +792,13 @@ class GlibcArena:
 
     def heap_addr(self):
         main_arena_addr = to_unsigned_long(gdb.parse_and_eval("&main_arena"))
-        if self.addr == main_arena_addr:
+        if int(self) == main_arena_addr:
             heap_section = HeapBaseFunction.heap_base()
             if not heap_section:
                 err("Heap not initialized")
                 return None
             return heap_section
-        _addr = self.addr + self.struct_size
+        _addr = int(self) + self.struct_size
         return malloc_align_address(_addr)
 
     def __str__(self):

--- a/gef.py
+++ b/gef.py
@@ -6716,7 +6716,7 @@ class GlibcHeapChunksCommand(GenericCommand):
             if heap_addr is None:
                 return
         else:
-            heap_addr = int(args.address, 0)
+            heap_addr = parse_address(args.address)
 
         nb = self.get_setting("peek_nb_byte")
         current_chunk = GlibcChunk(heap_addr, from_base=True, allow_unaligned=args.allow_unaligned)

--- a/gef.py
+++ b/gef.py
@@ -789,6 +789,17 @@ class GlibcArena:
             return None
         return GlibcArena("*{:#x} ".format(addr_next))
 
+    def heap_addr(self):
+        main_arena_addr = to_unsigned_long(gdb.parse_and_eval("&main_arena"))
+        if self.addr == main_arena_addr:
+            heap_section = HeapBaseFunction.heap_base()
+            if not heap_section:
+                err("Heap not initialized")
+                return None
+            return heap_section
+        _addr = self.addr + self.struct_size
+        return malloc_align_address(_addr)
+
     def __str__(self):
         fmt = "Arena (base={:#x}, top={:#x}, last_remainder={:#x}, next={:#x}, next_free={:#x}, system_mem={:#x})"
         return fmt.format(self.__addr, self.top, self.last_remainder, self.n, self.nfree, self.sysmem)
@@ -806,31 +817,12 @@ class GlibcChunk:
         else:
             self.data_address = addr
         if not allow_unaligned:
-            self.align_data_address()
+            self.data_address = malloc_align_address(self.data_address)
         self.base_address = addr - 2 * self.ptrsize
 
         self.size_addr = int(self.data_address - self.ptrsize)
         self.prev_size_addr = self.base_address
         return
-
-    def align_data_address(self):
-        """Align chunk data addresses according to glibc's MALLOC_ALIGNMENT. See also Issue #689 on Github"""
-        __default_malloc_alignment = 0x10
-        if is_x86_32() and get_libc_version() >= (2, 26):
-            # Special case introduced in Glibc 2.26:
-            # https://elixir.bootlin.com/glibc/glibc-2.26/source/sysdeps/i386/malloc-alignment.h#L22
-            malloc_alignment = __default_malloc_alignment
-        else:
-            # Generic case:
-            # https://elixir.bootlin.com/glibc/glibc-2.26/source/sysdeps/generic/malloc-alignment.h#L22
-            __alignof__long_double = int(safe_parse_and_eval("_Alignof(long double)") or __default_malloc_alignment) # fallback to default if the expression fails to evaluate
-            malloc_alignment = max(__alignof__long_double, 2 * self.ptrsize)
-
-        ceil = lambda n: int(-1 * n // 1 * -1)
-        # align data_address to nearest next multiple of malloc_alignment
-        self.data_address = malloc_alignment * ceil(self.data_address / malloc_alignment)
-        return
-
 
     def get_chunk_size(self):
         return read_int_from_memory(self.size_addr) & (~0x07)
@@ -3582,6 +3574,23 @@ def align_address_to_page(address):
     """Align the address to a page."""
     a = align_address(address) >> DEFAULT_PAGE_ALIGN_SHIFT
     return a << DEFAULT_PAGE_ALIGN_SHIFT
+
+def malloc_align_address(address):
+    """Align addresses according to glibc's MALLOC_ALIGNMENT. See also Issue #689 on Github"""
+    __default_malloc_alignment = 0x10
+    if is_x86_32() and get_libc_version() >= (2, 26):
+        # Special case introduced in Glibc 2.26:
+        # https://elixir.bootlin.com/glibc/glibc-2.26/source/sysdeps/i386/malloc-alignment.h#L22
+        malloc_alignment = __default_malloc_alignment
+    else:
+        # Generic case:
+        # https://elixir.bootlin.com/glibc/glibc-2.26/source/sysdeps/generic/malloc-alignment.h#L22
+        __alignof__long_double = int(safe_parse_and_eval("_Alignof(long double)") or __default_malloc_alignment) # fallback to default if the expression fails to evaluate
+        malloc_alignment = max(__alignof__long_double, 2 * current_arch.ptrsize)
+
+    ceil = lambda n: int(-1 * n // 1 * -1)
+    # align address to nearest next multiple of malloc_alignment
+    return malloc_alignment * ceil((address / malloc_alignment))
 
 
 def parse_address(address):
@@ -6604,7 +6613,7 @@ class GlibcHeapSetArenaCommand(GenericCommand):
         global __gef_default_main_arena__
 
         if not argv:
-            ok("Current main_arena set to: '{}'".format(__gef_default_main_arena__))
+            ok("Current arena set to: '{}'".format(__gef_default_main_arena__))
             return
 
         new_arena = safe_parse_and_eval(argv[0])
@@ -6696,21 +6705,20 @@ class GlibcHeapChunksCommand(GenericCommand):
     def do_invoke(self, *args, **kwargs):
         args = kwargs["arguments"]
 
-        if not args.address:
-            heap_section = HeapBaseFunction.heap_base()
-            if not heap_section:
-                err("Heap not initialized")
-                return
-        else:
-            heap_section = parse_address(args.address)
-
         arena = get_main_arena()
         if arena is None:
             err("No valid arena")
             return
 
+        if not args.address:
+            heap_addr = arena.heap_addr()
+            if heap_addr is None:
+                return
+        else:
+            heap_addr = int(args.address, 0)
+
         nb = self.get_setting("peek_nb_byte")
-        current_chunk = GlibcChunk(heap_section, from_base=True, allow_unaligned=args.allow_unaligned)
+        current_chunk = GlibcChunk(heap_addr, from_base=True, allow_unaligned=args.allow_unaligned)
         while True:
             if current_chunk.base_address == arena.top:
                 gef_print("{} {} {}".format(str(current_chunk), LEFT_ARROW, Color.greenify("top chunk")))

--- a/gef.py
+++ b/gef.py
@@ -151,7 +151,7 @@ __pie_breakpoints__                    = {}
 __pie_counter__                        = 1
 __gef_remote__                         = None
 __gef_qemu_mode__                      = False
-__gef_current_arena__             = "main_arena"
+__gef_current_arena__                  = "main_arena"
 __gef_int_stream_buffer__              = None
 __gef_redirect_output_fd__             = None
 


### PR DESCRIPTION
## Fix 'heap chunks' command for non-main arenas (#706) ##

### Description/Motivation/Screenshots ###
 
see #706 

This PR adds the capability to `GlibcArena` to get the  base address of the associated heap region  for main_arena and also non-main arenas. This new heap base address is used in the `heap chunks` command to make it work with non-main arenas.

![image](https://user-images.githubusercontent.com/37738506/132109314-e8346a2e-13e2-4fc3-bd14-a0be0ca33669.png)


For now better tests that check if `heap chunks` works with "main_arena" but also a "non-main arena" are still missing in this PR.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [ ] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
