### PR TITLE
updated add_context_pane settings use

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -10570,7 +10570,7 @@ class GefCommand(gdb.Command):
 
         # assure users can toggle the new context
         corrected_settings_name = pane_name.replace(" ", "_")
-        gef.config["context.layout"] += " " + corrected_settings_name
+        gef.config["context.layout"] += f" {corrected_settings_name}"
 
         # overload the printing of pane title
         context.layout_mapping[corrected_settings_name] = (display_pane_function, pane_title_function)

--- a/gef.py
+++ b/gef.py
@@ -10570,8 +10570,7 @@ class GefCommand(gdb.Command):
 
         # assure users can toggle the new context
         corrected_settings_name = pane_name.replace(" ", "_")
-        layout_settings = context.get_setting("layout")
-        context.update_setting("layout", f"{layout_settings} {corrected_settings_name}")
+        gef.config["context.layout"] += " " + corrected_settings_name
 
         # overload the printing of pane title
         context.layout_mapping[corrected_settings_name] = (display_pane_function, pane_title_function)


### PR DESCRIPTION
## Update add_context_pane settings use ##

### Description/Motivation/Screenshots ###
The new API for changing settings configs in GEF has broken the `add_context_pane` API. This is an update for that.


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
