### PR TITLE
fix a max() call on None in print_guessed_arguments

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8042,7 +8042,9 @@ class ContextCommand(GenericCommand):
                 pass
 
         if not nb_argument:
-            if is_x86_32():
+            if not parameter_set:
+                nb_argument = 0
+            elif is_x86_32():
                 nb_argument = len(parameter_set)
             else:
                 nb_argument = max(function_parameters.index(p)+1 for p in parameter_set)


### PR DESCRIPTION
## fix a max() call on None in print_guessed_arguments ##

### Description/Motivation/Screenshots ###
There is a bug in `print_guessed_arguments`, line 8048. If the set is empty, no iteration happens and `max` gets called on None. Attached is a binary (x86_64), and a gdb script to trigger the crash. 

[poc.zip](https://github.com/hugsy/gef/files/7335116/poc.zip)

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [X] My PR was done against the `dev` branch, not `master`.
- [X] My code follows the code style of this project.
- [X] My change includes a change to the documentation, if required.
- [X] My change adds tests as appropriate.
- [X] I have read and agree to the **CONTRIBUTING** document.
