### PR TITLE
Remove the `assert` on `get_register`

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3053,7 +3053,7 @@ def __get_register_for_selected_frame(regname, hash_key):
             regname = regname[1:]
         value = gdb.selected_frame().read_register(regname)
         return int(value)
-    except (ValueError, gdb.error) as e:
+    except (ValueError, gdb.error):
         pass
     return None
 
@@ -8113,7 +8113,6 @@ class ElfInfoCommand(GenericCommand):
             Shdr.SHT_PREINIT_ARRAY: "PREINIT_ARRAY",
             Shdr.SHT_GROUP:         "GROUP",
             Shdr.SHT_SYMTAB_SHNDX:  "SYMTAB_SHNDX",
-            Shdr.SHT_NUM:           "NUM",
             Shdr.SHT_LOOS:          "LOOS",
             Shdr.SHT_GNU_ATTRIBUTES:"GNU_ATTRIBUTES",
             Shdr.SHT_GNU_HASH:      "GNU_HASH",

--- a/gef.py
+++ b/gef.py
@@ -3041,18 +3041,22 @@ def get_register(regname):
 
 @lru_cache()
 def __get_register_for_selected_frame(regname, hash_key):
+    # 1st chance
     try:
         return parse_address(regname)
     except gdb.error:
-        assert regname[0] == "$"
-        regname = regname[1:]
-        try:
-            value = gdb.selected_frame().read_register(regname)
-            return int(value)
-        except ValueError:
-            return None
-        except gdb.error:
-            return None
+        pass
+
+    # 2nd chance
+    try:
+        if regname[0] == "$":
+            regname = regname[1:]
+        value = gdb.selected_frame().read_register(regname)
+        return int(value)
+    except (ValueError, gdb.error) as e:
+        pass
+    return None
+
 
 def get_path_from_info_proc():
     for x in gdb.execute("info proc", to_string=True).splitlines():

--- a/gef.py
+++ b/gef.py
@@ -3049,8 +3049,7 @@ def __get_register_for_selected_frame(regname, hash_key):
 
     # 2nd chance
     try:
-        if regname[0] == "$":
-            regname = regname[1:]
+        regname == regname.lstrip("$")
         value = gdb.selected_frame().read_register(regname)
         return int(value)
     except (ValueError, gdb.error):


### PR DESCRIPTION
## Remove the `assert` on `get_register` ##

`assert` are bad, so we remove one here, and give a second chance for `get_register` to execute properly if/when register doesn't start with a `$` (like PPC or MIPS at least).



### Description/Motivation/Screenshots ###

Register names don't always start with `$` (sometimes nothing - MIPS/PPC, something `$` - x64, sometimes `%` - SPARC).
This PR allows `get_register` to still attempt to get the value using `Frame.read_register()` even if the register doesn't start with `$`.

This PR should fix #752

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  | using `make test` 
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_check_mark: |                                           |
| AARCH64      | :heavy_check_mark: |                                           |
| MIPS         | :heavy_check_mark:  |                                           |
| POWERPC      |  :heavy_check_mark:  |                                           |
| SPARC        |❓  |                                           |
| RISC-V       | ❓  |                                           |


### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
