### PR TITLE
Add class factory support for `pcustom`

### DIFF
--- a/docs/commands/pcustom.md
+++ b/docs/commands/pcustom.md
@@ -124,14 +124,17 @@ Which will become:
 
 `pcustom` also supports the use of class factories to create a `ctypes.Structure` class whose structure will be adjusted based on the runtime information we provide (information about the currently debugged binary, the architecture, the size of a pointer and more).
 
-The syntax is relatively close to the way we use to create static classes (see above), but instead we will define a method that will generate the class.
+The syntax is relatively close to the way we use to create static classes (see above), but instead we will define a method that will generate the class. The requirements for this class factory method to be valid are:
+   - have one positional argument of type [`Gef`](https://github.com/hugsy/gef/blob/dev/docs/api/gef.md#class-gef)
+   - the name of the method itself **must** end with `_t`
 
 To continue the `person_t` function we defined in the example above, we could modify the static class as a dynamic one very easily:
 
 ```python
 import ctypes
+from typing import Optional
 
-def person_t(gef=None):
+def person_t(gef: Optional["Gef"]=None):
     fields = [
         ("age",  ctypes.c_int),
         ("name", ctypes.c_char * 256),
@@ -148,8 +151,9 @@ Thanks to the `gef` parameter, the structure can be transparently adjusted so th
 
 ```python
 import ctypes
+from typing import Optional
 
-def person_t(gef=None):
+def person_t(gef: Optional["Gef"]==None):
     fields = [
         ("age",  ctypes.c_uint8),
         ("name", ctypes.c_char * 256),

--- a/docs/commands/pcustom.md
+++ b/docs/commands/pcustom.md
@@ -124,9 +124,9 @@ Which will become:
 
 `pcustom` also supports the use of class factories to create a `ctypes.Structure` class whose structure will be adjusted based on the runtime information we provide (information about the currently debugged binary, the architecture, the size of a pointer and more).
 
-The syntax is relatively close to the way we use to create static classes (see above), but instead we will define a method that will generate the class. The requirements for this class factory method to be valid are:
-   - have one positional argument of type [`Gef`](https://github.com/hugsy/gef/blob/dev/docs/api/gef.md#class-gef)
-   - the name of the method itself **must** end with `_t`
+The syntax is relatively close to the way we use to create static classes (see above), but instead we define a function that will generate the class. The requirements for this class factory are:
+   - take a single [`Gef`](https://github.com/hugsy/gef/blob/dev/docs/api/gef.md#class-gef) positional argument
+   - End the function name with `_t`
 
 To continue the `person_t` function we defined in the example above, we could modify the static class as a dynamic one very easily:
 

--- a/docs/commands/pcustom.md
+++ b/docs/commands/pcustom.md
@@ -122,16 +122,16 @@ Which will become:
 
 #### Dynamic `ctypes.Structure`-like classes
 
-`pcustom` also supports the use of class factory to create a `ctypes.Structure` class whose structure will be adjusted based on the runtime information we can provide (information about the currently debugged binary, the architecture, the size of a pointer and more).
+`pcustom` also supports the use of class factories to create a `ctypes.Structure` class whose structure will be adjusted based on the runtime information we provide (information about the currently debugged binary, the architecture, the size of a pointer and more).
 
 The syntax is relatively close to the way we use to create static classes (see above), but instead we will define a method that will generate the class.
 
-To continue the `person_t` class we defined in the example above, we could redefine the static class as a dynamic one very easily as such:
+To continue the `person_t` function we defined in the example above, we could modify the static class as a dynamic one very easily:
 
 ```python
 import ctypes
 
-def person_t(gef = None):
+def person_t(gef=None):
     fields = [
         ("age",  ctypes.c_int),
         ("name", ctypes.c_char * 256),
@@ -149,7 +149,7 @@ Thanks to the `gef` parameter, the structure can be transparently adjusted so th
 ```python
 import ctypes
 
-def person_t(gef = None):
+def person_t(gef=None):
     fields = [
         ("age",  ctypes.c_uint8),
         ("name", ctypes.c_char * 256),

--- a/gef.py
+++ b/gef.py
@@ -83,7 +83,7 @@ from functools import lru_cache
 from io import StringIO, TextIOWrapper
 from types import ModuleType
 from typing import (Any, ByteString, Callable, Dict, Generator, IO, Iterator, List,
-                    NoReturn, Optional, Sequence, Tuple, Type, Union)
+                    NoReturn, Optional, Sequence, Set, Tuple, Type, Union)
 from urllib.request import urlopen
 
 
@@ -5323,6 +5323,9 @@ class ExternalStructureManager:
             self.module_path = mod_path
             self.name = struct_name
             self.class_type = self.__get_structure_class()
+            # if the symbol points to a class factory method and not a class
+            if not hasattr(self.class_type, "_fields_"):
+                self.class_type = self.class_type(gef)
             return
 
         def __str__(self) -> str:
@@ -5445,11 +5448,19 @@ class ExternalStructureManager:
 
         def __iter__(self) -> Generator[str, None, None]:
             _invalid = {"BigEndianStructure", "LittleEndianStructure", "Structure"}
-            _structs = {x for x in dir(self.raw) \
-                             if inspect.isclass(getattr(self.raw, x)) \
-                             and issubclass(getattr(self.raw, x), ctypes.Structure)}
-            for entry in (_structs - _invalid):
-                yield entry
+            for x in dir(self.raw):
+                if x in _invalid: continue
+                _attr = getattr(self.raw, x)
+
+                # if it's a ctypes.Structure class, add it
+                if inspect.isclass(_attr) and issubclass(_attr, ctypes.Structure):
+                    yield x
+                    continue
+
+                # also accept class factory functions
+                if callable(_attr) and _attr.__module__ == self.name and x.endswith("_t"):
+                    yield x
+                    continue
             return
 
     class Modules(dict):
@@ -11529,6 +11540,21 @@ class GefUiManager(GefManager):
         return
 
 
+class GefLibcManager(GefManager):
+    """Class managing everything libc-related (except heap)."""
+    def __init__(self) -> None:
+        self._version : Optional[Tuple[int, int]] = None
+        return
+
+    @property
+    def version(self) -> Optional[Tuple[int, int]]:
+        if not is_alive():
+            return None
+        if not self._version:
+            self._version = get_libc_version()
+        return self._version
+
+
 class Gef:
     """The GEF root class, which serves as a entrypoint for all the debugging session attributes (architecture,
     memory, settings, etc.)."""
@@ -11537,6 +11563,7 @@ class Gef:
         self.arch: Architecture = GenericArchitecture() # see PR #516, will be reset by `new_objfile_handler`
         self.config = GefSettingsManager()
         self.ui = GefUiManager()
+        self.libc = GefLibcManager()
         return
 
     def reinitialize_managers(self) -> None:

--- a/gef.py
+++ b/gef.py
@@ -5324,7 +5324,7 @@ class ExternalStructureManager:
             self.name = struct_name
             self.class_type = self.__get_structure_class()
             # if the symbol points to a class factory method and not a class
-            if not hasattr(self.class_type, "_fields_"):
+            if not hasattr(self.class_type, "_fields_") and callable(self.class_type):
                 self.class_type = self.class_type(gef)
             return
 

--- a/gef.py
+++ b/gef.py
@@ -83,7 +83,7 @@ from functools import lru_cache
 from io import StringIO, TextIOWrapper
 from types import ModuleType
 from typing import (Any, ByteString, Callable, Dict, Generator, IO, Iterator, List,
-                    NoReturn, Optional, Sequence, Set, Tuple, Type, Union)
+                    NoReturn, Optional, Sequence, Tuple, Type, Union)
 from urllib.request import urlopen
 
 


### PR DESCRIPTION
### Description/Motivation/Screenshots ###

This feature was suggested by a friend of mine and it's pretty simple and cool: the idea is to allow GEF to not just support static `ctypes.Structure` based classes for `pcustom`, but also methods that would act as class factory. Even though we lose a bit in the structure readability (IMO) we gain tons in fine tuning of the generated class, thanks to the runtime info provided by GEF.

For example it means we can merge the `elf` structure defined [here for 32b](https://github.com/hugsy/gef-extras/blob/dev/structs/elf32_t.py) and [there for 64b](https://github.com/hugsy/gef-extras/blob/dev/structs/elf64_t.py) or also improve the currently incorrect structure definition of the heap chunks/arenas in `gef-extras` based on the libc version.  I've also added a simple example in the docs.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
