### PR TITLE
fix: Remove Makefile bug that deletes the whole TMPDIR on 'make clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ testbins: $(TMPDIR) $(wildcard tests/binaries/*.c)
 
 clean:
 	TMPDIR=$(TMPDIR) $(MAKE) -j $(NB_CORES) -C tests/binaries clean
-	@rm -rf $(TMPDIR)
+	@rm -rf $(TMPDIR)/gef-* $(TMPDIR)/gef.py || true
 
 lint:
 	python3 -m pylint $(PYLINT_GEF_PARAMETERS) $(GEF_PATH)


### PR DESCRIPTION
## fix: Makefile bugs ##

### Description/Motivation/Screenshots ###

Fix Bug introduced in #739 that deletes the **whole** $TMPDIR. Instead only delete GEF files within.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |   |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
