### PR TITLE
Convert `libc_args_definitions` to `gef.ui.libc_args_table`

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3518,19 +3518,19 @@ def load_libc_args() -> bool:
     _libc_args_file = path / f"{_arch_mode}.json"
 
     # current arch and mode already loaded
-    if _arch_mode in gef.ui.highlight_table:
+    if _arch_mode in gef.ui.libc_args_table:
         return True
 
-    gef.ui.highlight_table[_arch_mode] = {}
+    gef.ui.libc_args_table[_arch_mode] = {}
     try:
         with _libc_args_file.open() as _libc_args:
-            gef.ui.highlight_table[_arch_mode] = json.load(_libc_args)
+            gef.ui.libc_args_table[_arch_mode] = json.load(_libc_args)
         return True
     except FileNotFoundError:
-        del gef.ui.highlight_table[_arch_mode]
+        del gef.ui.libc_args_table[_arch_mode]
         warn(f"Config context.libc_args is set but definition cannot be loaded: file {_libc_args_file} not found")
     except json.decoder.JSONDecodeError as e:
-        del gef.ui.highlight_table[_arch_mode]
+        del gef.ui.libc_args_table[_arch_mode]
         warn(f"Config context.libc_args is set but definition cannot be loaded from file {_libc_args_file}: {e}")
     return False
 
@@ -8547,7 +8547,7 @@ class ContextCommand(GenericCommand):
         if function_name.endswith("@plt"):
             _function_name = function_name.split("@")[0]
             try:
-                nb_argument = len(gef.ui.highlight_table[_arch_mode][_function_name])
+                nb_argument = len(gef.ui.libc_args_table[_arch_mode][_function_name])
             except KeyError:
                 pass
 
@@ -11524,6 +11524,7 @@ class GefUiManager(GefManager):
         self.context_hidden = False
         self.stream_buffer : Optional[StringIO] = None
         self.highlight_table: Dict[str, str] = {}
+        self.libc_args_table: Dict[str, Dict[str, Dict[str, str]]] = {}
         self.watches: Dict[int, Tuple[int, str]] = {}
         self.context_messages: List[str] = []
         return


### PR DESCRIPTION


### Description/Motivation/Screenshots ###

During the code refactoring `libc_args_definitions` was mistakenly replaced to point to `gef.ui.highlight_table`, resulting in issues like #820 
This PR fixes it by creating a proper table in the `gef` namespace `gef.ui.libc_args_table` ; and make the old  `libc_args_definitions` dict point to `gef.ui.libc_args_table`

Fixes #820 

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
