### PR TITLE
feat: allow tests to be run in other places than /tmp

### DIFF
--- a/tests/binaries/Makefile
+++ b/tests/binaries/Makefile
@@ -5,7 +5,7 @@ SOURCES         =       $(wildcard *.c)
 LINKED          =       $(SOURCES:.c=.out)
 LDFLAGS         =
 EXTRA_FLAGS     =
-BINDIR          =       /tmp
+TMPDIR          ?=      /tmp
 
 ifeq ($(TARGET), i686)
 CFLAGS          +=      -m32
@@ -25,11 +25,11 @@ all: $(LINKED)
 
 %.out : %.c
 	@echo "[+] Building '$@'"
-	@$(CC) $(CFLAGS) $(EXTRA_FLAGS) -o $(BINDIR)/$@ $? $(LDFLAGS)
+	@$(CC) $(CFLAGS) $(EXTRA_FLAGS) -o $(TMPDIR)/$@ $? $(LDFLAGS)
 
 clean :
 	@echo "[+] Cleaning stuff"
-	@cd $(BINDIR) && rm -f $(LINKED)
+	@cd $(TMPDIR) && rm -f $(LINKED)
 
 format-string-helper.out: EXTRA_FLAGS := -Wno-format-security
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -10,6 +10,7 @@
 import re
 import unittest
 import subprocess
+import os
 
 from helpers import (
     gdb_run_cmd,
@@ -19,8 +20,12 @@ from helpers import (
     gdb_test_python_method,
     include_for_architectures,
     ARCH,
-    is_64b
+    is_64b,
+    _target
 )
+
+BIN_LS = "/bin/ls"
+TMPDIR = os.getenv("TMPDIR", "/tmp")
 
 
 class GdbAssertionError(AssertionError):
@@ -61,7 +66,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_canary(self):
         self.assertFailIfInactiveSession(gdb_run_cmd("canary"))
-        res = gdb_start_silent_cmd("canary", target="/tmp/canary.out")
+        res = gdb_start_silent_cmd("canary", target=_target("canary"))
         self.assertNoException(res)
         self.assertIn("Found AT_RANDOM at", res)
         self.assertIn("The canary of process ", res)
@@ -102,15 +107,15 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         res = gdb_run_cmd(cmd)
         self.assertNoException(res)
 
-        target = "/tmp/checksec-no-canary.out"
+        target = _target("checksec-no-canary")
         res = gdb_run_cmd(cmd, target=target)
         self.assertIn("Canary                        : ✘", res)
 
-        target = "/tmp/checksec-no-nx.out"
+        target = _target("checksec-no-nx")
         res = gdb_run_cmd(cmd, target=target)
         self.assertIn("NX                            : ✘", res)
 
-        target = "/tmp/checksec-no-pie.out"
+        target = _target("checksec-no-pie")
         res = gdb_run_cmd(cmd, target=target)
         self.assertIn("PIE                           : ✘", res)
         return
@@ -161,7 +166,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_format_string_helper(self):
         cmd = "format-string-helper"
-        target = "/tmp/format-string-helper.out"
+        target = _target("format-string-helper")
         res = gdb_run_cmd(cmd,
                           after=["set args testtest",
                                  "run",],
@@ -179,7 +184,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_got(self):
         cmd = "got"
-        target = "/tmp/format-string-helper.out"
+        target = _target("format-string-helper")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_start_silent_cmd(cmd, target=target)
         self.assertIn("printf", res)
@@ -191,7 +196,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_gef_remote(self):
-        def start_gdbserver(exe="/tmp/default.out", port=1234):
+        def start_gdbserver(exe=_target("default"), port=1234):
             return subprocess.Popen(["gdbserver", f":{port}", exe],
                                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
@@ -212,7 +217,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_heap_arenas(self):
         cmd = "heap arenas"
-        target = "/tmp/heap.out"
+        target = _target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_start_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -221,16 +226,16 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_heap_set_arena(self):
         cmd = "heap set-arena main_arena"
-        target = "/tmp/heap.out"
+        target = _target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
-        res = gdb_run_silent_cmd(cmd, target=target, after=["heap arenas",])
+        res = gdb_run_silent_cmd(cmd, target=target, after=["heap arenas"])
         self.assertNoException(res)
         self.assertIn("Arena(base=", res)
         return
 
     def test_cmd_heap_chunk(self):
         cmd = "heap chunk p1"
-        target = "/tmp/heap.out"
+        target = _target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -239,7 +244,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_heap_chunks(self):
         cmd = "heap chunks"
-        target = "/tmp/heap.out"
+        target = _target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -247,7 +252,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertIn("top chunk", res)
 
         cmd = "python gdb.execute('heap chunks {}'.format(get_glibc_arena().next))"
-        target = "/tmp/heap-non-main.out"
+        target = _target("heap-non-main")
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertNotIn("using '&main_arena' instead", res)
@@ -258,7 +263,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
     def test_cmd_heap_chunks_mult_heaps(self):
         before = ['run', 'python gdb.execute("heap set-arena {}".format(get_glibc_arena().next))']
         cmd = "heap chunks"
-        target = "/tmp/heap-multiple-heaps.out"
+        target = _target("heap-multiple-heaps")
         res = gdb_run_silent_cmd(cmd, before=before, target=target)
         self.assertNoException(res)
         self.assertIn("Chunk(addr=", res)
@@ -268,7 +273,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
     def test_cmd_heap_bins_fast(self):
         cmd = "heap bins fast"
         before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]
-        target = "/tmp/heap-fastbins.out"
+        target = _target("heap-fastbins")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, before=before, target=target))
         res = gdb_run_silent_cmd(cmd, before=before, target=target)
         self.assertNoException(res)
