### PR TITLE
 Add mechanism to let architectures specify whether they support a gdb arch

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -213,3 +213,15 @@ args.foo --> [3, 14, 159, 2653] # a List(int) from user input
 args.bleh --> "" # the default value
 args.blah --> True # set to True because user input declared the option (would have been False otherwise)
 ```
+
+### Adding new architectures
+
+Support for new architectures can be added by inheriting from the `Architecture` class. To register the new architecture with gef, `@register_architecture` has to be added to the class. Examples can be found in [gef-extras](https://github.com/hugsy/gef-extras/tree/dev/archs).
+
+Sometimes architectures can more precisely determine whether they apply to the current target by looking at the architecture determined by gdb. For these cases the custom architecture may implement the `supports_gdb_arch()` static function to signal that they should be used instead of the default. One example is the ARM Cortex-M architecture which in some cases should rather be used than the generic ARM one:
+
+```python
+@staticmethod
+def supports_gdb_arch(gdb_arch: str) -> Optional[bool]:
+    return bool(re.search("^armv.*-m$", gdb_arch))
+```

--- a/docs/api.md
+++ b/docs/api.md
@@ -216,9 +216,16 @@ args.blah --> True # set to True because user input declared the option (would h
 
 ### Adding new architectures
 
-Support for new architectures can be added by inheriting from the `Architecture` class. To register the new architecture with gef, `@register_architecture` has to be added to the class. Examples can be found in [gef-extras](https://github.com/hugsy/gef-extras/tree/dev/archs).
+Support for new architectures can be added by inheriting from the `Architecture` class. To register the new architecture with gef, the decorator `@register_architecture` has to be added to the class. Examples can be found in [gef-extras](https://github.com/hugsy/gef-extras/tree/dev/archs).
 
-Sometimes architectures can more precisely determine whether they apply to the current target by looking at the architecture determined by gdb. For these cases the custom architecture may implement the `supports_gdb_arch()` static function to signal that they should be used instead of the default. One example is the ARM Cortex-M architecture which in some cases should rather be used than the generic ARM one:
+Sometimes architectures can more precisely determine whether they apply to the current target by looking at the architecture determined by gdb. For these cases the custom architecture may implement the `supports_gdb_arch()` static function to signal that they should be used instead of the default. The function receives only one argument:
+- `gdb_str` (of type `str`) which is the architecture name as reported by GDB. 
+
+The function **must** return:
+- `True` if the current `Architecture` class supports the target binary; `False` otherwise.
+- `None` to simply ignore this check and let GEF try to determine the architecture.
+
+One example is the ARM Cortex-M architecture which in some cases should rather be used than the generic ARM one:
 
 ```python
 @staticmethod

--- a/gef.py
+++ b/gef.py
@@ -2073,7 +2073,10 @@ def get_arch() -> str:
         arch_str = arch_str.replace("The target architecture is assumed to be ", "")
     elif "The target architecture is set to " in arch_str:
         # GDB version >= 10.1
-        arch_str = re.findall(r"\"(.+)\"", arch_str)[0]
+        if "\"auto\"" in arch_str:
+            arch_str = re.findall(r"currently \"(.+)\"", arch_str)[0]
+        else:
+            arch_str = re.findall(r"\"(.+)\"", arch_str)[0]
     else:
         # Unknown, we throw an exception to be safe
         raise RuntimeError(f"Unknown architecture: {arch_str}")

--- a/gef.py
+++ b/gef.py
@@ -2067,13 +2067,12 @@ def get_arch() -> str:
 
     arch_str = gdb.execute("show architecture", to_string=True).strip()
     if "The target architecture is set automatically (currently " in arch_str:
-        arch_str = arch_str.split("(currently ", 1)[1]
-        arch_str = arch_str.split(")", 1)[0]
+        arch_str = arch_str.lstrip("(currently ").rstrip(")")
     elif "The target architecture is assumed to be " in arch_str:
-        arch_str = arch_str.replace("The target architecture is assumed to be ", "")
+        arch_str = arch_str.lstrip("The target architecture is assumed to be ")
     elif "The target architecture is set to " in arch_str:
         # GDB version >= 10.1
-        if "\"auto\"" in arch_str:
+        if '"auto"' in arch_str:
             arch_str = re.findall(r"currently \"(.+)\"", arch_str)[0]
         else:
             arch_str = re.findall(r"\"(.+)\"", arch_str)[0]
@@ -2140,6 +2139,9 @@ class Architecture(metaclass=abc.ABCMeta):
 
     @staticmethod
     def supports_gdb_arch(gdb_arch: str) -> Optional[bool]:
+        """If implemented by a child `Architecture`, this function dictates if the current class
+        supports the loaded ELF file (which can be accessed via `gef.binary`). This callback
+        function will override any assumption made by GEF to determine the architecture."""
         return None
 
     @abc.abstractproperty
@@ -3170,6 +3172,9 @@ class MIPS64(MIPS):
     mode = "MIPS64"
     ptrsize = 8
 
+    @staticmethod
+    def supports_gdb_arch(gdb_arch: str) -> Optional[bool]:
+        return gdb_arch.startswith("mips") and gef.binary.e_class == Elf.Class.ELF_64_BITS
 
 def copy_to_clipboard(data: str) -> None:
     """Helper function to submit data to the clipboard"""
@@ -3767,14 +3772,10 @@ def reset_architecture(arch: Optional[str] = None, default: Optional[str] = None
     gdb_arch = get_arch()
     arch_name = gef.binary.e_machine if gef.binary else gdb_arch
 
-    if ((arch_name == "MIPS" or arch_name == Elf.Abi.MIPS)
-        and (gef.binary is not None and gef.binary.e_class == Elf.Class.ELF_64_BITS)):
-        # MIPS64 = arch(MIPS) + 64b flag
-        arch_name = "MIPS64"
-
     preciser_arch = next((a for a in arches.values() if a.supports_gdb_arch(gdb_arch)), None)
     if preciser_arch:
-        arch_name = preciser_arch.arch
+        gef.arch = preciser_arch()
+        return
 
     try:
         gef.arch = arches[arch_name]()


### PR DESCRIPTION
## Add mechanism to let architectures specify whether they support a gdb arch ##

### Description/Motivation/Screenshots ###
~~Should help with #799. Contains an enhancement for `get_arch()` and uses that function to determine whether we're dealing with ARM-M if the architecture has been added by gef-extras.~~
Add a callback to `Architecture` which can be used to detect whether a architecture supports a specific gdb arch.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |  |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_check_mark:  |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |   |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] My change adds tests as appropriate.
- [x] I have read and agree to the **CONTRIBUTING** document.
