### PR TITLE
Patch register retrieval

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8211,9 +8211,13 @@ class DereferenceCommand(GenericCommand):
         register_hints = []
 
         for regname in gef.arch.all_registers:
-            regvalue = gef.arch.register(regname)
-            if current_address == regvalue:
-                register_hints.append(regname)
+            try:
+                regvalue = gef.arch.register(regname)
+                if current_address == regvalue:
+                    register_hints.append(regname)
+            except:
+                # Register is unavailable
+                pass
 
         if register_hints:
             m = f"\t{LEFT_ARROW}{', '.join(list(register_hints))}"


### PR DESCRIPTION
The 'dereference' command errors out on MIPS32 when $fir is unavailable. 


## Description/Motivation/Screenshots

<!-- Describe technically what your patch does. -->
The function pprint_dereferenced errors out when a register for the supplied architecture does not exist, this patch likely needs to be fixed everywhere. Does not appear to be an issue anywhere else. 

<!-- Why is this change required? What problem does it solve? -->
A try catch was used as a patch. Potential permanent fix would be having registers populated via the `info registers` gdb command on initialization of local and remote for the architectures.
<!-- Why is this patch will make a better world? -->
Context won't break if a architecture doesn't use the standard register. 

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

 * [ ] x86-32
 * [ ] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [x] MIPS        
 * [ ] POWERPC     
 * [ ] SPARC       
 * [ ] RISC-V 


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
