### PR TITLE
refactor: use parse_address whenever appropriate

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3015,8 +3015,7 @@ def get_register(regname):
 @lru_cache()
 def __get_register_for_selected_frame(regname, hash_key):
     try:
-        value = gdb.parse_and_eval(regname)
-        return to_unsigned_long(value) if value.type.code == gdb.TYPE_CODE_INT else int(value)
+        return parse_address(regname)
     except gdb.error:
         assert regname[0] == "$"
         regname = regname[1:]
@@ -5300,6 +5299,7 @@ class PCustomCommand(GenericCommand):
         return
 
 
+
     def do_invoke(self, argv):
         argc = len(argv)
         if argc == 0:
@@ -7192,7 +7192,7 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
         try:
             # For multithreaded binaries, the tcache symbol (in thread local
             # storage) will give us the correct address.
-            tcache_addr = gdb.parse_and_eval("(void *) tcache")
+            tcache_addr = parse_address("(void *) tcache")
         except gdb.error:
             # In binaries not linked with pthread (and therefore there is only
             # one thread), we can't use the tcache symbol, but we can guess the
@@ -8117,7 +8117,7 @@ class EntryPointBreakCommand(GenericCommand):
 
         for sym in entrypoints:
             try:
-                value = gdb.parse_and_eval(sym)
+                value = parse_address(sym)
                 info("Breaking at '{:s}'".format(str(value)))
                 bp = EntryBreakBreakpoint(sym)
                 gdb.execute("run {}".format(" ".join(argv)))

--- a/gef.py
+++ b/gef.py
@@ -5299,7 +5299,6 @@ class PCustomCommand(GenericCommand):
         return
 
 
-
     def do_invoke(self, argv):
         argc = len(argv)
         if argc == 0:

--- a/gef.py
+++ b/gef.py
@@ -7149,7 +7149,7 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
             gef_print(titlify("Tcachebins for thread {:d}".format(thread.num)))
             tcache_empty = True
             for i in range(self.TCACHE_MAX_BINS):
-                chunk, count = self.tcachebin(int(tcache_addr), i)
+                chunk, count = self.tcachebin(tcache_addr, i)
                 chunks = set()
                 msg = []
 

--- a/gef.py
+++ b/gef.py
@@ -8917,7 +8917,6 @@ class MemoryWatchCommand(GenericCommand):
             self.usage()
             return
 
-        address = to_unsigned_long(gdb.parse_and_eval(argv[0]))
         address = parse_address(argv[0])
         size    = parse_address(argv[1]) if len(argv) > 1 else 0x10
         group   = "byte"

--- a/gef.py
+++ b/gef.py
@@ -782,7 +782,7 @@ class Instruction:
 @lru_cache()
 def search_for_main_arena():
     global __gef_current_arena__
-    malloc_hook_addr = to_unsigned_long(gdb.parse_and_eval("(void *)&__malloc_hook"))
+    malloc_hook_addr = parse_address("(void *)&__malloc_hook")
 
     if is_x86():
         addr = align_address_to_size(malloc_hook_addr + current_arch.ptrsize, 0x20)
@@ -800,7 +800,7 @@ class MallocStateStruct:
 
     def __init__(self, addr):
         try:
-            self.__addr = to_unsigned_long(gdb.parse_and_eval("&{}".format(addr)))
+            self.__addr = parse_address("&{}".format(addr))
         except gdb.error:
             warn("Could not parse address '&{}' when searching malloc_state struct, "
                  "using '&main_arena' instead".format(addr))
@@ -4258,7 +4258,7 @@ class TraceMallocRetBreakpoint(gdb.FinishBreakpoint):
         if self.return_value:
             loc = int(self.return_value)
         else:
-            loc = to_unsigned_long(gdb.parse_and_eval(current_arch.return_register))
+            loc = parse_address(current_arch.return_register)
 
         size = self.size
         ok("{} - {}({})={:#x}".format(Color.colorify("Heap-Analysis", "yellow bold"), self.name, size, loc))
@@ -4344,7 +4344,7 @@ class TraceReallocRetBreakpoint(gdb.FinishBreakpoint):
         if self.return_value:
             newloc = int(self.return_value)
         else:
