### PR TITLE
Riscv/ble

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2360,6 +2360,9 @@ class RISCV(Architecture):
         elif condition == "lt":
             if rs1 < rs2: taken, reason = True, f"{rs1}<{rs2}"
             else: taken, reason = False, f"{rs1}>={rs2}"
+        elif condition == "le":
+            if rs1 <= rs2: taken, reason = True, f"{rs1}<={rs2}"
+            else: taken, reason = False, f"{rs1}<={rs2}"
         elif condition == "ge":
             if rs1 < rs2: taken, reason = True, f"{rs1}>={rs2}"
             else: taken, reason = False, f"{rs1}<{rs2}"

--- a/gef.py
+++ b/gef.py
@@ -2362,7 +2362,7 @@ class RISCV(Architecture):
             else: taken, reason = False, f"{rs1}>={rs2}"
         elif condition == "le":
             if rs1 <= rs2: taken, reason = True, f"{rs1}<={rs2}"
-            else: taken, reason = False, f"{rs1}<={rs2}"
+            else: taken, reason = False, f"{rs1}>{rs2}"
         elif condition == "ge":
             if rs1 < rs2: taken, reason = True, f"{rs1}>={rs2}"
             else: taken, reason = False, f"{rs1}<{rs2}"


### PR DESCRIPTION
## Description/Motivation/Screenshots

You can observe an error if debugging the RISC-V Linux Kernel under
QEMU which states after hitting the pseudoinstruction blez s1, _OFFSET_

[!] Command 'context' failed to execute properly, reason: RISC-V:
Conditional instruction `blez s1, 0xffffffff8017f226 <vfs_reag> not
supported yet



## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

 * [ ] x86-32
 * [ ] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS        
 * [ ] POWERPC     
 * [ ] SPARC       
 * [x] RISC-V 


## Checklist

- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
