### PR TITLE
Fix context failed to execute because breakpoint.location is None

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8246,7 +8246,7 @@ class ContextCommand(GenericCommand):
 
         file_base_name = os.path.basename(symtab.filename)
         breakpoints = gdb.breakpoints() or []
-        bp_locations = [b.location for b in breakpoints if file_base_name in b.location]
+        bp_locations = [b.location for b in breakpoints if b.location and file_base_name in b.location]
         past_lines_color = get_gef_setting("theme.old_context")
 
         nb_line = self.get_setting("nb_lines_code")


### PR DESCRIPTION
## Fix context failed to execute because breakpoint.location is None when watchpoint is set ##

### Description ###
Fix error of
```bash
[ Legend: Modified register | Code | Heap | Stack | String ]
[!] Command 'context' failed to execute properly, reason: argument of type 'NoneType' is not iterable
```
when breakpoints are set and breakpoint.location is not available.

![20210914-191847-gef-fail-blur](https://user-images.githubusercontent.com/16630667/133249771-ecddda30-d665-4e12-b81d-6485bf0fe730.png)


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                           |
| x86-64       |           Yes            |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  |         Yes              |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
