### PR TITLE
CI: Lint: Add more linters to test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NB_CORES := $(shell grep --count '^processor' /proc/cpuinfo)
 PYLINT_DISABLE:= all
-PYLINT_ENABLE := F,E,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode
-PYLINT_TEST_ENABLE := $(PYLINT_ENABLE),line-too-long,multiple-statements,unused-import,consider-using-f-string,dangerous-default-value
+PYLINT_ENABLE := F,E,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode,dangerous-default-value,trailing-whitespace,unneeded-not,singleton-comparison,unused-import
+PYLINT_TEST_ENABLE := $(PYLINT_ENABLE),line-too-long,multiple-statements,consider-using-f-string
 PYLINT_JOBS := $(NB_CORES)
 PYLINT_SUGGEST_FIX := y
 PYLINT_COMMON_PARAMETERS := --jobs=$(PYLINT_JOBS) --suggestion-mode=$(PYLINT_SUGGEST_FIX) --exit-zero

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 NB_CORES := $(shell grep --count '^processor' /proc/cpuinfo)
 PYLINT_DISABLE:= all
 PYLINT_ENABLE := F,E,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode
+PYLINT_TEST_ENABLE := $(PYLINT_ENABLE),line-too-long,multiple-statements
 PYLINT_JOBS := $(NB_CORES)
 PYLINT_SUGGEST_FIX := y
-PYLINT_PARAMETERS := --disable=$(PYLINT_DISABLE) --enable=$(PYLINT_ENABLE) --jobs=$(PYLINT_JOBS) --suggestion-mode=$(PYLINT_SUGGEST_FIX) --exit-zero
+PYLINT_COMMON_PARAMETERS := --jobs=$(PYLINT_JOBS) --suggestion-mode=$(PYLINT_SUGGEST_FIX) --exit-zero
+PYLINT_GEF_PARAMETERS := --disable=$(PYLINT_DISABLE) --enable=$(PYLINT_ENABLE) $(PYLINT_COMMON_PARAMETERS)
+PYLINT_TEST_PARAMETERS := --disable=$(PYLINT_DISABLE) --enable=$(PYLINT_TEST_ENABLE) $(PYLINT_COMMON_PARAMETERS)
 TARGET := $(shell lscpu | head -1 | sed -e 's/Architecture:\s*//g')
 
 test: testbins
@@ -23,5 +26,5 @@ testbins: tests/binaries/*.c
 	@$(MAKE) -j $(NB_CORES) -C tests/binaries TARGET=$(TARGET) all
 
 lint:
-	python3 -m pylint $(PYLINT_PARAMETERS) gef.py
-	python3 -m pylint $(PYLINT_PARAMETERS) tests/*.py
+	python3 -m pylint $(PYLINT_GEF_PARAMETERS) gef.py
+	python3 -m pylint $(PYLINT_TEST_PARAMETERS) tests/*.py

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NB_CORES := $(shell grep --count '^processor' /proc/cpuinfo)
 PYLINT_DISABLE:= all
 PYLINT_ENABLE := F,E,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode
-PYLINT_TEST_ENABLE := $(PYLINT_ENABLE),line-too-long,multiple-statements
+PYLINT_TEST_ENABLE := $(PYLINT_ENABLE),line-too-long,multiple-statements,unused-import,consider-using-f-string
 PYLINT_JOBS := $(NB_CORES)
 PYLINT_SUGGEST_FIX := y
 PYLINT_COMMON_PARAMETERS := --jobs=$(PYLINT_JOBS) --suggestion-mode=$(PYLINT_SUGGEST_FIX) --exit-zero

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 NB_CORES := $(shell grep --count '^processor' /proc/cpuinfo)
 PYLINT_DISABLE:= all
-PYLINT_ENABLE := F,E,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode,dangerous-default-value,trailing-whitespace,unneeded-not,singleton-comparison,unused-import
-PYLINT_TEST_ENABLE := $(PYLINT_ENABLE),line-too-long,multiple-statements,consider-using-f-string
+PYLINT_ENABLE := F,E,unreachable,duplicate-key,unnecessary-semicolon,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode,dangerous-default-value,trailing-whitespace,unneeded-not,singleton-comparison,unused-import
+PYLINT_TEST_ENABLE := $(PYLINT_ENABLE),line-too-long,multiple-statements,consider-using-f-string,global-variable-not-assigned
 PYLINT_JOBS := $(NB_CORES)
 PYLINT_SUGGEST_FIX := y
-PYLINT_COMMON_PARAMETERS := --jobs=$(PYLINT_JOBS) --suggestion-mode=$(PYLINT_SUGGEST_FIX) --exit-zero
+PYLINT_COMMON_PARAMETERS := --jobs=$(PYLINT_JOBS) --suggestion-mode=$(PYLINT_SUGGEST_FIX)
 PYLINT_GEF_PARAMETERS := --disable=$(PYLINT_DISABLE) --enable=$(PYLINT_ENABLE) $(PYLINT_COMMON_PARAMETERS)
 PYLINT_TEST_PARAMETERS := --disable=$(PYLINT_DISABLE) --enable=$(PYLINT_TEST_ENABLE) $(PYLINT_COMMON_PARAMETERS)
 TARGET := $(shell lscpu | head -1 | sed -e 's/Architecture:\s*//g')

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NB_CORES := $(shell grep --count '^processor' /proc/cpuinfo)
 PYLINT_DISABLE:= all
 PYLINT_ENABLE := F,E,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode
