### PR TITLE
new feature: print-format and patch byte commands can work together

### DIFF
--- a/docs/commands/patch.md
+++ b/docs/commands/patch.md
@@ -7,3 +7,12 @@ gef➤ patch byte $eip 0x90
 gef➤ patch string $eip "cool!"
 ```
 
+These commands copy the first 10 bytes of $rsp+8 to $rip:
+
+```
+gef➤  print-format --lang bytearray -l 10 $rsp+8
+Saved data b'\xcb\xe3\xff\xff\xff\x7f\x00\x00\x00\x00'... in '$_gef0'
+gef➤  patch byte $rip $_gef0
+```
+
+Very handy to copy-paste-execute shellcodes/data from different memory regions.

--- a/docs/commands/print-format.md
+++ b/docs/commands/print-format.md
@@ -7,6 +7,7 @@ The command `print-format` (alias `pf`) will dump an arbitrary location as an ar
  - Assembly (`asm`)
  - Javascript (`js`)
  - Hex string (`hex`)
+ - For patch byte command or GDB $_gef[N] byte access (`bytearray`)
 
 
 ```
@@ -26,3 +27,15 @@ gef➤  print-format --lang py --bitlen 8 -l 10 --clip $rsp
 [+] Copied to clipboard
 buf = [0x87, 0xfa, 0xa3, 0xf7, 0xff, 0x7f, 0x0, 0x0, 0x30, 0xe6]
 ```
+
+These commands copy the first 10 bytes of $rsp+8 to $rip:
+
+```
+gef➤  print-format --lang bytearray -l 10 $rsp+8
+Saved data b'\xcb\xe3\xff\xff\xff\x7f\x00\x00\x00\x00'... in '$_gef0'
+gef➤  display/x $_gef0[5]
+4: /x $_gef0[5] = 0x7f
+gef➤  patch byte $rip $_gef0
+```
+
+Very handy to copy-paste-execute shellcodes/data from different memory regions.

--- a/tests/commands/patch.py
+++ b/tests/commands/patch.py
@@ -20,6 +20,10 @@ class PatchCommand(GefUnitTestGeneric):
         self.assertNoException(res)
         self.assertRegex(res, r"0xcc\s*0x[^c]{2}")
 
+    def test_cmd_patch_byte_bytearray(self):
+        res = gdb_start_silent_cmd_last_line("set $_gef69 = { 0xcc, 0xcc }", after=["patch byte $pc $_gef69", "display/8bx $pc",])
+        self.assertNoException(res)
+        self.assertRegex(res, r"(0xcc\s*)(\1)0x[^c]{2}")
 
     def test_cmd_patch_word(self):
         res = gdb_start_silent_cmd_last_line("patch word $pc 0xcccc", after=["display/8bx $pc",])

--- a/tests/commands/print_format.py
+++ b/tests/commands/print_format.py
@@ -25,3 +25,18 @@ class PrintFormatCommand(GefUnitTestGeneric):
         res = gdb_start_silent_cmd("print-format --lang iDontExist $sp")
         self.assertNoException(res)
         self.assertTrue("Language must be in:" in res)
+
+
+    def test_cmd_print_format_bytearray(self):
+        res = gdb_start_silent_cmd("set *((int*)$sp) = 0x41414141",
+                                   after=["print-format --lang bytearray -l 4 $sp"])
+        self.assertNoException(res)
+        try:
+            gef_var = res.split('$_gef')[1].split("'")[0]
+        except:
+            self.assertTrue(False)
+        self.assertTrue("\x41\x41\x41\x41" in res)
+        res = gdb_start_silent_cmd("set *((int*)$sp) = 0x41414141",
+                                   after=["print-format --lang bytearray -l 4 $sp", "p $_gef" + gef_var])
+        self.assertNoException(res)
+        self.assertTrue("0x41, 0x41, 0x41, 0x41" in res)


### PR DESCRIPTION
With this PR print-format and patch byte commands can work together

Very handy to copy-paste-execute shellcodes/data from different memory regions

Alternative for: "set" / "dump" & "restore" ... GDB commands

**Example of use:**

```
gef➤  patch byte $rip 0x41 0x42 0x43
gef➤  hexdump byte $rip
0x00007ffff7fcd050 <_start+0000>    41 42 43 e8 18 0d 00 00 49 89 c4 8b 05 97 ec 02    ABC.....I.......
0x00007ffff7fcd060 <_dl_start_user+0008>    00 5a 48 8d 24 c4 29 c2 52 48 89 d6 49 89 e5 48    .ZH.$.).RH..I..H
0x00007ffff7fcd070 <_dl_start_user+0018>    83 e4 f0 48 8b 3d c6 ff 02 00 49 8d 4c d5 10 49    ...H.=....I.L..I
0x00007ffff7fcd080 <_dl_start_user+0028>    8d 55 08 31 ed e8 d6 ef 00 00 48 8d 15 5f f1 00    .U.1......H.._..
gef➤  hexdump byte $rsp+8
0x00007fffffffe068     b5 e3 ff ff ff 7f 00 00 00 00 00 00 00 00 00 00    ................
0x00007fffffffe078     c1 e3 ff ff ff 7f 00 00 d0 e3 ff ff ff 7f 00 00    ................
0x00007fffffffe088     e4 e3 ff ff ff 7f 00 00 07 e4 ff ff ff 7f 00 00    ................
0x00007fffffffe098     3d e4 ff ff ff 7f 00 00 5e e4 ff ff ff 7f 00 00    =.......^.......
gef➤  print-format --lang bytearray -l 15 $rsp+8
Saved data b'\xb5\xe3\xff\xff\xff\x7f\x00\x00\x00\x00'... in '$_gef0'
gef➤  display/x $_gef0[5]
4: /x $_gef0[5] = 0x7f
gef➤  patch byte $rip $_gef0
gef➤  hexdump byte $rip
0x00007ffff7fcd050 <_start+0000>    b5 e3 ff ff ff 7f 00 00 00 00 00 00 00 00 00 02    ................
0x00007ffff7fcd060 <_dl_start_user+0008>    00 5a 48 8d 24 c4 29 c2 52 48 89 d6 49 89 e5 48    .ZH.$.).RH..I..H
0x00007ffff7fcd070 <_dl_start_user+0018>    83 e4 f0 48 8b 3d c6 ff 02 00 49 8d 4c d5 10 49    ...H.=....I.L..I
0x00007ffff7fcd080 <_dl_start_user+0028>    8d 55 08 31 ed e8 d6 ef 00 00 48 8d 15 5f f1 00    .U.1......H.._..
gef➤  p $_gef0
$1 = {0xb5, 0xe3, 0xff, 0xff, 0xff, 0x7f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
```

## How Has This Been Tested?

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :white_check_mark:                       |                                           |
| x86-64       | :white_check_mark:                      |                                           |
| ARM          | :x:                      |                                           |
| AARCH64      | :x:                      |                                           |
| MIPS         | :x:                      |                                           |
| POWERPC      | :x:                      |                                           |
| SPARC        | :x:                      |                                           |
| RISC-V       | :x:                      |                                           |
| `make test`  | :white_check_mark:                       |                                           |


## Checklist

- [X] My PR was done against the `dev` branch, not `master`.
- [X] My code follows the code style of this project.
- [X] My change includes a change to the documentation, if required.
- [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [X] I have read and agree to the **CONTRIBUTING** document.
