### PR TITLE
Fix vmmap failed due to libc args dict

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -217,7 +217,11 @@ def highlight_text(text: str) -> str:
 
     ansiSplit = re.split(ANSI_SPLIT_RE, text)
 
+    _arch_mode = f"{gef.arch.arch.lower()}_{gef.arch.mode}"
+
     for match, color in gef.ui.highlight_table.items():
+        if match == _arch_mode:
+            continue
         for index, val in enumerate(ansiSplit):
             found = val.find(match)
             if found > -1:


### PR DESCRIPTION
## Fix vmmap failed due to libc args dict ##

### Description ###

If turn `gef-extras.libc_args` on, e.g.
```
libc_args = True
libc_args_path = ~/gef-extras/glibc-function-args
```
`vmmap` will be failed as follows:
```
gef➤  vmmap 
[ Legend:  Code | Heap | Stack ]
Start              End                Offset             Perm Path
0x00555555554000 0x00555555556000 0x00000000000000 r-x /home/zhou/Desktop/girlfriend
0x00555555755000 0x00555555756000 0x00000000001000 r-- /home/zhou/Desktop/girlfriend
0x00555555756000 0x00555555757000 0x00000000002000 rw- /home/zhou/Desktop/girlfriend
[!] Command 'vmmap' failed to execute properly, reason: 'dict' object has no attribute 'split'
```

### Reason ###

This is caused by the loop `for match, color in gef.ui.highlight_table.items():`.
However, `highlight_table[_arch_mode]` is a `dict`.

### After patch ###

```
gef➤  vmmap 
[ Legend:  Code | Heap | Stack ]
Start              End                Offset             Perm Path
0x00555555554000 0x00555555556000 0x00000000000000 r-x /home/zhou/Desktop/girlfriend
0x00555555755000 0x00555555756000 0x00000000001000 r-- /home/zhou/Desktop/girlfriend
0x00555555756000 0x00555555757000 0x00000000002000 rw- /home/zhou/Desktop/girlfriend
0x007ffff79e2000 0x007ffff7bc9000 0x00000000000000 r-x /lib/x86_64-linux-gnu/libc-2.27.so
0x007ffff7bc9000 0x007ffff7dc9000 0x000000001e7000 --- /lib/x86_64-linux-gnu/libc-2.27.so
0x007ffff7dc9000 0x007ffff7dcd000 0x000000001e7000 r-- /lib/x86_64-linux-gnu/libc-2.27.so
0x007ffff7dcd000 0x007ffff7dcf000 0x000000001eb000 rw- /lib/x86_64-linux-gnu/libc-2.27.so
0x007ffff7dcf000 0x007ffff7dd3000 0x00000000000000 rw- 
0x007ffff7dd3000 0x007ffff7dfc000 0x00000000000000 r-x /lib/x86_64-linux-gnu/ld-2.27.so
0x007ffff7feb000 0x007ffff7fed000 0x00000000000000 rw- 
0x007ffff7ff7000 0x007ffff7ffa000 0x00000000000000 r-- [vvar]
0x007ffff7ffa000 0x007ffff7ffc000 0x00000000000000 r-x [vdso]
0x007ffff7ffc000 0x007ffff7ffd000 0x00000000029000 r-- /lib/x86_64-linux-gnu/ld-2.27.so
0x007ffff7ffd000 0x007ffff7ffe000 0x0000000002a000 rw- /lib/x86_64-linux-gnu/ld-2.27.so
0x007ffff7ffe000 0x007ffff7fff000 0x00000000000000 rw- 
0x007ffffffde000 0x007ffffffff000 0x00000000000000 rw- [stack]
0xffffffffff600000 0xffffffffff601000 0x00000000000000 r-x [vsyscall]
```