-            newloc = to_unsigned_long(gdb.parse_and_eval(current_arch.return_register))
+            newloc = parse_address(current_arch.return_register)
 
         if newloc != self:
             ok("{} - realloc({:#x}, {})={}".format(Color.colorify("Heap-Analysis", "yellow bold"),
@@ -4739,7 +4739,7 @@ class PrintFormatCommand(GenericCommand):
             err("Language must be in: {}".format(str(self.valid_formats)))
             return
 
-        start_addr = int(gdb.parse_and_eval(args.location))
+        start_addr = parse_address(args.location)
         size = int(args.bitlen / 8)
         end_addr = start_addr + args.length * size
         fmt = self.format_matrix[args.bitlen][0]
@@ -5312,7 +5312,7 @@ class PCustomCommand(GenericCommand):
             gdb.execute("pcustom show {}".format(structname))
         else:
             try:
-                address = int(gdb.parse_and_eval(argv[1]))
+                address = parse_address(argv[1])
             except gdb.error:
                 err("Failed to parse '{:s}'".format(argv[1]))
                 return
@@ -5819,7 +5819,7 @@ class IdaInteractCommand(GenericCommand):
         for bp in breakpoints:
             if bp.enabled and not bp.temporary:
                 if bp.location[0] == "*": # if it's an address i.e. location starts with "*"
-                    addr = int(gdb.parse_and_eval(bp.location[1:]))
+                    addr = parse_address(bp.location[1:])
                 else:  # it is a symbol
                     addr = int(gdb.parse_and_eval(bp.location).address)
                 if not (base_address <= addr < end_address):
@@ -5850,7 +5850,7 @@ class IdaInteractCommand(GenericCommand):
         for bp in breakpoints:
             if bp.enabled and not bp.temporary:
                 if bp.location[0] == "*": # if it's an address i.e. location starts with "*"
-                    addr = int(gdb.parse_and_eval(bp.location[1:]))
+                    addr = parse_address(bp.location[1:])
                 else:  # it is a symbol
                     addr = int(gdb.parse_and_eval(bp.location).address)
 
@@ -6962,7 +6962,7 @@ class GlibcHeapChunkCommand(GenericCommand):
         if get_glibc_arena() is None:
             return
 
-        addr = to_unsigned_long(gdb.parse_and_eval(args.address))
+        addr = parse_address(args.address)
         chunk = GlibcChunk(addr, allow_unaligned=args.allow_unaligned)
         gef_print(chunk.psprint())
         return
@@ -8918,7 +8918,8 @@ class MemoryWatchCommand(GenericCommand):
             return
 
         address = to_unsigned_long(gdb.parse_and_eval(argv[0]))
-        size    = to_unsigned_long(gdb.parse_and_eval(argv[1])) if len(argv) > 1  else 0x10
+        address = parse_address(argv[0])
+        size    = parse_address(argv[1]) if len(argv) > 1 else 0x10
         group   = "byte"
 
         if len(argv) == 3:
@@ -8956,7 +8957,7 @@ class MemoryUnwatchCommand(GenericCommand):
             self.usage()
             return
 
-        address = to_unsigned_long(gdb.parse_and_eval(argv[0]))
+        address = parse_address(argv[0])
         res = __watches__.pop(address, None)
         if not res:
             warn("You weren't watching {:#x}".format(address))
@@ -9024,7 +9025,7 @@ class HexdumpCommand(GenericCommand):
 
         args = kwargs["arguments"]
         target = args.address or self.__last_target
-        start_addr = to_unsigned_long(gdb.parse_and_eval(target))
+        start_addr = parse_address(target)
         read_from = align_address(start_addr)
 
         if self.format == "byte":
@@ -9164,7 +9165,7 @@ class PatchCommand(GenericCommand):
             self.usage()
             return
 
-        addr = align_address(int(gdb.parse_and_eval(args.location)))
+        addr = align_address(parse_address(args.location))
         size, fcode = self.SUPPORTED_SIZES[self.format]
 
         d = endian_str()
@@ -9248,7 +9249,7 @@ class PatchStringCommand(GenericCommand):
             return
 
         location, s = argv[0:2]
-        addr = align_address(int(gdb.parse_and_eval(location)))
+        addr = align_address(parse_address(location))
 
         try:
             s = codecs.escape_decode(s)[0]
@@ -9693,7 +9694,7 @@ class XorMemoryDisplayCommand(GenericCommand):
             self.usage()
             return
 
-        address = int(gdb.parse_and_eval(argv[0]))
+        address = parse_address(argv[0])
         length = int(argv[1], 0)
         key = argv[2]
         block = read_memory(address, length)
@@ -9761,7 +9762,7 @@ class TraceRunCommand(GenericCommand):
 
         try:
             loc_start   = current_arch.pc
-            loc_end     = int(gdb.parse_and_eval(argv[0]))
+            loc_end     = parse_address(argv[0])
         except gdb.error as e:
             err("Invalid location: {:s}".format(e))
             return
@@ -10465,7 +10466,7 @@ class HeapBaseFunction(GenericFunction):
     @staticmethod
     def heap_base():
         try:
-            base = int(gdb.parse_and_eval("mp_->sbrk_base"))
+            base = parse_address("mp_->sbrk_base")
             if base != 0:
                 return base
         except gdb.error:


### PR DESCRIPTION
## refactor: use parse_address whenever appropriate ##

### Description/Motivation/Screenshots ###

This small refactoring PR replaces the following occurrences with `parse_address` for consistency and easier maintainability:

- `to_unsigned_long(gdb.parse_and_eval(...))`
- `int(gdb.parse_and_eval(...))`

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
