### PR TITLE
Re-add lru_cache to __get_register_for_selected_frame

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2204,6 +2204,7 @@ class Architecture(metaclass=abc.ABCMeta):
         key = curframe.pc() ^ int(curframe.read_register('sp')) # todo: check when/if gdb.Frame implements `level()`
         return self.__get_register_for_selected_frame(regname, key)
 
+    @lru_cache()
     def __get_register_for_selected_frame(self, regname: str, hash_key: int) -> Optional[int]:
         # 1st chance
         try:


### PR DESCRIPTION
Dropping this was causing 30-40% performance degradation of our
'context' use case. We already add the 'hash_key' so that the LRU cache
takes into account the selected frame to avoid using the cache when the
frame has changed.


### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: | Replace with :heavy_check_mark: if tested |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_check_mark: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
