### PR TITLE
main will be the default branch for gef-extras and gef installation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -79,7 +79,7 @@ This will deploy the latest version of `gef`'s _main_ branch from Github. If no 
 To contribute to GEF, you might prefer using git directly.
 
 ```bash
-$ git clone https://github.com/hugsy/gef.git
+$ git clone --branch dev https://github.com/hugsy/gef.git
 $ echo source `pwd`/gef/gef.py >> ~/.gdbinit
 ```
 
@@ -106,7 +106,7 @@ $ bash -c "$(wget https://github.com/hugsy/gef/raw/main/scripts/gef-extras.sh -O
 
 # or manually
 ## clone the repo
-$ git clone https://github.com/hugsy/gef-extras.git
+$ git clone --branch main https://github.com/hugsy/gef-extras.git
 
 ## then specify gef to load this directory
 $ gdb -ex 'gef config gef.extra_plugins_dir "/path/to/gef-extras/scripts"' -ex 'gef save' -ex quit

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -5,6 +5,12 @@
 #
 set -e
 
+branch="main"
+if [ "$1" = "dev" ]; then
+    branch="dev"
+    echo "set branch to dev"
+fi
+
 if [ $# -ge 1 ]; then
   DIR="$(realpath "$1")/gef-extras"
   test -d "${DIR}" || exit 1
@@ -14,7 +20,7 @@ else
   DIR="${HOME}/.gef-extras"
 fi
 
-git clone https://github.com/hugsy/gef-extras.git "${DIR}"
+git clone --branch ${branch} https://github.com/hugsy/gef-extras.git "${DIR}"
 ver=$(gdb -q -nx -ex 'pi print(f"{sys.version_info.major}.{sys.version_info.minor}", end="")' -ex quit)
 python${ver} -m pip install --requirement "${DIR}"/requirements.txt --upgrade
 gdb -q -ex "gef config gef.extra_plugins_dir '${DIR}/scripts'" \


### PR DESCRIPTION
Before this PR, **gef-extras.sh** installation script uses **dev branch** by default.

main will be the default branch for gef-extras and gef installation. Also, it should be reflected in documentation.

Also I updated doc because standard users (non-devs) should use git clone with --branch main.

IMO this PR **must be merged in main** (2022.06 - Upset Constant) as hotfix because installation via **gef-extras.sh** ONLY installs **dev branch** and dont works correctly with **gef main**.

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

 * [x] x86-32
 * [x] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS        
 * [ ] POWERPC     
 * [ ] SPARC       
 * [ ] RISC-V 


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
