### PR TITLE
fix bash errs on unary operator expected

### DIFF
--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -8,6 +8,9 @@ if [ "$1" = "dev" ]; then
     echo "set branch to dev"
 fi
 
+curl_found=0
+wget_found=0
+
 # check dependencies
 if [ `which curl` ]; then
 	curl_found=1


### PR DESCRIPTION
## fix bash unary operate issue on install ##

### Description/Motivation/Screenshots ###
this patch fixes an error with bash processing the install script so that it actually runs.

### How Has This Been Tested? ###
this is related to the installation script which creates the following error on ubuntu 20.04:

```
~ $ bash -c "$(wget http://gef.blah.cat/sh -O -)"
--2021-12-06 23:22:48--  http://gef.blah.cat/sh
Resolving gef.blah.cat (gef.blah.cat)... 40.121.232.30
Connecting to gef.blah.cat (gef.blah.cat)|40.121.232.30|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://github.com/hugsy/gef/raw/master/scripts/gef.sh [following]
--2021-12-06 23:22:48--  https://github.com/hugsy/gef/raw/master/scripts/gef.sh
Resolving github.com (github.com)... 140.82.113.4
Connecting to github.com (github.com)|140.82.113.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://raw.githubusercontent.com/hugsy/gef/master/scripts/gef.sh [following]
--2021-12-06 23:22:49--  https://raw.githubusercontent.com/hugsy/gef/master/scripts/gef.sh
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.111.133, 185.199.109.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1175 (1.1K) [text/plain]
Saving to: ‘STDOUT’

-                                                    100%[=====================================================================================================================>]   1.15K  --.-KB/s    in 0s      

2021-12-06 23:22:49 (38.0 MB/s) - written to stdout [1175/1175]

bash: line 25: [: -eq: unary operator expected
```

testing was performed by manually executing the script from the main repository directory and verifying that gef installed at the latest revision (a .gef-*.py was present), and that gef functioned within gdb.

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required. -- N/A
- [ ] My change adds tests as appropriate. -- N/A
- [x] I have read and agree to the **CONTRIBUTING** document.
