### PR TITLE
small fixes in reset_architecture()

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3771,7 +3771,11 @@ def reset_architecture(arch: Optional[str] = None, default: Optional[str] = None
             raise OSError(f"Specified arch {arch.upper()} is not supported")
 
     if not gef.binary:
-        gef.binary = get_elf_headers()
+        try:
+            gef.binary = get_elf_headers()
+        except RuntimeError:
+            # in case the binary is not an ELF file
+            pass
 
     gdb_arch = get_arch()
     arch_name = gef.binary.e_machine if gef.binary else gdb_arch
@@ -3782,7 +3786,7 @@ def reset_architecture(arch: Optional[str] = None, default: Optional[str] = None
         return
 
     try:
-        gef.arch = arches[arch_name]()
+        gef.arch = arches[arch_name.upper()]()
     except KeyError:
         if default:
             try:


### PR DESCRIPTION
## small fixes in reset_architecture() ##

### Description/Motivation/Screenshots ###

I ran into some issues while trying to use https://github.com/bet4it/udbserver.

The patch includes small bug fixes in `reset_architecture()`. The first is catching a `RuntimeError` if parsing the ELF header fails (in the case where the binary is not an ELF file), and the second one is `arch_name.upper()`.

### How Has This Been Tested? ###

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :heavy_multiplication_x: |                                           |
| x86-64       | :heavy_multiplication_x: |                                           |
| ARM          | :heavy_check_mark:       |                                           |
| AARCH64      | :heavy_multiplication_x: |                                           |
| MIPS         | :heavy_multiplication_x: |                                           |
| POWERPC      | :heavy_multiplication_x: |                                           |
| SPARC        | :heavy_multiplication_x: |                                           |
| RISC-V       | :heavy_multiplication_x: |                                           |
| `make test`  | :heavy_multiplication_x: |                                           |

### Checklist ###

- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