@@ -280,7 +285,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
     def test_cmd_heap_bins_non_main(self):
         cmd = "python gdb.execute('heap bins fast {}'.format(get_glibc_arena().next))"
         before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]
-        target = "/tmp/heap-non-main.out"
+        target = _target("heap-non-main")
         res = gdb_run_silent_cmd(cmd, before=before, target=target)
         self.assertNoException(res)
         self.assertIn("size=0x20", res)
@@ -288,7 +293,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_heap_bins_tcache(self):
         cmd = "heap bins tcache"
-        target = "/tmp/heap-non-main.out"
+        target = _target("heap-non-main")
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         # ensure tcachebins is populated
@@ -297,7 +302,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_heap_bins_tcache_all(self):
         cmd = "heap bins tcache all"
-        target = "/tmp/heap-tcache.out"
+        target = _target("heap-tcache")
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         # ensure there's 2 tcachebins
@@ -307,7 +312,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_heap_analysis(self):
         cmd = "heap-analysis-helper"
-        target = "/tmp/heap-analysis.out"
+        target = _target("heap-analysis")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd))
         res = gdb_start_silent_cmd(cmd, after=["continue"], target=target)
         self.assertNoException(res)
@@ -346,19 +351,19 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertNoException(res)
         res = gdb_start_silent_cmd("memory watch $pc")
         self.assertNoException(res)
-        target = "/tmp/memwatch.out"
+        target = _target("memwatch")
         res = gdb_start_silent_cmd("memory watch &myglobal",
-                before=["set args 0xdeadbeef",],
-                after=["continue",],
-                target=target,
-                context='memory')
+                                   before=["set args 0xdeadbeef"],
+                                   after=["continue"],
+                                   target=target,
+                                   context='memory')
         self.assertIn("deadbeef", res)
         self.assertNotIn("cafebabe", res)
         res = gdb_start_silent_cmd("memory watch &myglobal",
-                before=["set args 0xcafebabe",],
-                after=["continue"],
-                target=target,
-                context="memory")
+                                   before=["set args 0xcafebabe"],
+                                   after=["continue"],
+                                   target=target,
+                                   context="memory")
         self.assertIn("cafebabe", res)
         self.assertNotIn("deadbeef", res)
 
@@ -451,7 +456,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_patch_qword_symbol(self):
-        target = "/tmp/bss.out"
+        target = _target("bss")
         before = gdb_run_silent_cmd("deref -l 1 $sp", target=target)
         after = gdb_run_silent_cmd("patch qword $sp &msg", after=["deref -l 1 $sp"], target=target)
         self.assertNoException(before)
@@ -481,7 +486,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     @include_for_architectures(["x86_64", "aarch64"])
     def test_cmd_pattern_search(self):
-        target = "/tmp/pattern.out"
+        target = _target("pattern")
         if ARCH == "aarch64":
             r = "$x30"
         elif ARCH == "x86_64":
@@ -537,18 +542,19 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         return
 
     def test_cmd_process_search(self):
