### PR TITLE
fix: create tempdir before first usage

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -11339,7 +11339,9 @@ if __name__ == "__main__":
         __gef__ = GefCommand()
         __gef__.setup()
 
-        gdb.execute("save gdb-index {}".format(get_gef_setting("gef.tempdir")))
+        tempdir = get_gef_setting("gef.tempdir")
+        gef_makedirs(tempdir)
+        gdb.execute("save gdb-index {}".format(tempdir))
 
         # gdb events configuration
         gef_on_continue_hook(continue_handler)


### PR DESCRIPTION
## fix: create tempdir before first usage ##

### Description/Motivation/Screenshots ###

Very very tiny PR to fix issue when `GEF` throws an exception when `save gdb-index {get_gef_setting("gef.tempdir")}` is called before that directory has actually been created.

#### Before ####

![image](https://user-images.githubusercontent.com/37738506/135659075-767e7024-53da-4959-88f5-d6c05ac3cb00.png)

#### After ####

![image](https://user-images.githubusercontent.com/37738506/135659200-70927456-3ed3-4493-99f9-a4a5abb806e8.png)


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_check_mark: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
