### PR TITLE
Use sha256 for gef_hash to quiet static analyzers

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -4737,7 +4737,7 @@ class VersionCommand(GenericCommand):
         gef_fpath = os.path.abspath(os.path.expanduser(inspect.stack()[0][1]))
         gef_dir = os.path.dirname(gef_fpath)
         with open(gef_fpath, "rb") as f:
-            gef_hash = hashlib.sha1(f.read()).hexdigest()
+            gef_hash = hashlib.sha256(f.read()).hexdigest()
 
         if os.access("{}/.git".format(gef_dir), os.X_OK):
             ver = subprocess.check_output("git log --format='%H' -n 1 HEAD", cwd=gef_dir, shell=True).decode("utf8").strip()
@@ -4747,7 +4747,7 @@ class VersionCommand(GenericCommand):
             gef_blob_hash = subprocess.check_output("git hash-object {}".format(gef_fpath), shell=True).decode().strip()
             gef_print("GEF: (Standalone)")
             gef_print("Blob Hash({}): {}".format(gef_fpath, gef_blob_hash))
-        gef_print("SHA1({}): {}".format(gef_fpath, gef_hash))
+        gef_print("SHA256({}): {}".format(gef_fpath, gef_hash))
         gef_print("GDB: {}".format(gdb.VERSION, ))
         py_ver = "{:d}.{:d}".format(sys.version_info.major, sys.version_info.minor)
         gef_print("GDB-Python: {}".format(py_ver, ))


### PR DESCRIPTION
## Use sha256 for gef_hash to quiet static analyzers ##

### Description/Motivation/Screenshots ###
Switches to using hashlib.sha256 instead of hashlib.sha1 for the gef_hash.
This is primarily to quiet static analyzers that complain about the use of SHA1.

### How Has This Been Tested? ###
| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-64       | :heavy_check_mark: |                                           |

### Checklist ###
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
