### PR TITLE
Configuration for the stale bot 

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - do-not-stale
+  - security
+# Label to use when marking an issue as stale
+staleLabel: need-more-info
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. You can
+  reopen it by adding a comment to this issue.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because it has not had recent activity.
+  If you are the owner of this issue, you can either re-open it and provide a more
+  complete description; or create a new issue.
+  Thank you for your contributions.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,10 +4,10 @@ daysUntilStale: 60
 daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - do-not-stale
+  - pinned
   - security
 # Label to use when marking an issue as stale
-staleLabel: need-more-info
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
@@ -19,3 +19,7 @@ closeComment: >
   If you are the owner of this issue, you can either re-open it and provide a more
   complete description; or create a new issue.
   Thank you for your contributions.
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true  
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true


### PR DESCRIPTION
Created `.github/stale.yml` to auto tag an inactive issue, and close it if still no activity; as recommended by @daniellimws [here](https://discord.com/channels/705160148813086841/705160148813086843/836055917233176577)

Pretty straight forward, but you can read https://github.com/marketplace/stale for details.

This is the default configuration (I just made the `daysUntilClose` to close after 30), with custom comments. 

Note: The file must be merged in `master` to be effective.This 