### PR TITLE
Allow new file format

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -82,7 +82,7 @@ from functools import lru_cache
 from io import StringIO, TextIOWrapper
 from types import ModuleType
 from typing import (Any, ByteString, Callable, Dict, Generator, Iterable,
-                    Iterator, List, NoReturn, Optional, Sequence, Tuple, Type,
+                    Iterator, List, NoReturn, Optional, Sequence, Set, Tuple, Type,
                     Union)
 from urllib.request import urlopen
 


### PR DESCRIPTION
## Description/Motivation/Screenshots

Create a new root class for file formats (`FileFormat`) that subclasses will automatically use to register as a file format candidate. Each subclass must have a `is_valid(pathlib.Path) -> bool` function to be valid. When checking for a file format, the first valid class will be taken. 

Currently, only `Elf` stays builtin to GEF but see PR https://github.com/hugsy/gef-extras/pull/68 for PE and MachO support.


## How Has This Been Tested ?

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :white_check_mark:                      |  |
| x86-64       | :white_check_mark:                       |                                        |
| ARM          | :x:                      |                                           |
| AARCH64      | :x:                      |                                           |
| MIPS         | :x:                      |                                           |
| POWERPC      | :x:                      |                                           |
| SPARC        | :x:                      |                                           |
| RISC-V       | :x:                      |                                           |
| `make test`  | :white_check_mark:          |                                           |



## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