-        res = gdb_start_silent_cmd("process-search", target="/tmp/pattern.out",
+        target = _target("pattern")
+        res = gdb_start_silent_cmd("process-search", target=target,
                                    before=["set args w00tw00t"])
         self.assertNoException(res)
-        self.assertIn("/tmp/pattern.out", res)
+        self.assertIn(target, res)
 
         res = gdb_start_silent_cmd("process-search gdb.*fakefake",
-                                   target="/tmp/pattern.out", before=["set args w00tw00t"])
+                                   target=target, before=["set args w00tw00t"])
         self.assertNoException(res)
         self.assertIn("gdb", res)
 
         res = gdb_start_silent_cmd("process-search --smart-scan gdb.*fakefake",
-                                   target="/tmp/pattern.out", before=["set args w00tw00t"])
+                                   target=target, before=["set args w00tw00t"])
         self.assertNoException(res)
         self.assertNotIn("gdb", res)
         return
@@ -591,14 +597,13 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_scan(self):
         cmd = "scan libc stack"
-        target = "/tmp/checksec-no-pie.out"
+        target = _target("checksec-no-pie")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd))
         res = gdb_start_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn(target, res)
 
-        target = "/tmp/default.out"
-        res = gdb_start_silent_cmd("scan binary libc", target=target)
+        res = gdb_start_silent_cmd("scan binary libc")
         self.assertNoException(res)
         self.assertIn("__libc_start_main", res)
         return
@@ -612,7 +617,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
     def test_cmd_set_permission(self):
         self.assertFailIfInactiveSession(gdb_run_cmd("set-permission"))
-        target = "/tmp/set-permission.out"
+        target = _target("set-permission")
 
         # get the initial stack address
         res = gdb_start_silent_cmd("vmmap", target=target)
@@ -622,7 +627,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
 
         # compare the new permissions
         res = gdb_start_silent_cmd(f"set-permission {stack_address:#x}",
-                                   after=[f"xinfo {stack_address:#x}",], target=target)
+                                   after=[f"xinfo {stack_address:#x}"], target=target)
         self.assertNoException(res)
         line = [l.strip() for l in res.splitlines() if l.startswith("Permissions: ")][0]
         self.assertEqual(line.split()[1], "rwx")
@@ -714,8 +719,8 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertFailIfInactiveSession(res)
 
         cmd = "trace-run $pc+1"
-        res = gdb_start_silent_cmd(cmd,
-                                   before=["gef config trace-run.tracefile_prefix /tmp/gef-trace-"])
+        res = gdb_start_silent_cmd(
+            cmd, before=[f"gef config trace-run.tracefile_prefix {TMPDIR}/gef-trace-"])
         self.assertNoException(res)
         self.assertIn("Tracing from", res)
         return
@@ -727,7 +732,7 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         res = gdb_run_silent_cmd(cmd)
         self.assertFailIfInactiveSession(res)
 
-        target = "/tmp/unicorn.out"
+        target = _target("unicorn")
         before = ["break function1"]
         after = ["si"]
         start_marker = "= Starting emulation ="
@@ -845,23 +850,24 @@ class TestGefFunctionsUnit(GefUnitTestGeneric):
         return
 
     def test_func_get_filepath(self):
-        res = gdb_test_python_method("get_filepath()", target="/bin/ls")
+        res = gdb_test_python_method("get_filepath()", target=BIN_LS)
         self.assertNoException(res)
-        subprocess.call(["cp", "/bin/ls", "/tmp/foo bar"])
-        res = gdb_test_python_method("get_filepath()", target="/tmp/foo bar")
+        target = _target("foo bar", extension="")
+        subprocess.call(["cp", BIN_LS, target])
+        res = gdb_test_python_method("get_filepath()", target=target)
         self.assertNoException(res)
-        subprocess.call(["rm", "/tmp/foo bar"])
+        subprocess.call(["rm", target])
         return
 
     def test_func_get_pid(self):
-        res = gdb_test_python_method("get_pid()", target="/bin/ls")
+        res = gdb_test_python_method("get_pid()", target=BIN_LS)
         self.assertNoException(res)
         self.assertTrue(int(res.splitlines()[-1]))
         return
 
     def test_fun_gef_get_auxiliary_values(self):
         func = "gef_get_auxiliary_values()"
-        res = gdb_test_python_method(func, target="/bin/ls")
+        res = gdb_test_python_method(func, target=BIN_LS)
         self.assertNoException(res)
         # we need at least ("AT_PLATFORM", "AT_EXECFN") right now
         self.assertTrue("'AT_PLATFORM'" in res)
