### PR TITLE
very slightly simplify GEFs instruction finding api

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1938,10 +1938,6 @@ def get_nth_instruction_from(addr: int, n: int) -> Instruction:
     """Return the `n`-th instruction after `addr` as an Instruction object. n can also be negative."""
     if n < 0:
         prev_addr = get_nth_instruction_addr_from(addr, n)
-        if prev_addr is None:
-            # hack to avoid optional return value
-            warn("Returning the current instruction instead")
-            return get_instruction_at(addr)
         return get_instruction_at(prev_addr)
     return list(gdb_disassemble(addr, count=n + 1))[n]
 


### PR DESCRIPTION
## very slightly simplify GEFs instruction finding api ##

### Description/Motivation/Screenshots ###

The "instruction finding api" of GEF is currently a little confusing. For example `gef_get_instruction_at()` and `gef_current_instruction` do basically the exact same thing (the only difference underneath being a generator used vs a list).
Furthermore some of those function names did not properly reflect the code: e.g. `gef_current_instruction()` does not return the current instruction but the instruction at a specified address.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark: |  |
| x86-64       | :heavy_check_mark: |                                           |
| ARM          | :heavy_multiplication_x: |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_check_mark: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [ ] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
