### PR TITLE
refactor: remove utf8 encoding declaration

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-#
-#
 #######################################################################################
 # GEF - Multi-Architecture GDB Enhanced Features for Exploiters & Reverse-Engineers
 #


### PR DESCRIPTION
## refactor: remove utf8 encoding declaration ##

### Description/Motivation/Screenshots ###

As Part of [PEP 3210](https://www.python.org/dev/peps/pep-3120/) in Python 3.0 the utf-8 encoding declaration is the default and can be omitted (which saves some bytes for the whole file ;) )

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |   `test_cmd_elf_info` already failed on this branch before this PR                                        |

### Checklist ###


- [x] My PR was done against the `gdb_8_py36_code_refactor` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
