### PR TITLE
Add test for printing chunks with multiple heaps

### DIFF
--- a/tests/binaries/Makefile
+++ b/tests/binaries/Makefile
@@ -44,6 +44,6 @@ pattern.out: EXTRA_FLAGS := -D_FORTIFY_SOURCE=0 -fno-stack-protector
 
 canary.out: EXTRA_FLAGS := -fstack-protector-all
 
-heap-non-main.out heap-tcache.out: EXTRA_FLAGS := -pthread
+heap-non-main.out heap-tcache.out heap-multiple-heaps.out: EXTRA_FLAGS := -pthread
 
 default.out: EXTRA_FLAGS := -fstack-protector-all -fpie -pie

--- a/tests/binaries/heap-multiple-heaps.c
+++ b/tests/binaries/heap-multiple-heaps.c
@@ -1,0 +1,47 @@
+/**
+ * -*- mode: c -*-
+ * -*- coding: utf-8 -*-
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+/* Any allocation over 128KB is directed directly to mmap, which we don't want. */
+#define LESS_THAN_MMAP_THRESHOLD    (127 * 1024)
+/* Experimentally, a new heap is created at ~500 allocations. */
+#define NUM_ALLOCS                  1032
+/* The expected distance is the chunk size plus room for the metadata. */
+#define EXPECTED_CHUNK_DISTANCE     LESS_THAN_MMAP_THRESHOLD + 24
+
+void *thread()
+{
+        void *pointers[NUM_ALLOCS];
+        for (int i = 0; i < NUM_ALLOCS; i++) {
+            pointers[i] = malloc(LESS_THAN_MMAP_THRESHOLD);
+            int chunk_distance = (i > 0) ? pointers[i] - pointers[i-1] : EXPECTED_CHUNK_DISTANCE;
+            /* If the chunk_distance is negative, a new heap was created 
+             * before the first heap. If greater than the expected distance,
+             * then a new heap was created after the first heap.
+             */
+            if (chunk_distance < 0 ||
+                    chunk_distance > EXPECTED_CHUNK_DISTANCE) {
+                __builtin_trap();
+            }
+        }
+
+        (void)pointers;
+        return NULL;
+}
+
+int main(int argc, char** argv, char** envp)
+{
+        void* p1 = malloc(0x10);
+
+        pthread_t thread1;
+        pthread_create(&thread1, NULL, thread, NULL);
+        pthread_join(thread1, NULL);
+
+        (void)p1;
+        return EXIT_SUCCESS;
+}

--- a/tests/binaries/heap-multiple-heaps.c
+++ b/tests/binaries/heap-multiple-heaps.c
@@ -9,7 +9,13 @@
 
 /* Any allocation over 128KB is directed directly to mmap, which we don't want. */
 #define LESS_THAN_MMAP_THRESHOLD    (127 * 1024)
-/* Experimentally, a new heap is created at ~500 allocations. */
+/* For a 64-bit executable, an arena has about 0x8000000 bytes of space before
+ * it runs into another arena. 0x8000000 / 127KB is roughly 1032, so that's
+ * our upper limit for the number of allocations we'll create. In practice,
+ * you don't need nearly this many allocations to trigger the creation of a
+ * new heap within a non-main arena. For 64-bit executables, a new heap
+ * triggers at around ~500 allocations of 127KB each.
+ */
 #define NUM_ALLOCS                  1032
 /* The expected distance is the chunk size plus room for the metadata. */
 #define EXPECTED_CHUNK_DISTANCE     LESS_THAN_MMAP_THRESHOLD + 24

--- a/tests/binaries/heap-multiple-heaps.c
+++ b/tests/binaries/heap-multiple-heaps.c
@@ -26,7 +26,7 @@ void *thread()
         for (int i = 0; i < NUM_ALLOCS; i++) {
             pointers[i] = malloc(LESS_THAN_MMAP_THRESHOLD);
             int chunk_distance = (i > 0) ? pointers[i] - pointers[i-1] : EXPECTED_CHUNK_DISTANCE;
-            /* If the chunk_distance is negative, a new heap was created 
+            /* If the chunk_distance is negative, a new heap was created
              * before the first heap. If greater than the expected distance,
              * then a new heap was created after the first heap.
              */

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -233,7 +233,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_heap_chunks_mult_heaps(self):
-        before = ['python gdb.execute("heap set-arena {}".format(get_main_arena().next))']
+        before = ['run', 'python gdb.execute("heap set-arena {}".format(get_glibc_arena().next))']
         cmd = "heap chunks"
         target = "/tmp/heap-multiple-heaps.out"
         res = gdb_run_silent_cmd(cmd, before=before, target=target)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -232,6 +232,16 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertIn("top chunk", res)
         return
 
+    def test_cmd_heap_chunks_mult_heaps(self):
+        before = ['python gdb.execute("heap set-arena {}".format(get_main_arena().next))']
+        cmd = "heap chunks"
+        target = "/tmp/heap-multiple-heaps.out"
+        res = gdb_run_silent_cmd(cmd, before=before, target=target)
+        self.assertNoException(res)
+        self.assertIn("Chunk(addr=", res)
+        self.assertIn("top chunk", res)
+        return
+
     def test_cmd_heap_bins_fast(self):
         cmd = "heap bins fast"
         before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]


### PR DESCRIPTION
This test checks that when a non-main arena has multiple (and therefore
non-contiguous) heaps, we still print them all out.

## Add test for printing chunks with multiple heaps ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

As part of the ongoing effort to fix the `heap chunks` for non-main arenas, this PR adds a test that triggers the creation of a new heap in a non-main arena. This new heap will be non-contiguous with the original heap, which is a corner case that our eventual solution for the `heap chunks` command will have to handle.

Originally discussed at #709.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
