### PR TITLE
Add feature to print heap chunks of all arenas

### DIFF
--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -67,7 +67,7 @@ Multi-threaded programs have different arenas, and the knowledge of the
 to help you list all the arenas allocated in your program **at the moment you
 call the command**.
 
-![heap-arenas](https://i.imgur.com/ajbLiCF.png)
+![heap-arenas](https://i.imgur.com/RUTiADa.png)
 
 ### `heap set-arena` command ###
 

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -28,6 +28,14 @@ gef➤ heap chunks [arena_address]
 
 ![heap-chunks-arena](https://i.imgur.com/y1fybRx.png)
 
+In order to display the chunks of all the available arenas at once use
+
+```
+gef➤ heap chunks -a
+```
+
+![heap-chunks-all](https://i.imgur.com/pTjRJFo.png)
+
 Because usually the heap chunks are aligned to a certain number of bytes in
 memory GEF automatically re-aligns the chunks data start addresses to match
 Glibc's behavior. To be able to view unaligned chunks as well, you can disable

--- a/gef.py
+++ b/gef.py
@@ -998,6 +998,12 @@ class GlibcArena:
     def __int__(self):
         return self.__addr
 
+    def __iter__(self):
+        arena = self
+        while arena is not None:
+            yield arena
+            arena = arena.get_next()
+
     def fastbin(self, i):
         """Return head chunk in fastbinsY[i]."""
         addr = int(self.fastbinsY[i])
@@ -1268,15 +1274,7 @@ def get_glibc_arena(addr=None):
 
 def get_glibc_arenas(addr=None, get_all=True):
     arena = get_glibc_arena(addr)
-    arenas = [arena]
-    if not get_all:
-        return arenas
-    while True:
-        arena = arena.get_next()
-        if arena is None:
-            break
-        arenas.append(arena)
-    return arenas
+    return [arena for arena in iter(arena)] if get_all else [arena]
 
 
 def titlify(text, color=None, msg_color=None):

--- a/gef.py
+++ b/gef.py
@@ -1056,8 +1056,11 @@ class GlibcArena:
         return ptr & ~(heap_max_size - 1)
 
     def __str__(self):
-        fmt = "Arena (base={:#x}, top={:#x}, last_remainder={:#x}, next={:#x}, next_free={:#x}, system_mem={:#x})"
-        return fmt.format(self.__addr, self.top, self.last_remainder, self.n, self.nfree, self.sysmem)
+        fmt = "{:s}(base={:#x}, top={:#x}, last_remainder={:#x}, next={:#x}, next_free={:#x}, system_mem={:#x})"
+        return fmt.format(
+            Color.colorify("Arena", "blue bold underline"),
+            self.__addr, self.top, self.last_remainder, self.n, self.nfree, self.sysmem
+        )
 
 
 class GlibcChunk:

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -193,7 +193,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_start_silent_cmd(cmd, target=target)
         self.assertNoException(res)
-        self.assertIn("Arena (base=", res)
+        self.assertIn("Arena(base=", res)
         return
 
     def test_cmd_heap_set_arena(self):
@@ -202,7 +202,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target, after=["heap arenas",])
         self.assertNoException(res)
-        self.assertIn("Arena (base=", res)
+        self.assertIn("Arena(base=", res)
         return
 
     def test_cmd_heap_chunk(self):


### PR DESCRIPTION
## Add feature to print heap chunks of all arenas ##

### Description/Motivation/Screenshots ###

This PR adds a new flag `--all`/`-a` to the `heap chunks` command to print out all chunks of all arenas at once (see Screenshot).

Furthermore the style of the Arena output is adjusted to match the style of the Chunks:
- The word "Arena" is colorized (blue).
- The whitespace right after "Arena" has been removed.

![image](https://user-images.githubusercontent.com/37738506/134078340-59efbd86-6c98-4857-b1d4-14eee6c2e4e4.png)
![image](https://user-images.githubusercontent.com/37738506/134078410-4cb37a93-b268-4510-a2b2-7a2adf2fa8c1.png)


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
