### PR TITLE
remove unnecessary warnings

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -10613,7 +10613,7 @@ class GefRestoreCommand(gdb.Command):
                 key = f"{section}.{optname}"
                 try:
                     setting = gef.config.raw_entry(key)
-                except Exception as e:
+                except Exception:
                     continue
                 new_value = cfg.get(section, optname)
                 if setting.type == bool:

--- a/gef.py
+++ b/gef.py
@@ -10614,7 +10614,6 @@ class GefRestoreCommand(gdb.Command):
                 try:
                     setting = gef.config.raw_entry(key)
                 except Exception as e:
-                    warn(f"Invalid setting '{key}': {e}")
                     continue
                 new_value = cfg.get(section, optname)
                 if setting.type == bool:


### PR DESCRIPTION
## Remove  Unnecessary Warnings on gef remote command ##

Removing unnecessary warning when using gef with gef-extras.
This PR solves issue related to [https://github.com/hugsy/gef/issues/823](https://github.com/hugsy/gef/issues/823) .

Fixes #823 