### PR TITLE
Support for custom contexts in ContextCommand

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -92,7 +92,7 @@ gef➤  source /path/to/custom_context_pane.py
 ```
 
 It can even be included in the same file as a Command.
-Now on each break you will notice a new pane near the bottom of the context. This order
+Now on each break you will notice a new pane near the bottom of the context. The order
 can be modified in the gef context config.
 
 ### Context Pane API ###

--- a/docs/api.md
+++ b/docs/api.md
@@ -93,14 +93,14 @@ gef➤  source /path/to/custom_context_pane.py
 
 It can even be included in the same file as a Command.
 Now on each break you will notice a new pane near the bottom of the context. The order
-can be modified in the gef context config.
+can be modified in the `GEF` context config.
 
 ### Context Pane API ###
 
-The api demonstrated above requires very specific argument types:
+The API demonstrated above requires very specific argument types:
 `register_external_context_pane(pane_name, display_pane_function, pane_title_function)`
 - `pane_name`: a string that will be used as the panes setting name
-- `display_pane_function`: a function that uses gef_print() to print content in the pane
+- `display_pane_function`: a function that uses `gef_print()` to print content in the pane
 - `pane_title_function`: a function that returns the string of the panes title 
 
 ## API ##

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,6 +70,39 @@ or add to your `~/.gdbinit`:
 $ echo source /path/to/newcmd.py >> ~/.gdbinit
 ```
 
+## Custom context panes ##
+
+Sometimes you want something similar to a command to run on each break-like event 
+and display itself as a part of the GEF context. Here is a simple example of how to
+make a custom context pane:
+```python
+__start_time__ = int(time.time())
+def wasted_time_debugging():
+    gef_print("You have wasted {} seconds!".format(int(time.time()) - __start_time__))
+
+def wasted_time_debugging_title():
+    return "wasted:time:debugging:{}".format(int(time.time()) - __start_time__)
+
+register_external_context_pane("wasted_time_debugging", wasted_time_debugging, wasted_time_debugging_title)
+```
+
+Loading it in `GEF` is as easy as loading a command
+```
+gef➤  source /path/to/custom_context_pane.py
+```
+
+It can even be included in the same file as a Command.
+Now on each break you will notice a new pane near the bottom of the context. This order
+can be modified in the gef context config.
+
+### Context Pane API ###
+
+The api demonstrated above requires very specific argument types:
+`register_external_context_pane(pane_name, display_pane_function, pane_title_function)`
+- `pane_name`: a string that will be used as the panes setting name
+- `display_pane_function`: a function that uses gef_print() to print content in the pane
+- `pane_title_function`: a function that returns the string of the panes title 
+
 ## API ##
 
 Some of the most important parts of the API for creating new commands are

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,9 +72,10 @@ $ echo source /path/to/newcmd.py >> ~/.gdbinit
 
 ## Custom context panes ##
 
-Sometimes you want something similar to a command to run on each break-like event 
-and display itself as a part of the GEF context. Here is a simple example of how to
-make a custom context pane:
+Sometimes you want something similar to a command to run on each break-like
+event and display itself as a part of the GEF context. Here is a simple example
+of how to make a custom context pane:
+
 ```python
 __start_time__ = int(time.time())
 def wasted_time_debugging():
@@ -87,21 +88,24 @@ register_external_context_pane("wasted_time_debugging", wasted_time_debugging, w
 ```
 
 Loading it in `GEF` is as easy as loading a command
+
 ```
 gef➤  source /path/to/custom_context_pane.py
 ```
 
 It can even be included in the same file as a Command.
-Now on each break you will notice a new pane near the bottom of the context. The order
-can be modified in the `GEF` context config.
+Now on each break you will notice a new pane near the bottom of the context.
+The order can be modified in the `GEF` context config.
 
 ### Context Pane API ###
 
 The API demonstrated above requires very specific argument types:
 `register_external_context_pane(pane_name, display_pane_function, pane_title_function)`
-- `pane_name`: a string that will be used as the panes setting name
-- `display_pane_function`: a function that uses `gef_print()` to print content in the pane
-- `pane_title_function`: a function that returns the string of the panes title 
+
+-`pane_name`: a string that will be used as the panes setting name
+-`display_pane_function`: a function that uses `gef_print()` to print content
+in the pane
+-`pane_title_function`: a function that returns the string of the panes title
 
 ## API ##
 

--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -22,15 +22,13 @@ menu when hitting a breakpoint.
 ### Adding custom context panes ###
 
 As well as using the built in context panes, you can add your own custom pane that
-will be displated at each break-like event with all the other panes. Custom panes
+will be displayed at each break-like event with all the other panes. Custom panes
 can be added using the api:
 ```python
 register_external_context_pane(pane_name, display_pane_function, pane_title_function)
 ```
 
