### PR TITLE
--regex support for search-pattern command

### DIFF
--- a/docs/commands/search-pattern.md
+++ b/docs/commands/search-pattern.md
@@ -35,3 +35,12 @@ Sometimes, you may need to search for a very common pattern. To limit the search
 gef➤  search-pattern 0x4005f6 little libc
 gef➤  search-pattern 0x4005f6 little 0x603100-0x603200
 ```
+### Searching in a specific range using regex ###
+Sometimes, you may need an advanced search using regex. Just use --regex arg.
+
+Example: how to find null-end-printable(from x20-x7e) C strings (min size >=2 bytes) with a regex:
+
+```
+gef➤  search-pattern --regex 0x401000 0x401500 ([\\x20-\\x7E]{2,})(?=\\x00)   
+
+```

--- a/tests/commands/search_pattern.py
+++ b/tests/commands/search_pattern.py
@@ -3,7 +3,7 @@ search_pattern command test module
 """
 
 
-from tests.utils import BIN_SH, GefUnitTestGeneric, gdb_run_cmd, gdb_start_silent_cmd
+from tests.utils import BIN_SH, GefUnitTestGeneric, gdb_run_cmd, gdb_start_silent_cmd, gdb_start_silent_cmd_last_line
 
 
 class SearchPatternCommand(GefUnitTestGeneric):
@@ -15,3 +15,16 @@ class SearchPatternCommand(GefUnitTestGeneric):
         res = gdb_start_silent_cmd(f"grep {BIN_SH}")
         self.assertNoException(res)
         self.assertIn("0x", res)
+
+    def test_cmd_search_pattern_regex(self):
+        res = gdb_start_silent_cmd_last_line("set {char[6]} $sp = { 0x41, 0x42, 0x43, 0x44, 0x45, 0x00 }", 
+after=[r"search-pattern --regex $sp $sp+7 ([\\x20-\\x7E]{2,})(?=\\x00)",])
+        self.assertNoException(res)
+        self.assertTrue(r"b'ABCDE'" in res)
+        # this should not match because binary string is not null ended:
+        res = gdb_start_silent_cmd_last_line("set {char[6]} $sp = { 0x41, 0x42, 0x43, 0x44, 0x45, 0x03 }", 
+after=[r"search-pattern --regex $sp $sp+7 ([\\x20-\\x7E]{2,})(?=\\x00)",])
+        self.assertNoException(res)
+        self.assertTrue(r"b'ABCDE'" not in res)
+
+


### PR DESCRIPTION
## Description/Motivation/Screenshots

```
search-pattern --regex 0x401000 0x401500 ([\\x20-\\x7E]{2,})(?=\\x00)   
```

 It matchs null-end-printable(from x20-x7e) C strings (min size >=2 bytes)

![newf](https://user-images.githubusercontent.com/9882181/176970309-dc5b3c14-6236-499d-a73b-08c03406a9f0.PNG)

x86_64 binary POC:

[poc.zip](https://github.com/hugsy/gef/files/9031450/poc.zip)

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

 * [x] x86-32
 * [x] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS        
 * [ ] POWERPC     
 * [ ] SPARC       
 * [ ] RISC-V 


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
