### PR TITLE
tests: add tests for heap bins small, large and unsorted cmd

### DIFF
--- a/tests/binaries/Makefile
+++ b/tests/binaries/Makefile
@@ -46,4 +46,6 @@ canary.out: EXTRA_FLAGS := -fstack-protector-all
 
 heap-non-main.out heap-tcache.out heap-multiple-heaps.out: EXTRA_FLAGS := -pthread
 
+heap-bins.out: EXTRA_FLAGS := -Wno-unused-result
+
 default.out: EXTRA_FLAGS := -fstack-protector-all -fpie -pie

--- a/tests/binaries/heap-bins.c
+++ b/tests/binaries/heap-bins.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "utils.h"
+
+int main(){
+    void *small = malloc(0x10); // small chunk
+    malloc(0x20); // avoid consolidation of chunks
+    void *large = malloc(0x410); // large chunk
+    malloc(0x20); // avoid consolidation of chunks
+    free(small);
+    free(large);
+    void *unsorted = malloc(0x420); // make sure the unsorted chunk is bigger than large chunk
+    malloc(0x420); // sort the freed chunks from unsorted to their corresponding bins
+    free(unsorted);
+    DebugBreak();
+    return EXIT_SUCCESS;
+}

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -291,6 +291,15 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertIn("Chunk(addr=", res)
         return
 
+    def test_cmd_heap_bins_large(self):
+        cmd = "heap bins large"
+        target = _target("heap-bins")
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertIn("Found 1 chunks in 1 large non-empty bins", res)
+        self.assertIn("Chunk(addr=", res)
+        self.assertIn("size=0x420", res)
+
     def test_cmd_heap_bins_non_main(self):
         cmd = "python gdb.execute('heap bins fast {}'.format(get_glibc_arena().next))"
         before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]
@@ -299,6 +308,17 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertNoException(res)
         self.assertIn("size=0x20", res)
         return
+
+    def test_cmd_heap_bins_small(self):
+        cmd = "heap bins small"
+        before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]
+        target = _target("heap-bins")
+        res = gdb_run_silent_cmd(cmd, before=before, target=target)
+        self.assertNoException(res)
+        self.assertIn("Found 1 chunks in 1 small non-empty bins", res)
+        self.assertIn("Chunk(addr=", res)
+        self.assertIn("size=0x20", res)
+
 
     def test_cmd_heap_bins_tcache(self):
         cmd = "heap bins tcache"
@@ -318,6 +338,15 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         tcachebins_lines = [x for x in res.splitlines() if x.startswith("Tcachebins[idx=")]
         self.assertTrue(len(tcachebins_lines) == 2)
         return
+
+    def test_cmd_heap_bins_unsorted(self):
+        cmd = "heap bins unsorted"
+        target = _target("heap-bins")
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertIn("Found 1 chunks in unsorted bin", res)
+        self.assertIn("Chunk(addr=", res)
+        self.assertIn("size=0x430", res)
 
     def test_cmd_heap_analysis(self):
         cmd = "heap-analysis-helper"

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -319,7 +319,6 @@ class TestGefCommandsUnit(GefUnitTestGeneric):
         self.assertIn("Chunk(addr=", res)
         self.assertIn("size=0x20", res)
 
-
     def test_cmd_heap_bins_tcache(self):
         cmd = "heap bins tcache"
         target = _target("heap-non-main")


### PR DESCRIPTION
## Add tests for `heap bins` `small`, `large` and `unsorted` cmd

### Description/Motivation/Screenshots ###

This PR adds some missing tests for:
- `heap bins small`
- `heap bins large`
- `heap bins unsorted`

All 3 new tests use the same binary file `heap-bins.out`.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###


- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
