### PR TITLE
refactor: replace OSError aliases

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -390,7 +390,7 @@ def only_if_gdb_version_higher_than(required_gdb_version):
                 f(*args, **kwargs)
             else:
                 reason = "GDB >= {} for this command".format(required_gdb_version)
-                raise EnvironmentError(reason)
+                raise OSError(reason)
         return inner_f
     return wrapper
 
@@ -406,7 +406,7 @@ def only_if_current_arch_in(valid_architectures):
                 f(*args, **kwargs)
             else:
                 reason = "This command cannot work for the '{}' architecture".format(gef.arch.arch)
-                raise EnvironmentError(reason)
+                raise OSError(reason)
         return inner_f
     return wrapper
 
@@ -2098,7 +2098,7 @@ class Architecture(metaclass=abc.ABCMeta):
             elif "big endian" in output:
                 self.__endianness = Endianness.BIG_ENDIAN
             else:
-                raise EnvironmentError(f"No valid endianess found in '{output}'")
+                raise OSError(f"No valid endianess found in '{output}'")
         return self.__endianness
 
     def get_ith_parameter(self, i, in_func=True):
@@ -3156,7 +3156,7 @@ def open_file(path, use_cache=False):
     if is_remote_debug() and not __gef_qemu_mode__:
         lpath = download_file(path, use_cache)
         if not lpath:
-            raise IOError("cannot open remote path {:s}".format(path))
+            raise OSError("cannot open remote path {:s}".format(path))
         path = lpath
 
     return open(path, "r")
@@ -3744,7 +3744,7 @@ def get_memory_alignment(in_bits=False):
     except:
         pass
 
-    raise EnvironmentError("GEF is running under an unsupported mode")
+    raise OSError("GEF is running under an unsupported mode")
 
 
 def clear_screen(tty=""):
@@ -5660,7 +5660,7 @@ class IdaInteractCommand(GenericCommand):
             s.settimeout(1)
             s.connect((host, port))
             s.close()
-        except socket.error:
+        except OSError:
             return False
         return True
 
@@ -5753,7 +5753,7 @@ class IdaInteractCommand(GenericCommand):
                 jump = getattr(self.sock, "jump")
                 jump(hex(gef.arch.pc-main_base_address),)
 
-        except socket.error:
+        except OSError:
             self.disconnect()
         return
 

--- a/gef.py
+++ b/gef.py
@@ -9968,7 +9968,7 @@ class GotCommand(GenericCommand):
 
         try:
             readelf = gef.session.constants["readelf"]
-        except IOError:
+        except OSError:
             err("Missing `readelf`")
             return
 


### PR DESCRIPTION
## refactor: replace `OSError` aliases ##

### Description/Motivation/Screenshots ###

As Part of [PEP 3151](https://www.python.org/dev/peps/pep-3151/) (Python3.3) several error classes have been merged into `OSError` and have then been aliased to `OSError`. This PR replaces the aliases.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: | `test_cmd_elf_info` already failed on this branch before this PR                                          |

### Checklist ###


- [x] My PR was done against the `gdb_8_py36_code_refactor` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
