### PR TITLE
feat: add github action for markdown linting

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -80,3 +80,14 @@ jobs:
         GEF_CI_ARCH: ${{ steps.set-arch-properties.outputs.arch }}
       run: |
         make test
+
+  markdown-lint:
+    name: Lint markdown files
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: echo "export PATH=$PATH:/usr/local/bundle/bin" >> $GITHUB_PATH
+    - name: Run mdl
+      uses: actionshub/markdownlint@main
+      with:
+        path: "README.md docs"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -91,3 +91,4 @@ jobs:
       uses: actionshub/markdownlint@main
       with:
         path: "README.md docs"
+      continue-on-error: true

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,3 @@
+rules "~MD002", "~MD006", "~MD014", "~MD034"
+# view rules at: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+# MD034 can be enabled when https://github.com/markdownlint/markdownlint/issues/191 has been resolved


### PR DESCRIPTION
## Add GitHub Action for markdown linting ##

### Description/Motivation/Screenshots ###

This PR would add a GitHub Action to lint Markdown files (`README.md` and files in `docs/`). This way new contributions to GEF have to use a cleaner style for the documentation and the reviews of PR can focus more on the content rather than formatting issues and other nitpicks.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
