### PR TITLE
ELF class upgrades

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3997,6 +3997,10 @@ def get_process_maps():
     return gef.memory.maps
 
 
+@deprecated("Use `reset_architecture`")
+def set_arch():
+    return reset_architecture()
+
 #
 # GDB event hooking
 #

--- a/gef.py
+++ b/gef.py
@@ -978,14 +978,16 @@ class Shdr:
         SHT_GNU_HASH         = 0x6ffffff6
         SHT_GNU_LIBLIST      = 0x6ffffff7
         SHT_CHECKSUM         = 0x6ffffff8
-        SHT_LOSUNW           = SHT_SUNW_move       = 0x6ffffffa
+        SHT_LOSUNW           = 0x6ffffffa
+        SHT_SUNW_move        = 0x6ffffffa
         SHT_SUNW_COMDAT      = 0x6ffffffb
         SHT_SUNW_syminfo     = 0x6ffffffc
         SHT_GNU_verdef       = 0x6ffffffd
         SHT_GNU_verneed      = 0x6ffffffe
-        SHT_GNU_versym       = SHT_HISUNW          = SHT_HIOS       = 0x6fffffff
+        SHT_GNU_versym       = 0x6fffffff
         SHT_LOPROC           = 0x70000000
-        SHT_ARM_EXIDX        = SHT_X86_64_UNWIND   = 0x70000001
+        SHT_ARM_EXIDX        = 0x70000001
+        SHT_X86_64_UNWIND    = 0x70000001
         SHT_ARM_ATTRIBUTES   = 0x70000003
         SHT_MIPS_OPTIONS     = 0x7000000d
         DT_MIPS_INTERFACE    = 0x7000002a
@@ -3773,7 +3775,7 @@ def reset_architecture(arch: Optional[str] = None, default: Optional[str] = None
     arch_name = gef.binary.e_machine if gef.binary else get_arch()
 
     if ((arch_name == "MIPS" or arch_name == Elf.Abi.MIPS)
-        and (gef.binary.e_class == Elf.Class.ELF_64_BITS)):
+        and (gef.binary is not None and gef.binary.e_class == Elf.Class.ELF_64_BITS)):
         # MIPS64 = arch(MIPS) + 64b flag
         arch_name = "MIPS64"
 
@@ -6248,7 +6250,7 @@ class ChangePermissionCommand(GenericCommand):
         gdb.execute("continue")
         return
 
-    def get_stub_by_arch(self, addr: int, size: int, perm: Permission) -> Optional[bytearray]:
+    def get_stub_by_arch(self, addr: int, size: int, perm: Permission) -> Union[str, bytearray, None]:
         code = gef.arch.mprotect_asm(addr, size, perm)
         arch, mode = get_keystone_arch()
         raw_insns = keystone_assemble(code, arch, mode, raw=True)
@@ -8033,9 +8035,7 @@ class EntryPointBreakCommand(GenericCommand):
             bp.delete()
 
         # break at entry point
-        entry = get_entry_point()
-        if entry is None:
-            return
+        entry = gef.binary.entry_point
 
         if is_pie(fpath):
             self.set_init_tbreak_pie(entry, argv)

--- a/gef.py
+++ b/gef.py
@@ -962,6 +962,8 @@ class Shdr:
     sh_addralign = None
     sh_entsize   = None
 
+    __name       = ""
+
     def __init__(self, elf: Optional[Elf], off: int) -> None:
         if elf is None:
             return
@@ -987,13 +989,17 @@ class Shdr:
             elf.seek(stroff + 12 + 4)
             offset = struct.unpack(f"{endian}I", elf.read(4))[0]
         elf.seek(offset + self.sh_name)
-        self.sh_name = ""
+        self.__name = ""
         while True:
             c = ord(elf.read(1))
             if c == 0:
                 break
-            self.sh_name += chr(c)
+            self.__name += chr(c)
         return
+
+    @property
+    def name(self):
+        return self.__name
 
 
 class Instruction:
@@ -8007,7 +8013,7 @@ class ElfInfoCommand(GenericCommand):
             if s.sh_flags & Shdr.SHF_COMPRESSED:       sh_flags += "C"
 
             gef_print("  [{:2d}] {:20s} {:>15s} {:#10x} {:#8x} {:#8x} {:#8x} {:5s} {:#4x} {:#4x} {:#8x}".format(
-                i, s.sh_name, sh_type, s.sh_addr, s.sh_offset, s.sh_size, s.sh_entsize, sh_flags, s.sh_link, s.sh_info, s.sh_addralign))
+                i, s.name, sh_type, s.sh_addr, s.sh_offset, s.sh_size, s.sh_entsize, sh_flags, s.sh_link, s.sh_info, s.sh_addralign))
         return
 
 

