### PR TITLE
Improve identifying Stack Canaries

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2045,7 +2045,7 @@ def checksec(filename: str) -> Dict[str, bool]:
         return False
 
     results = collections.OrderedDict()
-    results["Canary"] = __check_security_property("-s", filename, r"__stack_chk_fail") is True
+    results["Canary"] = __check_security_property("-rs", filename, r"__stack_chk_fail") is True
     has_gnu_stack = __check_security_property("-W -l", filename, r"GNU_STACK") is True
     if has_gnu_stack:
         results["NX"] = __check_security_property("-W -l", filename, r"GNU_STACK.*RWE") is False


### PR DESCRIPTION
## <Improve identifying Stack Canaries> ##

### Description/Motivation/Screenshots ###
This update is to improve detection of Stack Canaries in cases where the symbol is located in one of the relocation sections. 

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_check_mark:  |                                           |
| x86-64       | :heavy_check_mark:  |                                           |
| ARM          | :heavy_multiplication_x: |  Should work as before    |
| AARCH64      | :heavy_multiplication_x: |   Should work as before   |
| MIPS         | :heavy_multiplication_x: |   Should work as before   |
| POWERPC      | :heavy_multiplication_x: |    Should work as before   |
| SPARC        | :heavy_multiplication_x: |   Should work as before   |
| RISC-V       | :heavy_multiplication_x: |    Should work as before  |
| `make test`  | :heavy_multiplication_x: |    Should work as before     |

### Checklist ###

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
