### PR TITLE
Explicitly close the remote session

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3506,9 +3506,8 @@ def exit_handler(_: "gdb.ExitedEvent") -> None:
     reset_all_caches()
     gef.session.qemu_mode = False
     if gef.session.remote:
-        # make sure the tempdir is trashed
         gef.session.remote.close()
-        del(gef.session.remote)
+        del gef.session.remote
         gef.session.remote = None
     return
 

--- a/tests/regressions/gdbserver_connection.py
+++ b/tests/regressions/gdbserver_connection.py
@@ -1,0 +1,15 @@
+from tests.utils import (
+    GefUnitTestGeneric,
+    gdb_run_cmd,
+    gdbserver_session,
+)
+
+
+class RegressionGdbserverConnection(GefUnitTestGeneric):
+    def test_can_establish_connection_to_gdbserver_again_after_disconnect(self):
+        """Ensure that gdb can connect to a gdbserver again after disconnecting (PR #896)."""
+
+        with gdbserver_session(port=5001) as _, gdbserver_session(port=5002) as _:
+            buf = gdb_run_cmd("gef-remote 127.0.0.1 5001",
+                              after=["detach", "gef-remote 127.0.0.1 5002", "continue"])
+            self.assertNoException(buf)


### PR DESCRIPTION
## Description/Motivation/Screenshots

<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->

This solves an issue with the `__del__` magic method being called unreliably, in particular it will often get called just when creating a new remote session using `gef-remote` which causes an exception in the `__del__` hook:
```
<method 'disconnect' of 'gdb.EventRegistry' objects> returned a result with an exception set
```

Because of this exception gdb has to be restarted before using the `gef-remote` command again.


## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

 * [ ] x86-32
 * [x] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS        
 * [ ] POWERPC     
 * [ ] SPARC       
 * [ ] RISC-V 


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
