### PR TITLE
fix bug in path logic gef-extras.sh

### DIFF
--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -5,19 +5,32 @@
 #
 set -e
 
-branch="main"
-if [ "$1" = "dev" ]; then
-    branch="dev"
-    echo "set branch to dev"
-fi
+usage() { echo "Usage: $0 [-b <main|dev>] [-p <path_to_install>]" 1>&2; exit 1; }
 
-if [ $# -ge 1 ]; then
-  DIR="$(realpath "$1")/gef-extras"
-  test -d "${DIR}" || exit 1
-elif [ -d "${HOME}/.config" ]; then
-  DIR="${HOME}/.config/gef-extras"
+branch="main"
+while getopts ":b:p:" o; do
+    case "${o}" in
+        b)
+            branch=${OPTARG}
+            ;;
+        p)
+            path=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [ -z "$path" ]; then
+  if [ -d "${HOME}/.config" ]; then
+    DIR="${HOME}/.config/gef-extras"
+  else
+    DIR="${HOME}/.gef-extras"
+  fi
 else
-  DIR="${HOME}/.gef-extras"
+  DIR="$(realpath "$path")/gef-extras"
+  test -d "${DIR}" || exit 1
 fi
 
 git clone --branch ${branch} https://github.com/hugsy/gef-extras.git "${DIR}"


### PR DESCRIPTION
This PR improves and fix a bug in path logic (introduced in #870)  (**gef-extras.sh**)

Now it works with named args (@hugsy  suggestion):

./gef-extras.sh -h                          
Usage: /home/dreg/gef-extras.sh [-b <main|dev>] [-p <path_to_install>]


By default it uses **main** and **default path logic** 
                  
Examples of use:

./gef-extras.sh <- (**main branch**, default path)
./gef-extras.sh -b main <- (**main branch**, default path)
./gef-extras.sh -b dev  <-  (**dev branch**, default path)
./gef-extras.sh -b dev -p /home/kali/gextras  <-  (**dev branch**, specific path)
./gef-extras.sh -p /home/kali/gextras  <-  (**main branch**, specific path)
./gef-extras.sh -b main -p /home/kali/gextras  <-  (**main branch**, specific path)

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

 * [x] x86-32
 * [x] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS        
 * [ ] POWERPC     
 * [ ] SPARC       
 * [ ] RISC-V 


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
