### PR TITLE
fix: DeprecationWarning for unicode-escape decoding

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -79,6 +79,7 @@ import time
 import traceback
 import configparser
 import xmlrpc.client as xmlrpclib
+import warnings
 
 from functools import lru_cache
 from io import StringIO
@@ -2758,16 +2759,20 @@ def read_int_from_memory(addr):
 def read_cstring_from_memory(address, max_length=GEF_MAX_STRING_LENGTH, encoding=None):
     """Return a C-string read from memory."""
 
-    if not encoding:
-        encoding = "unicode_escape"
+    encoding = encoding or "unicode-escape"
 
-    char_ptr = cached_lookup_type("char").pointer()
-
-    length = min(address|(DEFAULT_PAGE_SIZE-1), max_length+1)
+    length = min(address | (DEFAULT_PAGE_SIZE-1), max_length+1)
     try:
-        res = gdb.Value(address).cast(char_ptr).string(encoding=encoding, length=length).strip()
+        res_bytes = bytes(read_memory(address, length))
     except gdb.error:
-        res = bytes(read_memory(address, length)).decode("utf-8")
+        err("Can't read memory at '{}'".format(address))
+        return ""
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = res_bytes.decode(encoding, "strict")
+    except UnicodeDecodeError:
+        res = res_bytes.decode("latin-1", "replace")  # latin-1 as fallback due to its single-byte to glyph mapping
 
     res = res.split("\x00", 1)[0]
     ustr = res.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")

--- a/gef.py
+++ b/gef.py
@@ -2769,10 +2769,12 @@ def read_cstring_from_memory(address, max_length=GEF_MAX_STRING_LENGTH, encoding
         return ""
     try:
         with warnings.catch_warnings():
+            # ignore DeprecationWarnings (see #735)
             warnings.simplefilter("ignore")
             res = res_bytes.decode(encoding, "strict")
     except UnicodeDecodeError:
-        res = res_bytes.decode("latin-1", "replace")  # latin-1 as fallback due to its single-byte to glyph mapping
+        # latin-1 as fallback due to its single-byte to glyph mapping
+        res = res_bytes.decode("latin-1", "replace")
 
     res = res.split("\x00", 1)[0]
     ustr = res.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")


### PR DESCRIPTION
## fix: DeprecationWarning for unicode-escape decoding ##

### Description/Motivation/Screenshots ###
 
see Issue #735 

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###


- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
