### PR TITLE
Fix error message on help

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2862,7 +2862,10 @@ def parse_arguments(required_arguments, optional_arguments):
                 else:
                     parser.add_argument(*argname, type=argtype, default=argvalue)
 
-            parsed_args = parser.parse_args(*(args[1:]))
+            try:
+                parsed_args = parser.parse_args(*(args[1:]))
+            except RuntimeWarning:
+                return
             kwargs["arguments"] = parsed_args
             return f(*args, **kwargs)
         return wrapper
@@ -7569,7 +7572,10 @@ class RopperCommand(GenericCommand):
         # ropper set up own autocompleter after which gdb/gef autocomplete don't work
         old_completer_delims = readline.get_completer_delims()
         old_completer = readline.get_completer()
-        ropper.start(argv)
+        try:
+            ropper.start(argv)
+        except RuntimeWarning:
+            return
         readline.set_completer(old_completer)
         readline.set_completer_delims(old_completer_delims)
         return


### PR DESCRIPTION
## Fix error message on help ##

### Description/Motivation/Screenshots ###

As part of #693 this tiny PR removes the GEF error messages on `-h`/`--help` for the commands.

#### Before
![image](https://user-images.githubusercontent.com/37738506/133945050-6d9342ce-4da2-489c-b358-955f53caac65.png)

#### After
![image](https://user-images.githubusercontent.com/37738506/133945077-a46075f1-2147-4c97-bc5b-db88cf0b2c1c.png)


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |   |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