-Check the [api](../api.md) documentation to see a full usage of the api. Custom panes
-added act just like normal panes, meaning you can disable them in the context 
-layout config.
+Check the [api](../api.md) documentation to see a full usage of the registration api.
 
 
 ### Editing context layout ###

--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -21,9 +21,9 @@ menu when hitting a breakpoint.
 
 ### Adding custom context panes ###
 
-As well as using the built in context panes, you can add your own custom pane that
-will be displayed at each break-like event with all the other panes. Custom panes
-can be added using the api:
+As well as using the built-in context panes, you can add your own custom pane that
+will be displayed at each `break`-like event with all the other panes. Custom panes
+can be added using the API:
 ```python
 register_external_context_pane(pane_name, display_pane_function, pane_title_function)
 ```

--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -19,6 +19,20 @@ menu when hitting a breakpoint.
   instructions to be executed.
 
 
+### Adding custom context panes ###
+
+As well as using the built in context panes, you can add your own custom pane that
+will be displated at each break-like event with all the other panes. Custom panes
+can be added using the api:
+```python
+register_external_context_pane(pane_name, display_pane_function, pane_title_function)
+```
+
+Check the [api](../api.md) documentation to see a full usage of the api. Custom panes
+added act just like normal panes, meaning you can disable them in the context 
+layout config.
+
+
 ### Editing context layout ###
 
 `gef` allows you to configure your own setup for the display, by re-arranging

--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -18,18 +18,18 @@ menu when hitting a breakpoint.
 * The code context box shows the 10 (by default but can be tweaked) next
   instructions to be executed.
 
-
 ### Adding custom context panes ###
 
 As well as using the built-in context panes, you can add your own custom pane that
 will be displayed at each `break`-like event with all the other panes. Custom panes
 can be added using the API:
+
 ```python
 register_external_context_pane(pane_name, display_pane_function, pane_title_function)
 ```
 
-Check the [api](../api.md) documentation to see a full usage of the registration api.
-
+Check the [API](../api.md) documentation to see a full usage of the
+registration API.
 
 ### Editing context layout ###
 

--- a/gef.py
+++ b/gef.py
@@ -4527,7 +4527,7 @@ class NamedBreakpoint(gdb.Breakpoint):
 
 def register_external_context_pane(pane_name, display_pane_function, pane_title_function):
     """
-    Registering function for new GEF Context View. pane_title_function must return a string.
+    Registering function for new GEF Context View.
     pane_name: a string that has no spaces (used in settings)
     display_pane_function: a function that uses gef_print() to print strings
     pane_title_function: a function that returns a string, which will be displayed as the title
@@ -4537,7 +4537,7 @@ def register_external_context_pane(pane_name, display_pane_function, pane_title_
     def pane_title(): return "example:pane"
     register_external_context_pane("example_pane", display_pane, pane_title)
     """
-    return __gef__.add_context_pane(pane_name, display_pane_function, pane_title_function)
+    __gef__.add_context_pane(pane_name, display_pane_function, pane_title_function)
 
 
 #
@@ -4654,10 +4654,7 @@ class GenericCommand(gdb.Command, metaclass=abc.ABCMeta):
         return key in __config__
 
     def update_setting(self, name, value, description=None):
-        """
-        Function to allow for internal commands to update the value
-        of a setting without destroying the description.
-        """
+        """Update the value of a setting without destroying the description"""
         # make sure settings are always associated to the root command (which derives from GenericCommand)
         if "GenericCommand" not in [x.__name__ for x in self.__class__.__bases__]:
             return
@@ -10685,7 +10682,7 @@ class GefCommand(gdb.Command):
         return
 
     def add_context_pane(self, pane_name, display_pane_function, pane_title_function):
-        """Add a new context pane to ContextCommand"""
+        """Add a new context pane to ContextCommand."""
         for cmd, class_name, class_obj in self.loaded_commands:
             if isinstance(class_obj, ContextCommand):
                 context_obj = class_obj
@@ -10698,7 +10695,6 @@ class GefCommand(gdb.Command):
 
         # overload the printing of pane title
         context_obj.layout_mapping[corrected_settings_name] = (display_pane_function, pane_title_function)
-        return True
 
     def load(self, initial=False):
         """Load all the commands and functions defined by GEF into GDB."""

--- a/gef.py
+++ b/gef.py
@@ -10700,7 +10700,7 @@ class GefCommand(gdb.Command):
         # assure users can toggle the new context
         corrected_settings_name = pane_name.replace(" ", "_")
         layout_settings = context_obj.get_setting("layout")
-        context_obj.update_setting("layout", layout_settings+f" {corrected_settings_name} ")
+        context_obj.update_setting("layout", layout_settings+f" {corrected_settings_name}")
 
         # overload the printing of pane title
         context_obj.layout_mapping[corrected_settings_name] = (pane_function, pane_name)