-PYLINT_TEST_ENABLE := $(PYLINT_ENABLE),line-too-long,multiple-statements,unused-import,consider-using-f-string
+PYLINT_TEST_ENABLE := $(PYLINT_ENABLE),line-too-long,multiple-statements,unused-import,consider-using-f-string,dangerous-default-value
 PYLINT_JOBS := $(NB_CORES)
 PYLINT_SUGGEST_FIX := y
 PYLINT_COMMON_PARAMETERS := --jobs=$(PYLINT_JOBS) --suggestion-mode=$(PYLINT_SUGGEST_FIX) --exit-zero

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -89,7 +89,7 @@ def gdb_start_silent_cmd(cmd, before: List[str]=[], after: List[str]=[],
     disables the `context` and sets a tbreak at the most convenient entry
     point."""
     before += ["gef config context.clear_screen False",
-               "gef config context.layout '{}'".format(context),
+               f"gef config context.layout '{context}'",
                "entry-break"]
     return gdb_run_cmd(cmd, before, after, target, strip_ansi)
 
@@ -104,7 +104,8 @@ def gdb_start_silent_cmd_last_line(cmd, before: List[str]=[], after: List[str]=[
 def gdb_test_python_method(meth: str, before: str="", after: str="",
                            target: str=PATH_TO_DEFAULT_BINARY,
                            strip_ansi: bool=STRIP_ANSI_DEFAULT) -> str:
-    cmd = "pi {}print({});{}".format(before+";" if before else "", meth, after)
+    brk = before + ";" if before else ""
+    cmd = f"pi {brk}print({meth});{after}"
     return gdb_start_silent_cmd(cmd, target=target, strip_ansi=strip_ansi)
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -67,7 +67,7 @@ def gdb_run_cmd(cmd: str, before: List[str]=[], after: List[str]=[],
 
 def gdb_run_silent_cmd(cmd, before: List[str]=[], after: List[str]=[],
                        target: str=PATH_TO_DEFAULT_BINARY,
-                       strip_ansi: str=STRIP_ANSI_DEFAULT) -> str:
+                       strip_ansi: bool=STRIP_ANSI_DEFAULT) -> str:
     """Disable the output and run entirely the `target` binary."""
     before += ["gef config context.clear_screen False",
                "gef config context.layout '-code -stack'",
@@ -103,7 +103,7 @@ def gdb_start_silent_cmd_last_line(cmd, before: List[str]=[], after: List[str]=[
 
 def gdb_test_python_method(meth: str, before: str="", after: str="",
                            target: str=PATH_TO_DEFAULT_BINARY,
-                           strip_ansi: str=STRIP_ANSI_DEFAULT) -> str:
+                           strip_ansi: bool=STRIP_ANSI_DEFAULT) -> str:
     cmd = "pi {}print({});{}".format(before+";" if before else "", meth, after)
     return gdb_start_silent_cmd(cmd, target=target, strip_ansi=strip_ansi)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,4 @@
-from typing import List, Iterable
+from typing import Iterable
 import re
 import subprocess
 import os
@@ -21,7 +21,7 @@ def ansi_clean(s: str) -> str:
     return ansi_escape.sub("", s)
 
 
-def gdb_run_cmd(cmd: str, before: List[str]=[], after: List[str]=[],
+def gdb_run_cmd(cmd: str, before: Iterable[str]=(), after: Iterable[str]=(),
                 target: str=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT) -> str:
     """Execute a command inside GDB. `before` and `after` are lists of commands to be executed
     before (resp. after) the command to test."""
@@ -65,36 +65,36 @@ def gdb_run_cmd(cmd: str, before: List[str]=[], after: List[str]=[],
     return result
 
 
-def gdb_run_silent_cmd(cmd, before: List[str]=[], after: List[str]=[],
+def gdb_run_silent_cmd(cmd, before: Iterable[str]=(), after: Iterable[str]=(),
                        target: str=PATH_TO_DEFAULT_BINARY,
                        strip_ansi: bool=STRIP_ANSI_DEFAULT) -> str:
     """Disable the output and run entirely the `target` binary."""
-    before += ["gef config context.clear_screen False",
-               "gef config context.layout '-code -stack'",
-               "run"]
+    before = [*before, "gef config context.clear_screen False",
+              "gef config context.layout '-code -stack'",
+              "run"]
     return gdb_run_cmd(cmd, before, after, target, strip_ansi)
 
 
-def gdb_run_cmd_last_line(cmd, before: List[str]=[], after: List[str]=[],
+def gdb_run_cmd_last_line(cmd, before: Iterable[str]=(), after: Iterable[str]=(),
                           target: str=PATH_TO_DEFAULT_BINARY,
-                          strip_ansi: str=STRIP_ANSI_DEFAULT) -> str:
+                          strip_ansi: bool=STRIP_ANSI_DEFAULT) -> str:
     """Execute a command in GDB, and return only the last line of its output."""
     return gdb_run_cmd(cmd, before, after, target, strip_ansi).splitlines()[-1]
 
 
-def gdb_start_silent_cmd(cmd, before: List[str]=[], after: List[str]=[],
+def gdb_start_silent_cmd(cmd, before: Iterable[str]=(), after: Iterable[str]=(),
                          target=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT,
                          context=DEFAULT_CONTEXT) -> str:
     """Execute a command in GDB by starting an execution context. This command
     disables the `context` and sets a tbreak at the most convenient entry
     point."""
-    before += ["gef config context.clear_screen False",
-               f"gef config context.layout '{context}'",
-               "entry-break"]
+    before = [*before, "gef config context.clear_screen False",
+              f"gef config context.layout '{context}'",
+              "entry-break"]
     return gdb_run_cmd(cmd, before, after, target, strip_ansi)
 
 
-def gdb_start_silent_cmd_last_line(cmd, before: List[str]=[], after: List[str]=[],
+def gdb_start_silent_cmd_last_line(cmd, before: Iterable[str]=(), after: Iterable[str]=(),
                                    target=PATH_TO_DEFAULT_BINARY,
                                    strip_ansi=STRIP_ANSI_DEFAULT) -> str:
     """Execute `gdb_start_silent_cmd()` and return only the last line of its output."""
@@ -121,7 +121,7 @@ def include_for_architectures(valid_architectures: Iterable[str] = CI_VALID_ARCH
     return wrapper
 
 
-def exclude_for_architectures(invalid_architectures: Iterable[str] = []):
+def exclude_for_architectures(invalid_architectures: Iterable[str]=()):
     def wrapper(f):
         def inner_f(*args, **kwargs):
             if ARCH not in invalid_architectures:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,7 +21,8 @@ def ansi_clean(s: str) -> str:
     return ansi_escape.sub("", s)
 
 
-def gdb_run_cmd(cmd: str, before: List[str]=[], after: List[str]=[], target: str=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT) -> str:
+def gdb_run_cmd(cmd: str, before: List[str]=[], after: List[str]=[],
+                target: str=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT) -> str:
     """Execute a command inside GDB. `before` and `after` are lists of commands to be executed
     before (resp. after) the command to test."""
     command = [
@@ -44,10 +45,12 @@ def gdb_run_cmd(cmd: str, before: List[str]=[], after: List[str]=[], target: str
     output = b"\n".join(lines)
     result = None
 
-    # The following is necessary because ANSI escape sequences might have been added in the middle of multibyte
-    # characters, e.g. \x1b[H\x1b[2J is added into the middle of \xe2\x94\x80 to become \xe2\x1b[H\x1b[2J\x94\x80
-    # which causes a UnicodeDecodeError when trying to decode \xe2.
-    # Such broken multibyte characters would need to be removed, otherwise the test will result in an error.
+    # The following is necessary because ANSI escape sequences might have been
+    # added in the middle of multibyte characters, e.g. \x1b[H\x1b[2J is added
+    # into the middle of \xe2\x94\x80 to become \xe2\x1b[H\x1b[2J\x94\x80 which
+    # causes a UnicodeDecodeError when trying to decode \xe2. Such broken
+    # multibyte characters would need to be removed, otherwise the test will
+    # result in an error.
     while not result:
         try:
             result = output.decode("utf-8")
@@ -62,7 +65,9 @@ def gdb_run_cmd(cmd: str, before: List[str]=[], after: List[str]=[], target: str
     return result
 
 
-def gdb_run_silent_cmd(cmd, before: List[str]=[], after: List[str]=[], target: str=PATH_TO_DEFAULT_BINARY, strip_ansi: str=STRIP_ANSI_DEFAULT) -> str:
+def gdb_run_silent_cmd(cmd, before: List[str]=[], after: List[str]=[],
+                       target: str=PATH_TO_DEFAULT_BINARY,
+                       strip_ansi: str=STRIP_ANSI_DEFAULT) -> str:
     """Disable the output and run entirely the `target` binary."""
     before += ["gef config context.clear_screen False",
                "gef config context.layout '-code -stack'",
@@ -70,26 +75,35 @@ def gdb_run_silent_cmd(cmd, before: List[str]=[], after: List[str]=[], target: s
     return gdb_run_cmd(cmd, before, after, target, strip_ansi)
 
 
-def gdb_run_cmd_last_line(cmd, before: List[str]=[], after: List[str]=[], target: str=PATH_TO_DEFAULT_BINARY, strip_ansi: str=STRIP_ANSI_DEFAULT) -> str:
+def gdb_run_cmd_last_line(cmd, before: List[str]=[], after: List[str]=[],
+                          target: str=PATH_TO_DEFAULT_BINARY,
+                          strip_ansi: str=STRIP_ANSI_DEFAULT) -> str:
     """Execute a command in GDB, and return only the last line of its output."""
     return gdb_run_cmd(cmd, before, after, target, strip_ansi).splitlines()[-1]
 
 
-def gdb_start_silent_cmd(cmd, before: List[str]=[], after: List[str]=[], target=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT, context=DEFAULT_CONTEXT) -> str:
-    """Execute a command in GDB by starting an execution context. This command disables the `context`
-    and sets a tbreak at the most convenient entry point."""
+def gdb_start_silent_cmd(cmd, before: List[str]=[], after: List[str]=[],
+                         target=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT,
+                         context=DEFAULT_CONTEXT) -> str:
+    """Execute a command in GDB by starting an execution context. This command
+    disables the `context` and sets a tbreak at the most convenient entry
+    point."""
     before += ["gef config context.clear_screen False",
                "gef config context.layout '{}'".format(context),
                "entry-break"]
     return gdb_run_cmd(cmd, before, after, target, strip_ansi)
 
 
-def gdb_start_silent_cmd_last_line(cmd, before: List[str]=[], after: List[str]=[], target=PATH_TO_DEFAULT_BINARY, strip_ansi=STRIP_ANSI_DEFAULT) -> str:
+def gdb_start_silent_cmd_last_line(cmd, before: List[str]=[], after: List[str]=[],
+                                   target=PATH_TO_DEFAULT_BINARY,
+                                   strip_ansi=STRIP_ANSI_DEFAULT) -> str:
     """Execute `gdb_start_silent_cmd()` and return only the last line of its output."""
     return gdb_start_silent_cmd(cmd, before, after, target, strip_ansi).splitlines()[-1]
 
 
-def gdb_test_python_method(meth: str, before: str="", after: str="", target: str=PATH_TO_DEFAULT_BINARY, strip_ansi: str=STRIP_ANSI_DEFAULT) -> str:
+def gdb_test_python_method(meth: str, before: str="", after: str="",
+                           target: str=PATH_TO_DEFAULT_BINARY,
+                           strip_ansi: str=STRIP_ANSI_DEFAULT) -> str:
     cmd = "pi {}print({});{}".format(before+";" if before else "", meth, after)
     return gdb_start_silent_cmd(cmd, target=target, strip_ansi=strip_ansi)
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -438,13 +438,15 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_patch_dword(self):
-        res = gdb_start_silent_cmd_last_line("patch dword $pc 0xcccccccc", after=["display/8bx $pc",])
+        res = gdb_start_silent_cmd_last_line("patch dword $pc 0xcccccccc",
+                                             after=["display/8bx $pc",])
         self.assertNoException(res)
         self.assertRegex(res, r"(0xcc\s*)(\1\1\1)0x[^c]{2}")
         return
 
     def test_cmd_patch_qword(self):
-        res = gdb_start_silent_cmd_last_line("patch qword $pc 0xcccccccccccccccc", after=["display/8bx $pc",])
+        res = gdb_start_silent_cmd_last_line("patch qword $pc 0xcccccccccccccccc",
+                                             after=["display/8bx $pc",])
         self.assertNoException(res)
         self.assertRegex(res, r"(0xcc\s*)(\1\1\1\1\1\1)0xcc")
         return
@@ -460,7 +462,8 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_patch_string(self):
-        res = gdb_start_silent_cmd_last_line("patch string $sp \"Gef!Gef!Gef!Gef!\"", after=["grep Gef!Gef!Gef!Gef!",])
+        res = gdb_start_silent_cmd_last_line("patch string $sp \"Gef!Gef!Gef!Gef!\"",
+                                             after=["grep Gef!Gef!Gef!Gef!",])
         self.assertNoException(res)
         self.assertIn("Gef!Gef!Gef!Gef!", res)
         return
@@ -490,13 +493,15 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
         cmd = f"pattern search {r}"
         target = "/tmp/pattern.out"
-        res = gdb_run_cmd(cmd, before=["set args aaaabaaacaaadaaaeaaafaaagaaahaaa", "run"], target=target)
+        res = gdb_run_cmd(cmd, before=["set args aaaabaaacaaadaaaeaaafaaagaaahaaa", "run"],
+                          target=target)
         self.assertNoException(res)
         self.assertIn("Found at offset", res)
 
         cmd = f"pattern search --period 8 {r}"
         target = "/tmp/pattern.out"
-        res = gdb_run_cmd(cmd, before=["set args aaaaaaaabaaaaaaacaaaaaaadaaaaaaa", "run"], target=target)
+        res = gdb_run_cmd(cmd, before=["set args aaaaaaaabaaaaaaacaaaaaaadaaaaaaa", "run"],
+                          target=target)
         self.assertNoException(res)
         self.assertIn("Found at offset", res)
         return
@@ -524,15 +529,18 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_process_search(self):
-        res = gdb_start_silent_cmd("process-search", target="/tmp/pattern.out", before=["set args w00tw00t", ])
+        res = gdb_start_silent_cmd("process-search", target="/tmp/pattern.out",
+                                   before=["set args w00tw00t", ])
         self.assertNoException(res)
         self.assertIn("/tmp/pattern.out", res)
 
-        res = gdb_start_silent_cmd("process-search gdb.*fakefake", target="/tmp/pattern.out", before=["set args w00tw00t", ])
+        res = gdb_start_silent_cmd("process-search gdb.*fakefake",
+                                   target="/tmp/pattern.out", before=["set args w00tw00t", ])
         self.assertNoException(res)
         self.assertIn("gdb", res)
 
-        res = gdb_start_silent_cmd("process-search --smart-scan gdb.*fakefake", target="/tmp/pattern.out", before=["set args w00tw00t", ])
+        res = gdb_start_silent_cmd("process-search --smart-scan gdb.*fakefake",
+                                   target="/tmp/pattern.out", before=["set args w00tw00t", ])
         self.assertNoException(res)
         self.assertNotIn("gdb", res)
         return
@@ -605,7 +613,8 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         stack_address = int(stack_line.split()[0], 0)
 
         # compare the new permissions
-        res = gdb_start_silent_cmd(f"set-permission {stack_address:#x}", after=[f"xinfo {stack_address:#x}",], target=target)
+        res = gdb_start_silent_cmd(f"set-permission {stack_address:#x}",
+                                   after=[f"xinfo {stack_address:#x}",], target=target)
         self.assertNoException(res)
         line = [l.strip() for l in res.splitlines() if l.startswith("Permissions: ")][0]
         self.assertEqual(line.split()[1], "rwx")
@@ -692,7 +701,8 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertFailIfInactiveSession(res)
 
         cmd = "trace-run $pc+1"
-        res = gdb_start_silent_cmd(cmd, before=["gef config trace-run.tracefile_prefix /tmp/gef-trace-"])
+        res = gdb_start_silent_cmd(cmd,
+                                   before=["gef config trace-run.tracefile_prefix /tmp/gef-trace-"])
         self.assertNoException(res)
         self.assertIn("Tracing from", res)
         return
@@ -785,11 +795,14 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         add_res = gdb_start_silent_cmd("aliases add alias_function_test example")
         self.assertNoException(add_res)
         # test list functionality
-        list_res = gdb_start_silent_cmd("aliases ls", before=["aliases add alias_function_test example"])
+        list_res = gdb_start_silent_cmd("aliases ls",
+                                        before=["aliases add alias_function_test example"])
         self.assertNoException(list_res)
         self.assertIn("alias_function_test", list_res)
         # test rm functionality
-        rm_res = gdb_start_silent_cmd("aliases ls", before=["aliases add alias_function_test example", "aliases rm alias_function_test"])
+        rm_res = gdb_start_silent_cmd("aliases ls",
+                                      before=["aliases add alias_function_test example",
+                                              "aliases rm alias_function_test"])
         self.assertNoException(rm_res)
         self.assertNotIn("alias_function_test", rm_res)
         return
@@ -948,9 +961,12 @@ class TestNonRegressionUnit(GefUnitTestGeneric):
         """Ensure the registers are printed in the correct order (PR #670)."""
         cmd = "registers"
         if ARCH == "i686":
-            registers_in_correct_order = ["$eax", "$ebx", "$ecx", "$edx", "$esp", "$ebp", "$esi", "$edi", "$eip", "$eflags", "$cs", ]
+            registers_in_correct_order = ["$eax", "$ebx", "$ecx", "$edx", "$esp", "$ebp", "$esi",
+                                          "$edi", "$eip", "$eflags", "$cs", ]
         elif ARCH == "x86_64":
-            registers_in_correct_order = ["$rax", "$rbx", "$rcx", "$rdx", "$rsp", "$rbp", "$rsi", "$rdi", "$rip", "$r8", "$r9", "$r10", "$r11", "$r12", "$r13", "$r14", "$r15", "$eflags", "$cs", ]
+            registers_in_correct_order = ["$rax", "$rbx", "$rcx", "$rdx", "$rsp", "$rbp", "$rsi",
+                                          "$rdi", "$rip", "$r8", "$r9", "$r10", "$r11", "$r12",
+                                          "$r13", "$r14", "$r15", "$eflags", "$cs", ]
         else:
             raise ValueError("Unknown architecture")
         lines = gdb_start_silent_cmd(cmd).splitlines()[-len(registers_in_correct_order):]
@@ -961,7 +977,8 @@ class TestNonRegressionUnit(GefUnitTestGeneric):
     @include_for_architectures(["x86_64",])
     def test_context_correct_registers_refresh_with_frames(self):
         """Ensure registers are correctly refreshed when changing frame (PR #668)"""
-        lines = gdb_run_silent_cmd("registers", after=["frame 5", "registers"], target="/tmp/nested.out").splitlines()
+        lines = gdb_run_silent_cmd("registers", after=["frame 5", "registers"],
+                                   target="/tmp/nested.out").splitlines()
         rips = [ x for x in lines if x.startswith("$rip") ]
         self.assertEqual(len(rips), 2) # we must have only 2 entries
         self.assertNotEqual(rips[0], rips[1]) # they must be different

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -356,7 +356,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertNotIn("cafebabe", res)
         res = gdb_start_silent_cmd("memory watch &myglobal",
                 before=["set args 0xcafebabe",],
-                after=["continue", ],
+                after=["continue"],
                 target=target,
                 context="memory")
         self.assertIn("cafebabe", res)
@@ -529,17 +529,17 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_process_search(self):
         res = gdb_start_silent_cmd("process-search", target="/tmp/pattern.out",
-                                   before=["set args w00tw00t", ])
+                                   before=["set args w00tw00t"])
         self.assertNoException(res)
         self.assertIn("/tmp/pattern.out", res)
 
         res = gdb_start_silent_cmd("process-search gdb.*fakefake",
-                                   target="/tmp/pattern.out", before=["set args w00tw00t", ])
+                                   target="/tmp/pattern.out", before=["set args w00tw00t"])
         self.assertNoException(res)
         self.assertIn("gdb", res)
 
         res = gdb_start_silent_cmd("process-search --smart-scan gdb.*fakefake",
-                                   target="/tmp/pattern.out", before=["set args w00tw00t", ])
+                                   target="/tmp/pattern.out", before=["set args w00tw00t"])
         self.assertNoException(res)
         self.assertNotIn("gdb", res)
         return
