### PR TITLE
Remove final `assert`

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7298,7 +7298,7 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
     def tcachebin(tcache_base, i):
         """Return the head chunk in tcache[i] and the number of chunks in the bin."""
         if i >= GlibcHeapTcachebinsCommand.TCACHE_MAX_BINS:
-            err("Incorrect index value, {} not in [0, {}[".format(i, GlibcHeapTcachebinsCommand.TCACHE_MAX_BINS))
+            err("Incorrect index value, index value must be between 0 and {}-1, given {}".format(GlibcHeapTcachebinsCommand.TCACHE_MAX_BINS, i))
             return None, 0
 
         tcache_chunk = GlibcChunk(tcache_base)

--- a/gef.py
+++ b/gef.py
@@ -7297,7 +7297,10 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
     @staticmethod
     def tcachebin(tcache_base, i):
         """Return the head chunk in tcache[i] and the number of chunks in the bin."""
-        assert i <  GlibcHeapTcachebinsCommand.TCACHE_MAX_BINS, "index should be less then TCACHE_MAX_BINS"
+        if i >= GlibcHeapTcachebinsCommand.TCACHE_MAX_BINS:
+            err("Incorrect index value, {} not in [0, {}[".format(i, GlibcHeapTcachebinsCommand.TCACHE_MAX_BINS))
+            return None, 0
+
         tcache_chunk = GlibcChunk(tcache_base)
 
         # Glibc changed the size of the tcache in version 2.30; this fix has


### PR DESCRIPTION
## Description

This PR removes the last `assert` in `GlibcHeapTcachebinsCommand.tcachebin()`.

## How Has This Been Tested ?

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

## Checklist 

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