--- a/gef.py
+++ b/gef.py
@@ -751,23 +751,23 @@ class Elf:
     e_magic: int                = ELF_MAGIC
     e_class: Class              = Class.ELF_32_BITS
     e_endianness: Endianness    = Endianness.LITTLE_ENDIAN
-    e_eiversion: Optional[int]  = None
-    e_osabi: Optional[OsAbi]    = None
-    e_abiversion: Optional[int] = None
-    e_pad: Optional[bytes]      = None
+    e_eiversion: int
+    e_osabi: OsAbi
+    e_abiversion: int
+    e_pad: bytes
     e_type: Type                = Type.ET_EXEC
     e_machine: Abi              = Abi.X86_32
-    e_version: Optional[int]    = None
-    e_entry: int                = 0
-    e_phoff : int               = 0
-    e_shoff : int               = 0
-    e_flags: Optional[int]      = None
-    e_ehsize : int              = 0
-    e_phentsize : int           = 0
-    e_phnum : int               = 0
-    e_shentsize : int           = 0
-    e_shnum : int               = 0
-    e_shstrndx : int            = 0
+    e_version: int
+    e_entry: int
+    e_phoff : int
+    e_shoff : int
+    e_flags: int
+    e_ehsize : int
+    e_phentsize : int
+    e_phnum : int
+    e_shentsize : int
+    e_shnum : int
+    e_shstrndx : int
 
     path: Optional[pathlib.Path] = None
 
@@ -912,14 +912,14 @@ class Phdr:
         PF_W            = 2
         PF_R            = 4
 
-    p_type: Optional["Phdr.Type"]     = None
-    p_flags: Optional["Phdr.Flags"]   = None
-    p_offset: int                     = 0
-    p_vaddr: int                      = 0
-    p_paddr: int                      = 0
-    p_filesz: int                     = 0
-    p_memsz: int                      = 0
-    p_align: int                      = 0
+    p_type: Type
+    p_flags: Flags
+    p_offset: int
+    p_vaddr: int
+    p_paddr: int
+    p_filesz: int
+    p_memsz: int
+    p_align: int
 
     def __init__(self, elf: Elf, off: int) -> None:
         if not elf:
@@ -1001,17 +1001,17 @@ class Shdr:
         ORDERED          = 0x40000000
         EXCLUDE          = 0x80000000
 
-    sh_name : int                      = 0
-    sh_type : Optional["Shdr.Type"]    = None
-    sh_flags : Optional["Shdr.Flags"]  = None
-    sh_addr : int                      = 0
-    sh_offset : int                    = 0
-    sh_size : int                      = 0
-    sh_link : int                      = 0
-    sh_info : int                      = 0
-    sh_addralign : int                 = 0
-    sh_entsize : int                   = 0
-    name : str                         = ""
+    sh_name : int
+    sh_type : Type
+    sh_flags : Flags
+    sh_addr : int
+    sh_offset : int
+    sh_size : int
+    sh_link : int
+    sh_info : int
+    sh_addralign : int
+    sh_entsize : int
+    name : str
 
     def __init__(self, elf: Optional[Elf], off: int) -> None:
         if elf is None:
@@ -1040,6 +1040,7 @@ class Shdr:
             elf.seek(stroff + 12 + 4)
             offset = u32(elf.read(4))
         elf.seek(offset + self.sh_name)
+        self.name = ""
         while True:
             c = u8(elf.read(1))
             if c == 0:

--- a/gef.py
+++ b/gef.py
@@ -762,15 +762,15 @@ class Elf:
     e_machine: Abi              = Abi.X86_32
     e_version: int
     e_entry: int
-    e_phoff : int
-    e_shoff : int
+    e_phoff: int
+    e_shoff: int
     e_flags: int
-    e_ehsize : int
-    e_phentsize : int
-    e_phnum : int
-    e_shentsize : int
-    e_shnum : int
-    e_shstrndx : int
+    e_ehsize: int
+    e_phentsize: int
+    e_phnum: int
+    e_shentsize: int
+    e_shnum: int
+    e_shstrndx: int
 
     path: Optional[pathlib.Path] = None
 
@@ -1022,17 +1022,17 @@ class Shdr:
         def _missing_(cls, _:int):
             return cls.UNKNOWN_FLAG
 
-    sh_name : int
-    sh_type : Type
-    sh_flags : Flags
-    sh_addr : int
-    sh_offset : int
-    sh_size : int
-    sh_link : int
-    sh_info : int
-    sh_addralign : int
-    sh_entsize : int
-    name : str
+    sh_name: int
+    sh_type: Type
+    sh_flags: Flags
+    sh_addr: int
+    sh_offset: int
+    sh_size: int
+    sh_link: int
+    sh_info: int
+    sh_addralign: int
+    sh_entsize: int
+    name: str
 
     def __init__(self, elf: Optional[Elf], off: int) -> None:
         if elf is None:

--- a/gef.py
+++ b/gef.py
@@ -845,7 +845,6 @@ class Elf:
     def entry_point(self) -> int:
         return self.e_entry
 
-    # deprecated
     @classproperty
     @deprecated("use `Elf.Abi.X86_64`")
     def X86_64(cls) -> int: return Elf.Abi.X86_64.value # pylint: disable=no-self-argument
@@ -3755,7 +3754,8 @@ def reset_architecture(arch: Optional[str] = None, default: Optional[str] = None
     If an arch is explicitly specified, use that one, otherwise try to parse it
     out of the current target. If that fails, and default is specified, select and
     set that arch.
-    Does not return but raise an exception if the architecture cannot be set.
+    Raise an exception if the architecture cannot be set.
+	Does not return a value.
     """
     global gef
     arches = __registered_architectures__

--- a/gef.py
+++ b/gef.py
@@ -618,9 +618,9 @@ class Address:
 class Permission(enum.Flag):
     """GEF representation of Linux permission."""
     NONE      = 0
-    READ      = 1
+    EXECUTE   = 1
     WRITE     = 2
-    EXECUTE   = 4
+    READ      = 4
     ALL       = 7
 
     def __str__(self) -> str:
@@ -885,7 +885,7 @@ class Elf:
 
 
 class Phdr:
-    class Type(enum.Enum):
+    class Type(enum.IntEnum):
         PT_NULL         = 0
         PT_LOAD         = 1
         PT_DYNAMIC      = 2
@@ -902,12 +902,18 @@ class Phdr:
         PT_LOSUNW       = 0x6ffffffa
         PT_SUNWBSS      = 0x6ffffffa
         PT_SUNWSTACK    = 0x6ffffffb
-        PT_HISUNW       = 0x6fffffff
-        PT_HIOS         = 0x6fffffff
+        PT_HISUNW       = PT_HIOS         = 0x6fffffff
         PT_LOPROC       = 0x70000000
+        PT_ARM_EIDX     = 0x70000001
+        PT_MIPS_ABIFLAGS= 0x70000003
         PT_HIPROC       = 0x7fffffff
+        UNKNOWN_PHDR    = 0xffffffff
 
-    class Flags(enum.Flag):
+        @classmethod
+        def _missing_(cls, _:int) -> Type:
+            return cls.UNKNOWN_PHDR
+
+    class Flags(enum.IntFlag):
         PF_X            = 1
         PF_W            = 2
         PF_R            = 4
@@ -946,7 +952,7 @@ class Phdr:
 
 
 class Shdr:
-    class Type(enum.Enum):
+    class Type(enum.IntEnum):
         SHT_NULL             = 0
         SHT_PROGBITS         = 1
         SHT_SYMTAB           = 2
@@ -970,21 +976,27 @@ class Shdr:
         SHT_GNU_HASH         = 0x6ffffff6
         SHT_GNU_LIBLIST      = 0x6ffffff7
         SHT_CHECKSUM         = 0x6ffffff8
-        SHT_LOSUNW           = 0x6ffffffa
-        SHT_SUNW_move        = 0x6ffffffa
+        SHT_LOSUNW           = SHT_SUNW_move       = 0x6ffffffa
         SHT_SUNW_COMDAT      = 0x6ffffffb
         SHT_SUNW_syminfo     = 0x6ffffffc
         SHT_GNU_verdef       = 0x6ffffffd
         SHT_GNU_verneed      = 0x6ffffffe
-        SHT_GNU_versym       = 0x6fffffff
-        SHT_HISUNW           = 0x6fffffff
-        SHT_HIOS             = 0x6fffffff
+        SHT_GNU_versym       = SHT_HISUNW          = SHT_HIOS       = 0x6fffffff
         SHT_LOPROC           = 0x70000000
+        SHT_ARM_EXIDX        = SHT_X86_64_UNWIND   = 0x70000001
+        SHT_ARM_ATTRIBUTES   = 0x70000003
+        SHT_MIPS_OPTIONS     = 0x7000000d
+        DT_MIPS_INTERFACE    = 0x7000002a
         SHT_HIPROC           = 0x7fffffff
         SHT_LOUSER           = 0x80000000
         SHT_HIUSER           = 0x8fffffff
+        UNKNOWN_SHDR         = 0xffffffff
 
-    class Flags(enum.Flag):
+        @classmethod
+        def _missing_(cls, _:int) -> Type:
+            return cls.UNKNOWN_SHDR
+
+    class Flags(enum.IntFlag):
         WRITE            = 1
         ALLOC            = 2
         EXECINSTR        = 4
@@ -1000,6 +1012,11 @@ class Shdr:
         RO_AFTER_INIT    = 0x00200000
         ORDERED          = 0x40000000
         EXCLUDE          = 0x80000000
+        UNKNOWN_FLAG     = 0xffffffff
+
+        @classmethod
+        def _missing_(cls, _:int):
+            return cls.UNKNOWN_FLAG
 
     sh_name : int
     sh_type : Type

--- a/gef.py
+++ b/gef.py
@@ -873,43 +873,43 @@ class Elf:
     # deprecated
     @classproperty
     @deprecated("use `Elf.Abi.X86_64`")
-    def X86_64(cls) -> int: return Elf.Abi.X86_64.value
+    def X86_64(cls) -> int: return Elf.Abi.X86_64.value # pylint: disable=no-self-argument
 
     @classproperty
     @deprecated("use `Elf.Abi.X86_32`")
-    def X86_32(cls) -> int : return Elf.Abi.X86_32.value
+    def X86_32(cls) -> int : return Elf.Abi.X86_32.value # pylint: disable=no-self-argument
 
     @classproperty
     @deprecated("use `Elf.Abi.ARM`")
-    def ARM(cls) -> int : return Elf.Abi.ARM.value
+    def ARM(cls) -> int : return Elf.Abi.ARM.value # pylint: disable=no-self-argument
 
     @classproperty
     @deprecated("use `Elf.Abi.MIPS`")
-    def MIPS(cls) -> int : return Elf.Abi.MIPS.value
+    def MIPS(cls) -> int : return Elf.Abi.MIPS.value # pylint: disable=no-self-argument
 
     @classproperty
     @deprecated("use `Elf.Abi.POWERPC`")
-    def POWERPC(cls) -> int : return Elf.Abi.POWERPC.value
+    def POWERPC(cls) -> int : return Elf.Abi.POWERPC.value # pylint: disable=no-self-argument
 
     @classproperty
     @deprecated("use `Elf.Abi.POWERPC64`")
-    def POWERPC64(cls) -> int : return Elf.Abi.POWERPC64.value
+    def POWERPC64(cls) -> int : return Elf.Abi.POWERPC64.value # pylint: disable=no-self-argument
 
     @classproperty
     @deprecated("use `Elf.Abi.SPARC`")
-    def SPARC(cls) -> int : return Elf.Abi.SPARC.value
+    def SPARC(cls) -> int : return Elf.Abi.SPARC.value # pylint: disable=no-self-argument
 
     @classproperty
     @deprecated("use `Elf.Abi.SPARC64`")
-    def SPARC64(cls) -> int : return Elf.Abi.SPARC64.value
+    def SPARC64(cls) -> int : return Elf.Abi.SPARC64.value # pylint: disable=no-self-argument
 
     @classproperty
     @deprecated("use `Elf.Abi.AARCH64`")
-    def AARCH64(cls) -> int : return Elf.Abi.AARCH64.value
+    def AARCH64(cls) -> int : return Elf.Abi.AARCH64.value  # pylint: disable=no-self-argument
 
     @classproperty
     @deprecated("use `Elf.Abi.RISCV`")
-    def RISCV(cls) -> int : return Elf.Abi.RISCV.value
+    def RISCV(cls) -> int : return Elf.Abi.RISCV.value # pylint: disable=no-self-argument
 
 
 class Phdr:

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -867,8 +867,8 @@ class TestGefFunctionsUnit(GefUnitTestGeneric):
         return
 
     @include_for_architectures(["x86_64", "i686"])
-    def test_func_set_arch(self):
-        res = gdb_test_python_method("gef.arch.arch, gef.arch.mode", before="set_arch()")
+    def test_func_reset_architecture(self):
+        res = gdb_test_python_method("gef.arch.arch, gef.arch.mode", before="reset_architecture()")
         res = (res.splitlines()[-1])
         self.assertIn("X86", res)
         return


### PR DESCRIPTION

### Description/Motivation/Screenshots ###

Bringing some more Python3.6 joy to the `Elf`  class and subclass, also benefiting the type hinting, which allows to delete ~100 loc of string printing. Some details:
 - Introduce new classes derived from `enum.Enum` or `enum.Flag` in the `Elf`, `Phdr` and `Shdr` classes
 - `get_entry_point` can now be deprecated in favor of `gef.binary.entry_point`
 - Simplified the helpers (`is_arch`, `is_x86_*`) which are way faster now (one lookup and test vs `gdb.execute`)
 - renamed `set_arch` to `reset_architecture` (doesn't return, the result was never used anyway)
 - we make `Elf` raise if the binary is corrupted (i.e. bad magic), any GDB won't process it
 - The old format of `Elf.$arch : int` was kept but deprecated (since they are property we can't use the decorator, so if you have ideas 😄 )



### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