@@ -714,8 +714,8 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertFailIfInactiveSession(res)
 
         target = "/tmp/unicorn.out"
-        before = ["break function1", ]
-        after = ["si", ]
+        before = ["break function1"]
+        after = ["si"]
         start_marker = "= Starting emulation ="
         end_marker = "Final registers"
         res = gdb_run_silent_cmd(cmd, target=target, before=before, after=after)
@@ -961,11 +961,11 @@ class TestNonRegressionUnit(GefUnitTestGeneric):
         cmd = "registers"
         if ARCH == "i686":
             registers_in_correct_order = ["$eax", "$ebx", "$ecx", "$edx", "$esp", "$ebp", "$esi",
-                                          "$edi", "$eip", "$eflags", "$cs", ]
+                                          "$edi", "$eip", "$eflags", "$cs"]
         elif ARCH == "x86_64":
             registers_in_correct_order = ["$rax", "$rbx", "$rcx", "$rdx", "$rsp", "$rbp", "$rsi",
                                           "$rdi", "$rip", "$r8", "$r9", "$r10", "$r11", "$r12",
-                                          "$r13", "$r14", "$r15", "$eflags", "$cs", ]
+                                          "$r13", "$r14", "$r15", "$eflags", "$cs"]
         else:
             raise ValueError("Unknown architecture")
         lines = gdb_start_silent_cmd(cmd).splitlines()[-len(registers_in_correct_order):]

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -18,7 +18,6 @@ from helpers import (
     gdb_start_silent_cmd_last_line,
     gdb_test_python_method,
     include_for_architectures,
-    exclude_for_architectures,
     ARCH,
     is_64b
 ) # pylint: disable=import-error
