### PR TITLE
Simplify how `nb_argument` is calculated in `print_guessed_arguments`

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8689,12 +8689,10 @@ class ContextCommand(GenericCommand):
                 pass
 
         if not nb_argument:
-            if not parameter_set:
-                nb_argument = 0
-            elif is_x86_32():
+            if is_x86_32():
                 nb_argument = len(parameter_set)
             else:
-                nb_argument = max(function_parameters.index(p)+1 for p in parameter_set)
+                nb_argument = max([function_parameters.index(p)+1 for p in parameter_set], default=0)
 
         args = []
         for i in range(nb_argument):


### PR DESCRIPTION
### Description ###

This  small PR simplifies a tiny block of code in `print_guessed_arguments` that seems to be resulting in some cases in an TypeError excetion as described in #753.

Fixes #753 

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | Using `make test`  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |


### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
