### PR TITLE
Minor update to unittest of `print-format` after #843

### DIFF
--- a/tests/commands/print_format.py
+++ b/tests/commands/print_format.py
@@ -14,29 +14,27 @@ class PrintFormatCommand(GefUnitTestGeneric):
         self.assertFailIfInactiveSession(gdb_run_cmd("print-format"))
         res = gdb_start_silent_cmd("print-format $sp")
         self.assertNoException(res)
-        self.assertTrue("buf = [" in res)
+        self.assertIn("buf = [" , res)
         res = gdb_start_silent_cmd("print-format --lang js $sp")
         self.assertNoException(res)
-        self.assertTrue("var buf = [" in res)
+        self.assertIn("var buf = [" , res)
         res = gdb_start_silent_cmd("set *((int*)$sp) = 0x41414141",
                                    after=["print-format --lang hex $sp"])
         self.assertNoException(res)
-        self.assertTrue("41414141" in res, f"{res}")
+        self.assertIn("41414141", res, f"{res}")
         res = gdb_start_silent_cmd("print-format --lang iDontExist $sp")
         self.assertNoException(res)
-        self.assertTrue("Language must be in:" in res)
+        self.assertIn("Language must be in:" , res)
 
 
     def test_cmd_print_format_bytearray(self):
         res = gdb_start_silent_cmd("set *((int*)$sp) = 0x41414141",
                                    after=["print-format --lang bytearray -l 4 $sp"])
         self.assertNoException(res)
-        try:
-            gef_var = res.split('$_gef')[1].split("'")[0]
-        except:
-            self.assertTrue(False)
+        gef_var = res.split('$_gef')[1].split("'")[0]
         self.assertTrue("\x41\x41\x41\x41" in res)
         res = gdb_start_silent_cmd("set *((int*)$sp) = 0x41414141",
                                    after=["print-format --lang bytearray -l 4 $sp", "p $_gef" + gef_var])
         self.assertNoException(res)
-        self.assertTrue("0x41, 0x41, 0x41, 0x41" in res)
+        self.assertIn(
+            f"Saved data b'AAAA'... in '$_gef{gef_var}'", res)


### PR DESCRIPTION
## Description/Motivation/Screenshots

Minor fix to `tests/print_format.py`


## How Has This Been Tested?

| Architecture |          Yes/No          | Comments                                  |
| ------------ | :----------------------: | ----------------------------------------- |
| x86-32       | :white_check_mark:                      |  |
| x86-64       | :white_check_mark:                      |                                           |
| ARM          | :white_check_mark:                      |                                           |
| AARCH64      | ❌                       |                                           |
| MIPS         | :x:                      |                                           |
| POWERPC      | :x:                      |                                           |
| SPARC        | :x:                      |                                           |
| RISC-V       | :x:                      |                                           |
| `make test`  | :white_check_mark:                      |                                           |



## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