@@ -193,7 +192,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_gef_remote(self):
         def start_gdbserver(exe="/tmp/default.out", port=1234):
-            return subprocess.Popen(["gdbserver", ":{}".format(port), exe],
+            return subprocess.Popen(["gdbserver", f":{port}", exe],
                                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         def stop_gdbserver(gdbserver):
@@ -318,7 +317,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertIn("calloc(32)=", res)
         addr = int(res.split("calloc(32)=")[1].split("\n")[0], 0)
         self.assertRegex(res, r"realloc\(.+, 48")
-        self.assertIn("free({:#x}".format(addr), res)
+        self.assertIn(f"free({addr:#x}", res)
         return
 
     def test_cmd_hexdump(self):
@@ -686,12 +685,12 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         ]
         for t in possible_themes:
             # testing command viewing
-            res = gdb_run_cmd("theme {}".format(t))
+            res = gdb_run_cmd(f"theme {t}")
             self.assertNoException(res)
 
             # testing command setting
             v = "blue blah 10 -1 0xfff bold"
-            res = gdb_run_cmd("theme {} {}".format(t, v))
+            res = gdb_run_cmd(f"theme {t} {v}")
             self.assertNoException(res)
         return
 
@@ -710,7 +709,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
     @include_for_architectures(["x86_64"])
     def test_cmd_unicorn_emulate(self):
         nb_insn = 4
-        cmd = "emu {}".format(nb_insn)
+        cmd = f"emu {nb_insn}"
         res = gdb_run_silent_cmd(cmd)
         self.assertFailIfInactiveSession(res)
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -20,7 +20,7 @@ from helpers import (
     include_for_architectures,
     ARCH,
     is_64b
-) # pylint: disable=import-error
+)
 
 
 class GdbAssertionError(AssertionError):
