### PR TITLE
fix: make shebang lines portable

### DIFF
--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ $# -ge 1 ]; then
-  DIR="$(realpath $1)/gef-extras"
+  DIR="$(realpath "$1")/gef-extras"
   test -d "${DIR}" || exit 1
 elif [ -d "${HOME}/.config" ]; then
   DIR="${HOME}/.config/gef-extras"

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -4,8 +4,8 @@ set -e
 
 if [ $# -ge 1 ]; then
   DIR="$(realpath $1)/gef-extras"
-  test -d ${DIR} || exit 1
-elif [ -d ${HOME}/.config ]; then
+  test -d "${DIR}" || exit 1
+elif [ -d "${HOME}/.config" ]; then
   DIR="${HOME}/.config/gef-extras"
 else
   DIR="${HOME}/.gef-extras"

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -11,7 +11,7 @@ else
   DIR="${HOME}/.gef-extras"
 fi
 
-git clone https://github.com/hugsy/gef-extras.git ${DIR}
+git clone https://github.com/hugsy/gef-extras.git "${DIR}"
 gdb -q -ex "gef config gef.extra_plugins_dir '${DIR}/scripts'" \
        -ex "gef config pcustom.struct_path '${DIR}/structs'" \
        -ex "gef config syscall-args.path '${DIR}/syscall-tables'" \

--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -12,9 +12,9 @@ curl_found=0
 wget_found=0
 
 # check dependencies
-if [ `which curl` ]; then
+if [ "$(which curl)" ]; then
 	curl_found=1
-elif [ `which wget` ]; then
+elif [ "$(which wget)" ]; then
 	wget_found=1
 else
 	echo "Please install cURL or wget and run again"

--- a/scripts/generate-api-docs.sh
+++ b/scripts/generate-api-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/generate-api-docs.sh
+++ b/scripts/generate-api-docs.sh
@@ -16,7 +16,7 @@ check()
 
 clean_doc()
 {
-    rm -fr -- ${output_path}/*.md
+    rm -fr -- "${output_path}/*.md"
 }
 
 
@@ -33,13 +33,13 @@ generate_doc()
 fixup_doc()
 {
     # rename
-    mv ${output_path}/__main__.md ${full_doc_path}
+    mv "${output_path}/__main__.md" "${full_doc_path}"
 
     # replace the title
-    sed -i 's?# <kbd>module</kbd> `__main__`?# <kbd>module</kbd> `GEF`?' ${full_doc_path}
+    sed -i 's?# <kbd>module</kbd> `__main__`?# <kbd>module</kbd> `GEF`?' "${full_doc_path}"
 
     # fix the hrefs
-    sed -i -ze 's!<a href="\([^"]*\)[^`]*`\([^`]*\)`!<a href="https://cs.github.com/hugsy/gef?q=\2"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>\n\n## <kbd>function</kbd> `\2`!g' ${full_doc_path}
+    sed -i -ze 's!<a href="\([^"]*\)[^`]*`\([^`]*\)`!<a href="https://cs.github.com/hugsy/gef?q=\2"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>\n\n## <kbd>function</kbd> `\2`!g' "${full_doc_path}"
 }
 
 check

--- a/tests/perf/context_times.sh
+++ b/tests/perf/context_times.sh
@@ -17,13 +17,13 @@ get_context_time() {
 }
 
 log_this_revision() {
-    rev=`git log -1 --pretty="format:%h"`
-    printf $rev
-    title=`git log -1 --pretty="format:%s"`
-    printf ",\"$title\""
-    for i in `seq 1 5`; do
-        rv=`$1`
-        printf ",$rv"
+    rev=$(git log -1 --pretty="format:%h")
+    printf "%s" "$rev"
+    title=$(git log -1 --pretty="format:%s")
+    printf ",\"%s\"" "$title"
+    for _ in $(seq 1 5); do
+        rv=$($1)
+        printf ",%s" "$rv"
     done
     printf "\n"
 }
@@ -39,7 +39,7 @@ clear_stats() {
 }
 
 get_current_branch_or_commit() {
-    b=`git branch | grep '\* '`
+    b=$(git branch | grep '\* ')
     case "$b" in
         *HEAD*)
             echo "$b" | tr -d ')' | cut -f 5 -d ' ';;
@@ -53,23 +53,23 @@ run_on_git_revisions() {
     end_ref=$2
     test_command=$3
 
-    orig_rev=`get_current_branch_or_commit`
-    revs=`git rev-list --reverse ${start_ref}..${end_ref}`
+    orig_rev=$(get_current_branch_or_commit)
+    revs=$(git rev-list --reverse "${start_ref}".."${end_ref}")
 
     for rev in $revs; do
-        echo "Checking out: $(git log --oneline -1 $rev)"
-        git checkout --quiet $rev
-        log_command $test_command
+        echo "Checking out: $(git log --oneline -1 "$rev")"
+        git checkout --quiet "$rev"
+        log_command "$test_command"
         git reset --hard --quiet
     done
 
     echo "Restoring original commit/branch: $orig_rev"
-    git checkout --quiet $orig_rev
+    git checkout --quiet "$orig_rev"
 }
 
 if [ $# == "2" ]; then
     clear_stats
-    run_on_git_revisions $1 $2 "time_gef_context"
+    run_on_git_revisions "$1" "$2" "time_gef_context"
 else
     echo "usage: $0 first_commit last_commit"
 fi

--- a/tests/perf/context_times.sh
+++ b/tests/perf/context_times.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Bail out early on an unexpected error
 set -e

--- a/tests/run-remote.sh
+++ b/tests/run-remote.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Bash script to automate running the tests running from any remote machine
 # (assumes GDB+Python3, requires sudo NOPASSWD)


### PR DESCRIPTION
## Make shell scripts portable ##

### Description/Motivation/Screenshots ###

Some Operating Systems like OpenBSD, Solaris or NixOS have a different path for `bash`. This PR makes the shell scripts more portable across these systems by changing the shebang lines to:
```sh
#!/usr/bin/env bash
```

https://en.wikipedia.org/w/index.php?title=Shebang_(Unix)&oldid=878552871#Portability

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
