### PR TITLE
Add test for gef-remote cmd

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install python and toolchain
       run: |
         sudo apt-get update
-        sudo apt-get install -y gdb-multiarch python3-dev python3-pip python3-wheel python3-setuptools git cmake gcc g++ pkg-config libglib2.0-dev
+        sudo apt-get install -y gdb-multiarch python3-dev python3-pip python3-wheel python3-setuptools git cmake gcc g++ pkg-config libglib2.0-dev gdbserver
         sudo python3 -m pip install --upgrade pip
 
     - name: Get pip cache dir

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -167,6 +167,26 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertNotIn("strcpy", res)
         return
 
+    def test_cmd_gef_remote(self):
+        def start_gdbserver(exe="/tmp/default.out", port=1234):
+            return subprocess.Popen(["gdbserver", ":{}".format(port), exe],
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        def stop_gdbserver(gdbserver):
+            """Stops the gdbserver and waits until it is terminated if it was
+            still running. Needed to make the used port available again."""
+            if gdbserver.poll() is None:
+                gdbserver.kill()
+                gdbserver.wait()
+            return
+
+        before = ["gef-remote :1234"]
+        gdbserver = start_gdbserver()
+        res = gdb_start_silent_cmd("vmmap", before=before)
+        self.assertNoException(res)
+        stop_gdbserver(gdbserver)
+        return
+
     def test_cmd_heap_arenas(self):
         cmd = "heap arenas"
         target = "/tmp/heap.out"


### PR DESCRIPTION
## Add test for gef-remote cmd ##

### Description/Motivation/Screenshots ###

Adding `test_cmd_gef_remote` (Continuation of #685 and #686).

Currently "only" testing `vmmap` in the gef-remote session as it is important for GEF to get the process mapping right in such remote sessions. But other commands can easily be added if/when needed the same way.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
