### PR TITLE
keep x86 and x86_64 FLAGS Register when calls to mprotect. 

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2729,11 +2729,13 @@ class X86(Architecture):
         _NR_mprotect = 125
         insns = [
             "pushad",
+            "pushfd",
             f"mov eax, {_NR_mprotect:d}",
             f"mov ebx, {addr:d}",
             f"mov ecx, {size:d}",
             f"mov edx, {perm.value:d}",
             "int 0x80",
+            "popfd",
             "popad",
         ]
         return "; ".join(insns)
@@ -2770,6 +2772,7 @@ class X86_64(X86):
     def mprotect_asm(cls, addr: int, size: int, perm: Permission) -> str:
         _NR_mprotect = 10
         insns = [
+            "pushfq",
             "push rax",
             "push rdi",
             "push rsi",
@@ -2787,6 +2790,7 @@ class X86_64(X86):
             "pop rsi",
             "pop rdi",
             "pop rax",
+            "popfq",
         ]
         return "; ".join(insns)
 


### PR DESCRIPTION
## Description/Motivation/Screenshots

Added pushfd, popfd, pushfq, popfq instructions

keep x86 and x86_64 FLAGS Register when calls to mprotect

**This PR is not strictly necessary because "int 0x80" and "syscall" dont change x86/x86_64 flags and our mprotect-payload only uses mov instructions**. But in my opinion, our execution of mprotect should be stealthy, so it's best to always use push-flags as a good practice.

payload execution will be more safe (a little) when some gef-dev/user modify mprotect-payload with instructions that modify the flags 

## How Has This Been Tested?

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :white_check_mark:                      |                                           |
| x86-64       | :white_check_mark:                      |                                           |
| ARM          | :x:                      |                                           |
| AARCH64      | :x:                      |                                           |
| MIPS         | :x:                      |                                           |
| POWERPC      | :x:                      |                                           |
| SPARC        | :x:                      |                                           |
| RISC-V       | :x:                      |                                           |
| `make test`  | :white_check_mark:                      |                                           |

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `master`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
