### PR TITLE
Update gef config parameters of gef-extras installation script

### DIFF
--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -15,8 +15,8 @@ git clone https://github.com/hugsy/gef-extras.git ${DIR}
 gdb -q -ex "gef config gef.extra_plugins_dir '${DIR}/scripts'" \
        -ex "gef config pcustom.struct_path '${DIR}/structs'" \
        -ex "gef config syscall-args.path '${DIR}/syscall-tables'" \
-       -ex "gef config libc_args True" \
-       -ex "gef config libc_args_path '${DIR}/glibc-function-args'" \
+       -ex "gef config context.libc_args True" \
+       -ex "gef config context.libc_args_path '${DIR}/glibc-function-args'" \
        -ex 'gef save' \
        -ex quit
 


### PR DESCRIPTION
## Update gef config parameters of gef-extras installation script

### Description ###
I tried to install `gef-extras` using `scripts/gef-extras.sh`, but I got the following error:

```
GEF for linux ready, type `gef' to start, `gef config' to configure
96 commands loaded for GDB 9.2 using Python engine 3.8
[!] Invalid command format
[!] Invalid command format
[+] Configuration saved to '/home/daniel/.gef.rc'
```

I changed the config paramter names according to the [README](https://github.com/hugsy/gef-extras/blob/master/README.md) of gef-extras, which fixes the installation for me. It leads to the following result:
```
GEF for linux ready, type `gef' to start, `gef config' to configure
96 commands loaded for GDB 9.2 using Python engine 3.8
[+] Configuration saved to '/home/daniel/.gef.rc'
```

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
