### PR TITLE
Adds constants to `gef.py` for M68K support (in `gef-extras`)

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -493,6 +493,7 @@ class Elf:
     AARCH64           = 0xb7
     RISCV             = 0xf3
     IA64              = 0x32
+    M68K              = 0x04
 
     ET_RELOC          = 1
     ET_EXEC           = 2
@@ -2740,6 +2741,20 @@ class MIPS(Architecture):
         return "; ".join(insns)
 
 
+SUPPORTED_ARCHITECTURES = {
+    "ARM": ARM, Elf.ARM: ARM,
+    "AARCH64": AARCH64, "ARM64": AARCH64, Elf.AARCH64: AARCH64,
+    "X86": X86, Elf.X86_32: X86,
+    "X86_64": X86_64, Elf.X86_64: X86_64, "i386:x86-64": X86_64,
+    "PowerPC": PowerPC, "PPC": PowerPC, Elf.POWERPC: PowerPC,
+    "PowerPC64": PowerPC64, "PPC64": PowerPC64, Elf.POWERPC64: PowerPC64,
+    "RISCV": RISCV, Elf.RISCV: RISCV,
+    "SPARC": SPARC, Elf.SPARC: SPARC,
+    "SPARC64": SPARC64, Elf.SPARC64: SPARC64,
+    "MIPS": MIPS, Elf.MIPS: MIPS,
+}
+
+
 def write_memory(address, buffer, length=0x10):
     """Write `buffer` at address `address`."""
     return gdb.selected_inferior().write_memory(address, buffer, length)
@@ -3756,23 +3771,11 @@ def set_arch(arch=None, default=None):
     set that arch.
     Return the selected arch, or raise an OSError.
     """
-    arches = {
-        "ARM": ARM, Elf.ARM: ARM,
-        "AARCH64": AARCH64, "ARM64": AARCH64, Elf.AARCH64: AARCH64,
-        "X86": X86, Elf.X86_32: X86,
-        "X86_64": X86_64, Elf.X86_64: X86_64, "i386:x86-64": X86_64,
-        "PowerPC": PowerPC, "PPC": PowerPC, Elf.POWERPC: PowerPC,
-        "PowerPC64": PowerPC64, "PPC64": PowerPC64, Elf.POWERPC64: PowerPC64,
-        "RISCV": RISCV, Elf.RISCV: RISCV,
-        "SPARC": SPARC, Elf.SPARC: SPARC,
-        "SPARC64": SPARC64, Elf.SPARC64: SPARC64,
-        "MIPS": MIPS, Elf.MIPS: MIPS,
-    }
     global current_arch, current_elf
 
     if arch:
         try:
-            current_arch = arches[arch.upper()]()
+            current_arch = SUPPORTED_ARCHITECTURES[arch.upper()]()
             return current_arch
         except KeyError:
             raise OSError("Specified arch {:s} is not supported".format(arch.upper()))
@@ -3783,11 +3786,11 @@ def set_arch(arch=None, default=None):
 
     arch_name = current_elf.e_machine if current_elf else get_arch()
     try:
-        current_arch = arches[arch_name]()
+        current_arch = SUPPORTED_ARCHITECTURES[arch_name]()
     except KeyError:
         if default:
             try:
-                current_arch = arches[default.upper()]()
+                current_arch = SUPPORTED_ARCHITECTURES[default.upper()]()
             except KeyError:
                 raise OSError("CPU not supported, neither is default {:s}".format(default.upper()))
         else:
@@ -8014,6 +8017,7 @@ class ElfInfoCommand(GenericCommand):
             Elf.AARCH64           : "AArch64",
             Elf.RISCV             : "RISC-V",
             Elf.IA64              : "IA-64",
+            Elf.M68K              : "M68K",
         }
 
         filename = args.filename or get_filepath()


### PR DESCRIPTION
### Description

Trivial PR to add the constants for M68K to `gef` so it can be sourced from https://github.com/hugsy/gef-extras/blob/master/archs/m68k.py


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
