### PR TITLE
Use `pytest` on top of `unittest` to allow multi-proc execution

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-18.04']
+        os: [ubuntu-20.04, ubuntu-18.04]
     name: "Run Unit tests on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     defaults:

--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,14 @@ PYLINT_PARAMETERS := --disable=$(PYLINT_DISABLE) --enable=$(PYLINT_ENABLE) --job
 
 test: testbins
 	@cp gef.py /tmp/gef.py
-	python3 tests/runtests.py
+	python3 -m pytest --verbose --numprocesses=$(NB_CORES) tests/runtests.py
 	@rm -f /tmp/gef.py
 	@rm -f /tmp/gef-*
 	@$(MAKE) -j $(NB_CORES) -C tests/binaries clean
 
 Test%: testbins
 	@cp gef.py /tmp/gef.py
-	python3 tests/runtests.py $@
+	python3 -m pytest --verbose --numprocesses=$(NB_CORES) tests/runtests.py $@
 	@rm -f /tmp/gef.py
 	@rm -f /tmp/gef-*
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you really need GDB+Python2, use the (not actively maintained) [`gef-legacy`]
 
 ## Community ##
 
-[![Discord](https://img.shields.io/badge/Discord-GDB--GEF-yellow)](https://discordapp.com/channels/705160148813086841/705160148813086843) [[invite link](https://discord.gg/HCS8Hg7)]
+[![Discord](https://img.shields.io/badge/Discord-GDB--GEF-yellow)](https://discord.gg/HCS8Hg7)
 
 _Note_: For maintenance simplicity, the unified communities on IRC/Gitter/Slack/Discord based [MatterBridge](https://github.com/42wim/matterbridge) are now discontinued. The GEF Discord is now the only way for talking with us!
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ keystone-engine
 pylint
 ropper
 unicorn
+pytest
+pytest-xdist

--- a/tests/binaries/unicorn.c
+++ b/tests/binaries/unicorn.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+#include <string.h>
+
+int function1()
+{
+    const char* a1 = "PATH";
+    const char* a2 = "WHATEVER";
+    return strcmp( getenv(a1), a2);
+}
+
+int main()
+{
+    return function1();
+}

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -631,12 +631,14 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
     def test_cmd_unicorn_emulate(self):
         nb_insn = 4
         cmd = "emu {}".format(nb_insn)
-        res = gdb_run_cmd(cmd)
+        res = gdb_run_silent_cmd(cmd)
         self.assertFailIfInactiveSession(res)
 
+        target = "/tmp/unicorn.out"
+        before = ["break function1", "si"]
         start_marker = "= Starting emulation ="
         end_marker = "Final registers"
-        res = gdb_start_silent_cmd(cmd)
+        res = gdb_run_silent_cmd(cmd, target=target, before=before)
         self.assertNoException(res)
         self.assertNotIn("Emulation failed", res)
         self.assertIn(start_marker, res)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -629,8 +629,6 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_unicorn_emulate(self):
-        before = ["br *main", "r", "si"]  # "si" needed to avoid invalid memory read
-
         nb_insn = 4
         cmd = "emu {}".format(nb_insn)
         res = gdb_run_cmd(cmd)
@@ -638,7 +636,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
         start_marker = "= Starting emulation ="
         end_marker = "Final registers"
-        res = gdb_run_cmd(cmd, before=before)
+        res = gdb_start_silent_cmd(cmd)
         self.assertNoException(res)
         self.assertNotIn("Emulation failed", res)
         self.assertIn(start_marker, res)


### PR DESCRIPTION
## Use `pytest` for CI ##

### Description/Motivation/Screenshots ###

This PR is background work for the self-hosting CI runners that will allow to test non-x86 archs (although GH Actions only offers ARM & AARCH64 for now).

Since each unittest we do is totally independent from one another, we can massively improve the time ~~wasted~~ spent in CI testing by splitting on more cores. That's exactly the point of this PR: make use of `pytest` + `pytest-xdist` on top of `unittest` to distribute the tests. New test time is (roughly) the old divided by the number of cores given.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       |  :heavy_check_mark: | |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      |  :heavy_check_mark: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
