### PR TITLE
add number arg for 'heap chunk' command

### DIFF
--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -60,11 +60,11 @@ Glibc's behavior. To be able to view unaligned chunks as well, you can disable
 this with the `--allow-unaligned` flag. Note that this might result in
 incorrect output.
 
-To display heap chunk layout from address, simply provides the `number` argument after the `address` argument:
+
+There is an optional `number` argument, to specify the number of chunks printed by this command. To do so, simply provide the `--number` argument:
 
 ```
-gef➤ heap chunk [address] [number]
-gef➤ heap chunk 0x4e5400 6
+gef➤ heap chunk --number 6 0x4e5400
 Chunk(addr=0x4e5400, size=0xd0, flags=PREV_INUSE)
 Chunk(addr=0x4e54d0, size=0x1a0, flags=PREV_INUSE)
 Chunk(addr=0x4e5670, size=0x200, flags=PREV_INUSE)

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -60,6 +60,20 @@ Glibc's behavior. To be able to view unaligned chunks as well, you can disable
 this with the `--allow-unaligned` flag. Note that this might result in
 incorrect output.
 
+To display heap chunk layout from address, simply provides the `number` argument after the `address` argument:
+
+```
+gef➤ heap chunk [address] [number]
+gef➤ heap chunk 0x4e5400 6
+Chunk(addr=0x4e5400, size=0xd0, flags=PREV_INUSE)
+Chunk(addr=0x4e54d0, size=0x1a0, flags=PREV_INUSE)
+Chunk(addr=0x4e5670, size=0x200, flags=PREV_INUSE)
+Chunk(addr=0x4e5870, size=0xbc0, flags=PREV_INUSE)
+Chunk(addr=0x4e6430, size=0x330, flags=PREV_INUSE)
+Chunk(addr=0x4e6760, size=0x4c0, flags=PREV_INUSE)
+
+```
+
 ### `heap arenas` command ###
 
 Multi-threaded programs have different arenas, and the knowledge of the

--- a/gef.py
+++ b/gef.py
@@ -7025,7 +7025,7 @@ class GlibcHeapChunkCommand(GenericCommand):
             if number > 0:
                 addr = parse_address(args.address)
                 current_chunk = GlibcChunk(addr, allow_unaligned=args.allow_unaligned)
-                while number:
+                for _ in range(number):
                     if current_chunk.size == 0:
                         break
 
@@ -7044,7 +7044,6 @@ class GlibcHeapChunkCommand(GenericCommand):
                         break
 
                     current_chunk = next_chunk
-                    number -= 1
 
         else:
             addr = parse_address(args.address)

--- a/gef.py
+++ b/gef.py
@@ -1217,6 +1217,8 @@ class GlibcChunk:
         flags = []
         if self.has_p_bit():
             flags.append(Color.colorify("PREV_INUSE", "red bold"))
+        else:
+            flags.append(Color.colorify("PREV_FREE", "green bold"))
         if self.has_m_bit():
             flags.append(Color.colorify("IS_MMAPPED", "red bold"))
         if self.has_n_bit():
@@ -7000,13 +7002,13 @@ class GlibcHeapChunkCommand(GenericCommand):
     See https://github.com/sploitfun/lsploits/blob/master/glibc/malloc/malloc.c#L1123."""
 
     _cmdline_ = "heap chunk"
-    _syntax_  = "{:s} [-h] [--allow-unaligned] address".format(_cmdline_)
+    _syntax_  = "{:s} [-h] [--allow-unaligned] address [number]".format(_cmdline_)
 
     def __init__(self):
         super().__init__(complete=gdb.COMPLETE_LOCATION)
         return
 
-    @parse_arguments({"address": ""}, {"--allow-unaligned": True})
+    @parse_arguments({"address": "", "number" : 1}, {"--allow-unaligned": True}, )
     @only_if_gdb_running
     def do_invoke(self, *args, **kwargs):
         args = kwargs["arguments"]
@@ -7015,12 +7017,39 @@ class GlibcHeapChunkCommand(GenericCommand):
             self.usage()
             return
 
-        if get_glibc_arena() is None:
-            return
+        # if get_glibc_arena() is None:
+        #     return
+        if int(args.number) > 1:
+            number = int(args.number)
+            #nb = self.get_setting("peek_nb_byte")
+            if number > 0:
+                addr = parse_address(args.address)
+                current_chunk = GlibcChunk(addr, allow_unaligned=args.allow_unaligned)
+                while number:
+                    if current_chunk.size == 0:
+                        break
 
-        addr = parse_address(args.address)
-        chunk = GlibcChunk(addr, allow_unaligned=args.allow_unaligned)
-        gef_print(chunk.psprint())
+                    line = str(current_chunk)
+                    # if nb:
+                    #     line += "\n    [{}]".format(hexdump(read_memory(current_chunk.data_address, nb), nb, base=current_chunk.data_address))
+                    gef_print(line)
+
+                    next_chunk_addr = current_chunk.get_next_chunk_addr()
+
+                    if not Address(value=next_chunk_addr).valid:
+                        break
+
+                    next_chunk = current_chunk.get_next_chunk()
+                    if next_chunk is None:
+                        break
+
+                    current_chunk = next_chunk
+                    number -= 1
+
+        else:
+            addr = parse_address(args.address)
+            chunk = GlibcChunk(addr, allow_unaligned=args.allow_unaligned)
+            gef_print(chunk.psprint())
         return
 
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -247,7 +247,8 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
-        self.assertIn("Chunk(addr=", res)
+        heap_lines = [x for x in res.splitlines() if x.startswith("Chunk(addr=")]
+        self.assertTrue(len(heap_lines) == 2)
         return
 
     def test_cmd_heap_chunks(self):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -242,6 +242,12 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn("NON_MAIN_ARENA flag: ", res)
+
+        cmd = "heap chunk --number 2 p1"
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertIn("Chunk(addr=", res)
         return
 
     def test_cmd_heap_chunks(self):


### PR DESCRIPTION
## add number arg for 'heap chunk command' ##

### Description/Motivation/Screenshots ###
add a number argument for heap chunk command which is usable for statically linked binary. There is no need to know the main_arena address and mp_ address for heap chunks, just chunk address and number.
```
gef➤  heap chunk -h
usage: heap chunk [-h] [--allow-unaligned] [--number NUMBER] [address]

