### PR TITLE
`@deprecated` warning display can be toggled off

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -377,10 +377,11 @@ def deprecated(solution: str = "") -> Callable:
     def decorator(f: Callable) -> Callable:
         @functools.wraps(f)
         def wrapper(*args: Tuple, **kwargs: Dict) -> Any:
-            msg = f"'{f.__name__}' is deprecated and will be removed in a feature release. "
-            if solution:
-                msg += solution
-            warn(msg)
+            if gef.config["gef.show_deprecated_warnings"] is True:
+                msg = f"'{f.__name__}' is deprecated and will be removed in a feature release. "
+                if solution:
+                    msg += solution
+                warn(msg)
             return f(*args, **kwargs)
 
         if not wrapper.__doc__:
@@ -10480,6 +10481,7 @@ class GefCommand(gdb.Command):
         gef.config["gef.extra_plugins_dir"] = GefSetting("", str, "Autoload additional GEF commands from external directory")
         gef.config["gef.disable_color"] = GefSetting(False, bool, "Disable all colors in GEF")
         gef.config["gef.tempdir"] = GefSetting(GEF_TEMP_DIR, str, "Directory to use for temporary/cache content")
+        gef.config["gef.show_deprecated_warnings"] = GefSetting(True, bool, "Toggle the display of the `deprecated` warnings")
         self.loaded_commands = []
         self.loaded_functions = []
         self.missing_commands = {}

--- a/gef.py
+++ b/gef.py
@@ -377,7 +377,7 @@ def deprecated(solution: str = "") -> Callable:
     def decorator(f: Callable) -> Callable:
         @functools.wraps(f)
         def wrapper(*args: Tuple, **kwargs: Dict) -> Any:
-            if gef.config["gef.show_deprecated_warnings"] is True:
+            if gef.config["gef.show_deprecation_warnings"] is True:
                 msg = f"'{f.__name__}' is deprecated and will be removed in a feature release. "
                 if solution:
                     msg += solution
@@ -10481,7 +10481,7 @@ class GefCommand(gdb.Command):
         gef.config["gef.extra_plugins_dir"] = GefSetting("", str, "Autoload additional GEF commands from external directory")
         gef.config["gef.disable_color"] = GefSetting(False, bool, "Disable all colors in GEF")
         gef.config["gef.tempdir"] = GefSetting(GEF_TEMP_DIR, str, "Directory to use for temporary/cache content")
-        gef.config["gef.show_deprecated_warnings"] = GefSetting(True, bool, "Toggle the display of the `deprecated` warnings")
+        gef.config["gef.show_deprecation_warnings"] = GefSetting(True, bool, "Toggle the display of the `deprecated` warnings")
         self.loaded_commands = []
         self.loaded_functions = []
         self.missing_commands = {}


### PR DESCRIPTION
### Description/Motivation/Screenshots ###

Simple PR to allow `@deprecated` warning display to be toggled off via config.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