@@ -32,7 +32,7 @@ class GefUnitTestGeneric(unittest.TestCase):
 
     @staticmethod
     def assertException(buf):
-        """Expect an exception to be raised"""
+        """Assert that GEF raised an Exception."""
         if not ("Python Exception <" in buf
                 or "Traceback" in buf
                 or "'gdb.error'" in buf
@@ -42,12 +42,12 @@ class GefUnitTestGeneric(unittest.TestCase):
 
     @staticmethod
     def assertNoException(buf):
-        """No exception should be raised"""
-        if not ("Python Exception <" not in buf
-                and "Traceback" not in buf
-                and "'gdb.error'" not in buf
-                and "Exception raised" not in buf
-                and "failed to execute properly, reason:" not in buf):
+        """Assert that no Exception was raised from GEF."""
+        if ("Python Exception <" in buf
+                or "Traceback" in buf
+                or "'gdb.error'" in buf
+                or "Exception raised" in buf
+                or "failed to execute properly, reason:" in buf):
             raise GdbAssertionError("Unexpected GDB Exception raised")
 
     @staticmethod
@@ -978,7 +978,7 @@ class TestNonRegressionUnit(GefUnitTestGeneric):
         """Ensure registers are correctly refreshed when changing frame (PR #668)"""
         lines = gdb_run_silent_cmd("registers", after=["frame 5", "registers"],
                                    target="/tmp/nested.out").splitlines()
-        rips = [ x for x in lines if x.startswith("$rip") ]
+        rips = [x for x in lines if x.startswith("$rip")]
         self.assertEqual(len(rips), 2) # we must have only 2 entries
         self.assertNotEqual(rips[0], rips[1]) # they must be different
         self.assertIn("<f10", rips[0]) # the first one must be in the f10 frame


### PR DESCRIPTION
We were absolutely falling for the mutable default pitfall: When we called functions such as `gdb_run_cmd` without `before` set, we were tacking on extra commands each time! That's what linters are for!