positional arguments:
  address

optional arguments:
  -h, --help         show this help message and exit
  --allow-unaligned
  --number NUMBER

gef➤  heap chunk 0x4e5400
Chunk(addr=0x4e5400, size=0xd0, flags=PREV_INUSE)
Chunk size: 208 (0xd0)
Usable size: 200 (0xc8)
Previous chunk size: 0 (0x0)
PREV_INUSE flag: On
IS_MMAPPED flag: Off
NON_MAIN_ARENA flag: Off

gef➤  heap chunk --number 6 0x4e5400
Chunk(addr=0x4e5400, size=0xd0, flags=PREV_INUSE)
Chunk(addr=0x4e54d0, size=0x1a0, flags=PREV_INUSE)
Chunk(addr=0x4e5670, size=0x200, flags=PREV_INUSE)
Chunk(addr=0x4e5870, size=0xbc0, flags=PREV_INUSE)
Chunk(addr=0x4e6430, size=0x330, flags=PREV_INUSE)
Chunk(addr=0x4e6760, size=0x4c0, flags=PREV_INUSE)
gef➤  heap chunk --number 10 0x4e5400
Chunk(addr=0x4e5400, size=0xd0, flags=PREV_INUSE)
Chunk(addr=0x4e54d0, size=0x1a0, flags=PREV_INUSE)
Chunk(addr=0x4e5670, size=0x200, flags=PREV_INUSE)
Chunk(addr=0x4e5870, size=0xbc0, flags=PREV_INUSE)
Chunk(addr=0x4e6430, size=0x330, flags=PREV_INUSE)
Chunk(addr=0x4e6760, size=0x4c0, flags=PREV_INUSE)
Chunk(addr=0x4e6c20, size=0x650, flags=PREV_FREE)
Chunk(addr=0x4e7270, size=0xd50, flags=PREV_INUSE)
Chunk(addr=0x4e7fc0, size=0x1e050, flags=PREV_INUSE)
[!] Command 'heap chunk' failed to execute properly, reason: Cannot access memory at address 0x506008
```

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
