### PR TITLE
Fixed TinyUrl links to point to `main`, not `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ echo source ~/.gdbinit-gef.py >> ~/.gdbinit
 
 # or alternatively from inside gdb directly
 $ gdb -q
-(gdb) pi import urllib.request as u, tempfile as t; g=t.NamedTemporaryFile(suffix='-gef.py'); open(g.name, 'wb+').write(u.urlopen('https://tinyurl.com/gef-master').read()); gdb.execute('source %s' % g.name)
+(gdb) pi import urllib.request as u, tempfile as t; g=t.NamedTemporaryFile(suffix='-gef.py'); open(g.name, 'wb+').write(u.urlopen('https://tinyurl.com/gef-main').read()); gdb.execute('source %s' % g.name)
 ```
 
 _Note_: to fetch the latest of GEF (i.e. from the `dev` branch), simply replace in the URL to https://gef.blah.cat/dev.

--- a/docs/install.md
+++ b/docs/install.md
@@ -52,7 +52,7 @@ Alternatively from inside `gdb` directly:
 
 ```bash
 $ gdb -q
-(gdb) pi import urllib.request as u, tempfile as t; g=t.NamedTemporaryFile(suffix='-gef.py'); open(g.name, 'wb+').write(u.urlopen('https://tinyurl.com/gef-master').read()); gdb.execute('source %s' % g.name)
+(gdb) pi import urllib.request as u, tempfile as t; g=t.NamedTemporaryFile(suffix='-gef.py'); open(g.name, 'wb+').write(u.urlopen('https://tinyurl.com/gef-main').read()); gdb.execute('source %s' % g.name)
 ```
 
 That's it! GEF is installed and correctly set up. You can confirm it by checking the `~/.gdbinit` file and see a line that sources (i.e. loads) GEF.


### PR DESCRIPTION
## Description/Motivation/Screenshots

Quick fix for #867 : updated the tinyurl links to perform the in-gdb installation


## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

 * [ ] x86-32
 * [ ] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS        
 * [ ] POWERPC     
 * [ ] SPARC       
 * [ ] RISC-V 


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [ ] My PR was done against the `dev` branch, not `main`.
- [ ] My code follows the code style of this project.
- [ ] My change includes a change to the documentation, if required.
- [ ] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [ ] I have read and agree to the **CONTRIBUTING** document.
