### PR TITLE
Fix unicorn-emulate cmd

### DIFF
--- a/docs/commands/unicorn-emulate.md
+++ b/docs/commands/unicorn-emulate.md
@@ -1,38 +1,44 @@
 ## Command unicorn-emulate ##
 
 If you have installed [`unicorn`](http://unicorn-engine.org) emulation engine
-and its Python bindings, `gef` integrates a new command to emulate instructions
+and its Python bindings, GEF integrates a new command to emulate instructions
 of your current debugging context !
 
-This command, `unicorn-emulate` (or its alias `emu`) will replicate the current
+This `unicorn-emulate` command (or its alias `emu`) will replicate the current
 memory mapping (including the page permissions) for you, and by default (i.e.
 without any additional argument), it will emulate the execution of the
-instruction about to be executed (i.e. the one pointed by `$pc`) and display
-which register(s) is(are) tainted by it.
+instruction about to be executed (i.e. the one pointed by `$pc`). Furthermore
+the command will print out the state of the registers before and after the
+emulation.
 
-Use `-h` for help
+Use `-h` for help:
+
 ```
 gef➤ emu -h
 ```
 
-For example, the following command will execute only the next 2 instructions:
+For example, the following command will emulate only the next 2 instructions:
+
 ```
-gef➤ emu -n 2
+gef➤ emu 2
 ```
 
 And show this:
-![emu](https://i.imgur.com/DmVH6o1.png)
+
+![emu](https://i.imgur.com/n4Oy5D0.png)
 
 In this example, we can see that after executing
-```
-0x80484db	 <main+75>  xor    eax,eax
-0x80484dd	 <main+77>  add    esp,0x18
-```
-The registers `eax` and `esp` are tainted (modified).
 
-A convenient option is `-o /path/to/file.py` that will generate a pure Python
-script embedding your current execution context, ready to be re-used outside
-`gef`!! This can be useful for dealing with obfuscation or solve crackmes if
-powered with a SMT for instance.
+```
+0x555555555171 <main+8>         sub    rsp, 0x10
+0x555555555175 <main+12>        mov    edi, 0x100
+```
+
+The registers `rsp` and `rdi` are tainted (modified).
+
+A convenient option is `--output-file /path/to/file.py` that will generate a
+pure Python script embedding your current execution context, ready to be re-used
+outside GEF!! This can be useful for dealing with obfuscation or solve crackmes
+if powered with a SMT for instance.
 
 

--- a/gef.py
+++ b/gef.py
@@ -6084,7 +6084,6 @@ def syscall_hook(emu, user_data):
     return
 
 def print_regs(emu, regs):
-    
     for i, r in enumerate(regs):
         print("{{:7s}} = {{:#0{ptrsize}x}}  ".format(r, emu.reg_read(regs[r])), end="")
         if (i % 4 == 3) or (i == len(regs)-1): print("")
@@ -6101,7 +6100,7 @@ def reset():
            verbose="True" if verbose else "False",
            syscall_reg=current_arch.syscall_register,
            cs_arch=cs_arch, cs_mode=cs_mode,
-           ptrsize=current_arch.ptrsize * 2,  # two hex chars per byte
+           ptrsize=current_arch.ptrsize * 2 + 2,  # two hex chars per byte plus "0x" prefix
            emu_block=emulate_segmentation_block if is_x86() else "",
            arch=arch, mode=mode,
            context_block=context_segmentation_block if is_x86() else "")

--- a/gef.py
+++ b/gef.py
@@ -1391,7 +1391,6 @@ def gef_disassemble(addr, nb_insn, nb_prev=0):
     """Disassemble `nb_insn` instructions after `addr` and `nb_prev` before `addr`.
     Return an iterator of Instruction objects."""
     nb_insn = max(1, nb_insn)
-    count = nb_insn + 1 if nb_insn & 1 else nb_insn
 
     if nb_prev:
         start_addr = gdb_get_nth_previous_instruction_address(addr, nb_prev)
@@ -1400,7 +1399,7 @@ def gef_disassemble(addr, nb_insn, nb_prev=0):
                 if insn.address == addr: break
                 yield insn
 
-    for insn in gdb_disassemble(addr, count=count):
+    for insn in gdb_disassemble(addr, count=nb_insn):
         yield insn
 
 
@@ -5979,16 +5978,16 @@ class UnicornEmulateCommand(GenericCommand):
         return
 
     @only_if_gdb_running
-    @parse_arguments({"nb": 1}, {"--start": 0, "--until": 0, "--skip-emulation": True, "--output-file": ""})
-    def do_invoke(self, argv, *args, **kwargs):
+    @parse_arguments({"nb": 1}, {"--start": "", "--until": "", "--skip-emulation": True, "--output-file": ""})
+    def do_invoke(self, *args, **kwargs):
         args = kwargs["arguments"]
-        start_address = args.start or current_arch.pc
-        end_address = args.until or self.get_unicorn_end_addr(start_address, args.nb)
+        start_address = parse_address(str(args.start or current_arch.pc))
+        end_address = parse_address(str(args.until or self.get_unicorn_end_addr(start_address, args.nb)))
         self.run_unicorn(start_address, end_address, skip_emulation=args.skip_emulation, to_file=args.output_file)
         return
 
     def get_unicorn_end_addr(self, start_addr, nb):
-        dis = list(gef_disassemble(start_addr, nb + 1, True))
+        dis = list(gef_disassemble(start_addr, nb + 1))
         last_insn = dis[-1]
         return last_insn.address
 
@@ -6085,6 +6084,7 @@ def syscall_hook(emu, user_data):
     return
 
 def print_regs(emu, regs):
+    
     for i, r in enumerate(regs):
         print("{{:7s}} = {{:#0{ptrsize}x}}  ".format(r, emu.reg_read(regs[r])), end="")
         if (i % 4 == 3) or (i == len(regs)-1): print("")
@@ -6101,7 +6101,7 @@ def reset():
            verbose="True" if verbose else "False",
            syscall_reg=current_arch.syscall_register,
            cs_arch=cs_arch, cs_mode=cs_mode,
-           ptrsize=current_arch.ptrsize,
+           ptrsize=current_arch.ptrsize * 2,  # two hex chars per byte
            emu_block=emulate_segmentation_block if is_x86() else "",
            arch=arch, mode=mode,
            context_block=context_segmentation_block if is_x86() else "")

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -629,13 +629,20 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_unicorn_emulate(self):
-        cmd = "emu 10"
+        nb_insn = 4
+        cmd = "emu {}".format(nb_insn)
         res = gdb_run_cmd(cmd)
         self.assertFailIfInactiveSession(res)
 
-        res = gdb_start_silent_cmd(cmd)
+        start_marker = "= Starting emulation ="
+        end_marker = "Final registers"
+        res = gdb_run_cmd(cmd, before=["start", "si"])  # "si" needed to avoid invalid memory read
         self.assertNoException(res)
-        self.assertIn("Final registers", res)
+        self.assertNotIn("Emulation failed", res)
+        self.assertIn(start_marker, res)
+        self.assertIn(end_marker, res)
+        insn_executed = len(res[res.find(start_marker):res.find(end_marker)].splitlines()[1:-1])
+        self.assertTrue(insn_executed >= nb_insn)
         return
 
     def test_cmd_vmmap(self):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -629,6 +629,8 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_unicorn_emulate(self):
+        target = "/tmp/default.out"
+
         nb_insn = 4
         cmd = "emu {}".format(nb_insn)
         res = gdb_run_cmd(cmd)
@@ -636,7 +638,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
         start_marker = "= Starting emulation ="
         end_marker = "Final registers"
-        res = gdb_run_cmd(cmd, before=["start", "si"])  # "si" needed to avoid invalid memory read
+        res = gdb_run_cmd(cmd, before=["start", "si"], target=target)  # "si" needed to avoid invalid memory read
         self.assertNoException(res)
         self.assertNotIn("Emulation failed", res)
         self.assertIn(start_marker, res)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -629,7 +629,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_unicorn_emulate(self):
-        target = "/tmp/default.out"
+        before = ["br *main", "r", "si"]  # "si" needed to avoid invalid memory read
 
         nb_insn = 4
         cmd = "emu {}".format(nb_insn)
@@ -638,7 +638,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
         start_marker = "= Starting emulation ="
         end_marker = "Final registers"
-        res = gdb_run_cmd(cmd, before=["start", "si"], target=target)  # "si" needed to avoid invalid memory read
+        res = gdb_run_cmd(cmd, before=before)
         self.assertNoException(res)
         self.assertNotIn("Emulation failed", res)
         self.assertIn(start_marker, res)


### PR DESCRIPTION
## Fix unicorn-emulate cmd ##

### Description/Motivation/Screenshots ###

This PR is part of #693 and covers the following points:
- Fix emulating the wrong number of instructions for even numbers
- Update docs for cmd (incl Screenshot)
- Fix alignment of registers in output
- Fix address parsing of cmd
- Update test to check for failed emulations and count the number of emulated instructions

Here some before/after screenshots:

#### Before ####

![image](https://user-images.githubusercontent.com/37738506/132553925-68301897-4129-4a78-a3fd-25221b4a2f3d.png)

#### After ####

![image](https://user-images.githubusercontent.com/37738506/132553840-7e2ca9ea-0f1d-42c4-87a8-70b4e51fce11.png)

In the future it might even be cool to print the registers in GEFs standard way (incl marking tainted registers with color) but this PR was more about fixing the broken parts of the command.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |   |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
