### PR TITLE
Fix namebreak and add additional unit tests

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -4206,8 +4206,7 @@ class NamedBreakpoint(gdb.Breakpoint):
     """Breakpoint which shows a specified name, when hit."""
 
     def __init__(self, location, name):
-        address = "*{}".format(parse_address(location))
-        super().__init__(spec=address, type=gdb.BP_BREAKPOINT, internal=False, temporary=False)
+        super().__init__(spec=location, type=gdb.BP_BREAKPOINT, internal=False, temporary=False)
         self.name = name
         self.loc = location
         return
@@ -7754,7 +7753,7 @@ class NamedBreakpointCommand(GenericCommand):
         super().__init__()
         return
 
-    @parse_arguments({"name": "", "address": "$pc"}, {})
+    @parse_arguments({"name": "", "address": "*$pc"}, {})
     def do_invoke(self, *args, **kwargs):
         args = kwargs["arguments"]
         if not args.name:

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -314,6 +314,14 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
     def test_cmd_name_break(self):
         res = gdb_run_cmd("nb foobar *main+10")
         self.assertNoException(res)
+
+        res = gdb_run_cmd("nb foobar *0xcafebabe")
+        self.assertNoException(res)
+        self.assertIn("at 0xcafebabe", res)
+
+        res = gdb_start_silent_cmd("nb foobar")
+        self.assertNoException(res)
+
         return
 
     def test_cmd_keystone_assemble(self):


### PR DESCRIPTION
## Fix namebreak and add additional unit tests ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

fix #707

Using `parse_address`, when the user already specified a direct address like `*0x40600` will result in dereferencing the address instead of just passing it to `Breakpoint`.

This patch replaces the default value for address, if none is given, with `*$pc` instead of `$pc` and removes parsing of the address completely, since user input will already be in the correct format for `Breakpoint`.

This way `nb` behaves more like default `b` command again

```
gef➤  nb testpc
Breakpoint 1 at 0x7ffff7ebde82: file ../sysdeps/unix/sysv/linux/read.c, line 26.
gef➤  nb testdirect *0x7ffff7ebde8a
Breakpoint 2 at 0x7ffff7ebde8a: file ../sysdeps/unix/sysv/linux/read.c, line 26.
gef➤  nb testdirect *0x7ffff7ebde8a+4
Breakpoint 3 at 0x7ffff7ebde8e: file ../sysdeps/unix/sysv/linux/read.c, line 26.
gef➤  nb testsymbol *read+32
Breakpoint 4 at 0x7ffff7ebde90: file ../sysdeps/unix/sysv/linux/read.c, line 26.
```

Kudos to @theguy147 for adding unit tests on `namebreak`. Added some additional tests, which will also check for direct address breakpoints.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |                                           |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
