### PR TITLE
tests: add missing commas in list

### DIFF
--- a/tests/commands/theme.py
+++ b/tests/commands/theme.py
@@ -14,14 +14,14 @@ class ThemeCommand(GefUnitTestGeneric):
         res = gdb_run_cmd("theme")
         self.assertNoException(res)
         possible_themes = [
-            "context_title_line"
-            "dereference_base_address"
-            "context_title_message"
-            "disable_color"
-            "dereference_code"
-            "dereference_string"
+            "context_title_line",
+            "dereference_base_address",
+            "context_title_message",
+            "disable_color",
+            "dereference_code",
+            "dereference_string",
             "default_title_message",
-            "default_title_line"
+            "default_title_line",
             "dereference_register_value",
             "xinfo_title_message",
         ]


### PR DESCRIPTION
## tests: add missing commas in list ##

This is a cleaned up version of #808. I tried to rebase that branch to [`better_tests`](https://github.com/hugsy/gef/tree/better_tests) but maybe because of some forced pushes it doesn't rebase properly with the correct changes.

Thanks to @mrshu for the find. If the original PR is cleaned up then we can merge that one instead.