@@ -871,7 +877,7 @@ class TestGefFunctionsUnit(GefUnitTestGeneric):
 
     def test_func_gef_convenience(self):
         func = "gef_convenience('meh')"
-        res = gdb_test_python_method(func, target="/bin/ls")
+        res = gdb_test_python_method(func, target=BIN_LS)
         self.assertNoException(res)
         return
 
@@ -907,8 +913,9 @@ class TestGdbFunctionsUnit(GefUnitTestGeneric):
 
     def test_func_heap(self):
         cmd = "deref $_heap()"
-        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target="/tmp/heap.out"))
-        res = gdb_run_silent_cmd(cmd, target="/tmp/heap.out")
+        target = _target("heap")
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         if is_64b():
             self.assertIn("+0x0048:", res)
@@ -916,7 +923,7 @@ class TestGdbFunctionsUnit(GefUnitTestGeneric):
             self.assertIn("+0x0024:", res)
 
         cmd = "deref $_heap(0x10+0x10)"
-        res = gdb_run_silent_cmd(cmd, target="/tmp/heap.out")
+        res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         if is_64b():
             self.assertIn("+0x0048:", res)
@@ -926,16 +933,18 @@ class TestGdbFunctionsUnit(GefUnitTestGeneric):
 
     def test_func_got(self):
         cmd = "deref $_got()"
-        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target="/tmp/heap.out"))
-        res = gdb_run_silent_cmd(cmd, target="/tmp/heap.out")
+        target = _target("heap")
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn("malloc", res)
         return
 
     def test_func_bss(self):
         cmd = "deref $_bss()"
-        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target="/tmp/bss.out"))
-        res = gdb_run_silent_cmd(cmd, target="/tmp/bss.out")
+        target = _target("bss")
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn("Hello world!", res)
         return
@@ -957,7 +966,7 @@ class TestGefConfigUnit(GefUnitTestGeneric):
 
     def test_config_show_opcodes_size(self):
         """Check opcodes are correctly shown"""
-        res = gdb_run_cmd("entry-break", before=["gef config context.show_opcodes_size 4",])
+        res = gdb_run_cmd("entry-break", before=["gef config context.show_opcodes_size 4"])
         self.assertNoException(res)
         self.assertTrue(len(res.splitlines()) > 1)
         # output format: 0xaddress   opcode  <symbol+offset>   mnemo  [operands, ...]
@@ -990,8 +999,9 @@ class TestNonRegressionUnit(GefUnitTestGeneric):
     @include_for_architectures(["x86_64",])
     def test_context_correct_registers_refresh_with_frames(self):
         """Ensure registers are correctly refreshed when changing frame (PR #668)"""
+        target = _target("nested")
         lines = gdb_run_silent_cmd("registers", after=["frame 5", "registers"],
-                                   target="/tmp/nested.out").splitlines()
+                                   target=target).splitlines()
         rips = [x for x in lines if x.startswith("$rip")]
         self.assertEqual(len(rips), 2) # we must have only 2 entries
         self.assertNotEqual(rips[0], rips[1]) # they must be different


### PR DESCRIPTION
## feat: allow tests to be run in other places than /tmp ##

### Description/Motivation/Screenshots ###

Today I tested `GEF` on a non-rooted Android device and had to manually make quite some changes to have the tests run because I didn't have access to the `tmp/` filesystem.

This PR allows changing the defaults for `TMPDIR` (where the binaries are compiled to and used for the tests and where `trace-run` saves the traces while testing) by setting an environment variable for easier testing in different environments.

Changes:
- Allow changing `TMPDIR` by using an environment variable of the same name instead of having hard coded paths for testing (default is still `/tmp` as before).
- Don't copy `gef.py` to `TMPDIR` but leave it in-place for testing (because there doesn't seem to be a need to copy it over)
- Allow changing `GEF_PATH` by using an environment variable to use quickly switch between different `gef.py` versions without VCS (useful for automated testing of different `GEF` versions)
- Makefile targets are set to `.PHONY` now
- Create `TMPDIR` if it doesn't exist
- Remove cleaning steps from `test` target in `Makefile` so e.g. the binaries don't need to be rebuild between every test run (instead introduce separate `clean` target).
- Allow running single test modules with e.g. `make TestGefCommandsUnit` (capitalized)
- Allow running single tests (or several) using patterns with e.g. `make test_cmd_elf_info` (specifically that one test) or `make test_cmd_heap_` (every test starting with "test_cmd_heap")

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
