### PR TITLE
Allow empty context titles

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -105,7 +105,7 @@ The API demonstrated above requires very specific argument types:
 -`pane_name`: a string that will be used as the panes setting name
 -`display_pane_function`: a function that uses `gef_print()` to print content
 in the pane
--`pane_title_function`: a function that returns the string of the panes title or None
+-`pane_title_function`: a function that returns the title string or None to hide the title
 
 ## API ##
 

--- a/gef.py
+++ b/gef.py
@@ -8351,8 +8351,8 @@ class ContextCommand(GenericCommand):
         line_color = get_gef_setting("theme.context_title_line")
         msg_color = get_gef_setting("theme.context_title_message")
 
+        # print nothing if no title is provided
         if not m:
-            gef_print(Color.colorify(HORIZONTAL_LINE * self.tty_columns, line_color))
             return
 
         trail_len = len(m) + 6

--- a/gef.py
+++ b/gef.py
@@ -8356,8 +8356,9 @@ class ContextCommand(GenericCommand):
         line_color = get_gef_setting("theme.context_title_line")
         msg_color = get_gef_setting("theme.context_title_message")
 
-        # print nothing if no title is provided
+        # print an empty line in case of ""
         if not m:
+            gef_print(Color.colorify(HORIZONTAL_LINE * self.tty_columns, line_color))
             return
 
         trail_len = len(m) + 6


### PR DESCRIPTION
## Allow empty context titles ##

### Description/Motivation/Screenshots ###
To allow a user to implement a custom context pane we need to give them a way to print no title. This includes removing the entire title line so nothing looks off. Currently, if you return `""` from the user function, which is handled with `context_title`, then you get an empty title line. We should have support for both an empty title line and the absence of one. I purpose we allow the user to return `None` and modify the `context_title` function slightly. 

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