--- a/gef.py
+++ b/gef.py
@@ -8266,20 +8266,18 @@ class ContextCommand(GenericCommand):
         if "capstone" in list(sys.modules.keys()):
             self.add_setting("use_capstone", False, "Use capstone as disassembler in the code pane (instead of GDB)")
 
-        self.layout_mapping = collections.OrderedDict(
-            {
-                "legend": (self.show_legend, None),
-                "regs": (self.context_regs, None),
-                "stack": (self.context_stack, None),
-                "code": (self.context_code, None),
-                "args": (self.context_args, None),
-                "memory": (self.context_memory, None),
-                "source": (self.context_source, None),
-                "trace": (self.context_trace, None),
-                "threads": (self.context_threads, None),
-                "extra": (self.context_additional_information, None),
-            }
-        )
+        self.layout_mapping = {
+            "legend": (self.show_legend, None),
+            "regs": (self.context_regs, None),
+            "stack": (self.context_stack, None),
+            "code": (self.context_code, None),
+            "args": (self.context_args, None),
+            "memory": (self.context_memory, None),
+            "source": (self.context_source, None),
+            "trace": (self.context_trace, None),
+            "threads": (self.context_threads, None),
+            "extra": (self.context_additional_information, None),
+        }
         return
 
     def post_load(self):
@@ -10688,14 +10686,10 @@ class GefCommand(gdb.Command):
 
     def add_context_pane(self, pane_name, pane_function):
         """Add a new context pane to ContextCommand"""
-        context_obj = None  # type: ContextCommand
         for cmd, class_name, class_obj in self.loaded_commands:
             if isinstance(class_obj, ContextCommand):
                 context_obj = class_obj
                 break
-
-        if not context_obj:
-            return False
 
         # assure users can toggle the new context
         corrected_settings_name = pane_name.replace(" ", "_")

--- a/gef.py
+++ b/gef.py
@@ -10694,7 +10694,7 @@ class GefCommand(gdb.Command):
         # assure users can toggle the new context
         corrected_settings_name = pane_name.replace(" ", "_")
         layout_settings = context_obj.get_setting("layout")
-        context_obj.update_setting("layout", layout_settings+f" {corrected_settings_name}")
+        context_obj.update_setting("layout", "{} {}".format(layout_settings, corrected_settings_name))
 
         # overload the printing of pane title
         context_obj.layout_mapping[corrected_settings_name] = (pane_function, pane_name)

--- a/gef.py
+++ b/gef.py
@@ -10683,7 +10683,7 @@ class GefCommand(gdb.Command):
 
     def add_context_pane(self, pane_name, display_pane_function, pane_title_function):
         """Add a new context pane to ContextCommand."""
-        for cmd, class_name, class_obj in self.loaded_commands:
+        for _, _, class_obj in self.loaded_commands:
             if isinstance(class_obj, ContextCommand):
                 context_obj = class_obj
                 break


### PR DESCRIPTION
## Custom Context Support ##

### Description/Motivation/Screenshots ###
<!-- Describe technically what your patch does. -->
This patch adds a new external api: `register_external_context_pane`, which takes three parameters:
1. `pane_name`: str. The name that will be printed as the context panes title
2. `pane_function`: function. The function that will be called to display things after the context title. Should use gef_print.
3. `pane_title_function`: function. The function returns a string which will be used for the context pane title.

<!-- Why is this change required? What problem does it solve? -->
To be concise, this new api essentially allows you to pass it an arbitrary function that will be executed after displaying your new context's title. More things could be added to create a wrapper class, but overall this is good enough to allow users to display arbitrary text on each break event while living in the context command. 

<!-- Why is this patch will make a better world? -->
This patch will make the world better because it will allow users to have more freedom when using GEFs workflow for a specific target which requires a custom environment. 

<!-- How does this look? Add a screenshot if you can -->
In this screenshot you can see that the last pane in the context is a custom context pane. You can also see that the pane is now a part of the actual context settings config:
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/21327264/134795749-c5eb8d76-496c-4338-b4ab-f822b7e02c9b.png">


Here is an example of the new api usage (also documented in the source):
```python
__start_time__ = int(time.time())
def wasted_time_debugging():
    gef_print("You have wasted {} seconds!".format(int(time.time()) - __start_time__))

def wasted_time_debugging_title():
    return "wasted:time:debugging:{}".format(int(time.time()) - __start_time__)

register_external_context_pane("wasted_time_debugging", wasted_time_debugging, wasted_time_debugging_title)
```
Take this file and simply run `source` on it like a normal external command in gef.

I'll wait on adding the docs until the main devs like the general format of the external api. 


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |                                                   |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
