### PR TITLE
max size preview of bytes for print-format command can be changed via config

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -4612,6 +4612,7 @@ class PrintFormatCommand(GenericCommand):
 
     def __init__(self) -> None:
         super().__init__(complete=gdb.COMPLETE_LOCATION)
+        self["max_size_preview"] = (10, "max size preview of bytes")
         return
 
     @property
@@ -4654,7 +4655,7 @@ class PrintFormatCommand(GenericCommand):
 
         if args.lang == "bytearray":
             data = gef.memory.read(start_addr, args.length)
-            preview = str(data[0:10])
+            preview = str(data[0:self["max_size_preview"]])
             out = f"Saved data {preview}... in '{gef_convenience(data)}'"
         elif args.lang == "py":
             out = f"buf = [{sdata}]"


### PR DESCRIPTION
max size preview of bytes for print-format command can be changed via config


## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

 * [x] x86-32
 * [x] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS        
 * [ ] POWERPC     
 * [ ] SPARC       
 * [ ] RISC-V 


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
