### PR TITLE
Fix heap chunks cmd for multiple heaps per arena

### DIFF
--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -27,7 +27,7 @@ this:
 gef➤ heap chunks [arena_address]
 ```
 
-![heap-chunks](https://i.imgur.com/2Ew2fA6.png)
+![heap-chunks-arena](https://i.imgur.com/y1fybRx.png)
 
 Because usually the heap chunks are aligned to a certain number of bytes in
 memory GEF automatically re-aligns the chunks data start addresses to match

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -19,9 +19,8 @@ gef➤ heap chunks
 
 ![heap-chunks](https://i.imgur.com/y90SfKH.png)
 
-To change the arena for which to display the chunks either use the `heap
-set-arena` command or provide the base address of the other arena like
-this:
+To select from which arena to display chunks either use the `heap set-arena`
+command or provide the base address of the other arena like this:
 
 ```
 gef➤ heap chunks [arena_address]

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -11,25 +11,29 @@ gef➤ heap <sub_commands>
 
 ### `heap chunks` command ###
 
-Displays all the chunks from the `heap` section.
+Displays all the chunks from the `heap` section of the current arena.
 
 ```
 gef➤ heap chunks
 ```
 
-In some cases, the allocation will start immediately from start of the page. If
-so, specify the base address of the first chunk as follows:
+![heap-chunks](https://i.imgur.com/y90SfKH.png)
+
+To change the arena for which to display the chunks either use the `heap
+set-arena` command or provide the base address of the other arena like
+this:
 
 ```
-gef➤ heap chunks [address]
+gef➤ heap chunks [arena_address]
 ```
 
 ![heap-chunks](https://i.imgur.com/2Ew2fA6.png)
 
 Because usually the heap chunks are aligned to a certain number of bytes in
 memory GEF automatically re-aligns the chunks data start addresses to match
-Glibc's behavior. To be able to view unaligned chunks as well, you can
-disable this with the `--allow-unaligned` flag.
+Glibc's behavior. To be able to view unaligned chunks as well, you can disable
+this with the `--allow-unaligned` flag. Note that this might result in
+incorrect output.
 
 ### `heap chunk` command ###
 
@@ -41,12 +45,13 @@ information related to a specific chunk:
 gef➤ heap chunk [address]
 ```
 
-![heap-chunk](https://i.imgur.com/SAWNptW.png)
+![heap-chunk](https://i.imgur.com/WXpHR58.png)
 
 Because usually the heap chunks are aligned to a certain number of bytes in
 memory GEF automatically re-aligns the chunks data start addresses to match
-Glibc's behavior. To be able to view unaligned chunks as well, you can
-disable this with the `--allow-unaligned` flag.
+Glibc's behavior. To be able to view unaligned chunks as well, you can disable
+this with the `--allow-unaligned` flag. Note that this might result in
+incorrect output.
 
 ### `heap arenas` command ###
 

--- a/gef.py
+++ b/gef.py
@@ -637,7 +637,8 @@ class MallocStateStruct:
         try:
             self.__addr = to_unsigned_long(gdb.parse_and_eval("&{}".format(addr)))
         except gdb.error:
-            warn("Could not parse address '&{}' when searching malloc_state struct, using '&main_arena' instead".format(addr))
+            warn("Could not parse address '&{}' when searching malloc_state struct, "
+                 "using '&main_arena' instead".format(addr))
             self.__addr = search_for_main_arena()
 
         self.num_fastbins = 10
@@ -1093,11 +1094,7 @@ def get_glibc_arena(addr=None):
         addr = "*{}".format(addr) if addr else __gef_current_arena__
         return GlibcArena(addr)
     except Exception as e:
-        err(
-            "Failed to get the glibc arena, heap commands may not work properly: {}".format(
-                e
-            )
-        )
+        err("Failed to get the glibc arena, heap commands may not work properly: {}".format(e))
         return None
 
 

--- a/gef.py
+++ b/gef.py
@@ -6816,12 +6816,12 @@ class GlibcHeapChunksCommand(GenericCommand):
         else:
             heap_info_structs = arena.get_heap_info_list()
             first_heap_info = heap_info_structs.pop(0)
-            heap_info_t_size = int(arena) - int(first_heap_info)
-            until = int(first_heap_info) + first_heap_info.size
+            heap_info_t_size = int(arena) - first_heap_info.addr
+            until = first_heap_info.addr + first_heap_info.size
             self.dump_chunks_heap(heap_addr, until=until, top=top_chunk_addr, allow_unaligned=allow_unaligned)
             for heap_info in heap_info_structs:
-                start = int(heap_info) + heap_info_t_size
-                until = int(heap_info) + heap_info.size
+                start = heap_info.addr + heap_info_t_size
+                until = heap_info.addr + heap_info.size
                 self.dump_chunks_heap(start, until=until, top=top_chunk_addr, allow_unaligned=allow_unaligned)
         return
 

--- a/gef.py
+++ b/gef.py
@@ -884,7 +884,7 @@ class GlibcArena:
         See https://github.com/bminor/glibc/blob/glibc-2.34/malloc/arena.c#L129"""
         if is_32bit():
             default_mmap_threshold_max = 512 * 1024
-        else:
+        else:  # 64bit
             default_mmap_threshold_max = 4 * 1024 * 1024 * cached_lookup_type("long").sizeof
         heap_max_size = 2 * default_mmap_threshold_max
         return ptr & ~(heap_max_size - 1)

--- a/gef.py
+++ b/gef.py
@@ -776,26 +776,26 @@ class GlibcHeapInfo:
 
     @property
     def ar_ptr(self):
-        return self.get_size_t_pointer(self.ar_ptr_addr)
+        return self._get_size_t_pointer(self.ar_ptr_addr)
 
     @property
     def prev(self):
-        return self.get_size_t_pointer(self.prev_addr)
+        return self._get_size_t_pointer(self.prev_addr)
 
     @property
     def size(self):
-        return self.get_size_t(self.size_addr)
+        return self._get_size_t(self.size_addr)
 
     @property
     def mprotect_size(self):
-        return self.get_size_t(self.mprotect_size_addr)
+        return self._get_size_t(self.mprotect_size_addr)
 
     # helper methods
-    def get_size_t_pointer(self, addr):
+    def _get_size_t_pointer(self, addr):
         size_t_pointer = self.size_t.pointer()
         return dereference(addr).cast(size_t_pointer)
 
-    def get_size_t(self, addr):
+    def _get_size_t(self, addr):
         return dereference(addr).cast(self.size_t)
 
 

--- a/gef.py
+++ b/gef.py
@@ -753,12 +753,9 @@ class GlibcHeapInfo:
             ptr_type = "unsigned long" if current_arch.ptrsize == 8 else "unsigned int"
             self.size_t = cached_lookup_type(ptr_type)
 
-    def __int__(self):
-        return self.__addr
-
     @property
     def addr(self):
-        return int(self)
+        return self.__addr
 
     @property
     def ar_ptr_addr(self):
@@ -870,7 +867,7 @@ class GlibcArena:
             return _addr
         return malloc_align_address(_addr)
 
-    def get_heap_infos(self):
+    def get_heap_info_list(self):
         if self.is_main_arena():
             return None
         heap_addr = self.get_heap_for_ptr(self.top)
@@ -887,7 +884,7 @@ class GlibcArena:
         See https://github.com/bminor/glibc/blob/glibc-2.34/malloc/arena.c#L129"""
         if is_32bit():
             default_mmap_threshold_max = 512 * 1024
-        elif is_64bit():
+        else:
             default_mmap_threshold_max = 4 * 1024 * 1024 * cached_lookup_type("long").sizeof
         heap_max_size = 2 * default_mmap_threshold_max
         return ptr & ~(heap_max_size - 1)
@@ -6674,7 +6671,6 @@ class CapstoneDisassembleCommand(GenericCommand):
         return (False, "")
 
 
-
 @register_command
 class GlibcHeapCommand(GenericCommand):
     """Base command to get information about the Glibc heap structure."""
@@ -6818,7 +6814,7 @@ class GlibcHeapChunksCommand(GenericCommand):
         if arena.is_main_arena():
             self.dump_chunks_heap(heap_addr, top=top_chunk_addr, allow_unaligned=allow_unaligned)
         else:
-            heap_info_structs = arena.get_heap_infos()
+            heap_info_structs = arena.get_heap_info_list()
             first_heap_info = heap_info_structs.pop(0)
             heap_info_t_size = int(arena) - int(first_heap_info)
             until = int(first_heap_info) + first_heap_info.size

--- a/gef.py
+++ b/gef.py
@@ -1087,6 +1087,7 @@ def get_libc_version():
     return 0, 0
 
 
+@lru_cache()
 def get_glibc_arena(addr=None):
     try:
         addr = "*{}".format(addr) if addr else __gef_current_arena__

--- a/gef.py
+++ b/gef.py
@@ -6805,7 +6805,7 @@ class GlibcHeapChunksCommand(GenericCommand):
         if arena is None:
             err("No valid arena")
             return
-
+        self.dump_chunks_arena(arena, allow_unaligned=args.allow_unaligned)
 
     def dump_chunks_arena(self, arena, print_arena=False, allow_unaligned=False):
         top_chunk_addr = arena.top

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -222,6 +222,14 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertNoException(res)
         self.assertIn("Chunk(addr=", res)
         self.assertIn("top chunk", res)
+
+        cmd = "python gdb.execute('heap chunks {}'.format(get_glibc_arena().next))"
+        target = "/tmp/heap-non-main.out"
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertNotIn("using '&main_arena' instead", res)
+        self.assertIn("Chunk(addr=", res)
+        self.assertIn("top chunk", res)
         return
 
     def test_cmd_heap_bins_fast(self):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -236,7 +236,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_heap_bins_non_main(self):
-        cmd = "python gdb.execute('heap bins fast {}'.format(get_main_arena().next))"
+        cmd = "python gdb.execute('heap bins fast {}'.format(get_glibc_arena().next))"
         before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]
         target = "/tmp/heap-non-main.out"
         res = gdb_run_silent_cmd(cmd, before=before, target=target)


### PR DESCRIPTION
## Fix heap chunks cmd for multiple heaps per arena ##

### Description/Motivation/Screenshots ###

see #706, #709 and #711

This PR fixes the `heap chunks` command for arenas with multiple heaps as described by @irontigran. The tests in #711 do work with this PR after fixing an error in it (when the `before` cmds are executed the heap has not been initialized yet).


There are quite some chunks here so I added a screenshot of the beginning and the end of the command output:

![image](https://user-images.githubusercontent.com/37738506/133534438-96cac41f-520a-4b16-812b-281aef224b40.png)

![image](https://user-images.githubusercontent.com/37738506/133534378-10a80c25-cb18-4469-8359-8af9a31fc73e.png)


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
