### PR TITLE
Fix filesystem paths for debugging process in containers

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -172,3 +172,11 @@ Discord is your answer: join and talk to us by clicking here
 
 If you cannot find the answer to your problem here or on the Discord, then go to the project [Issues page](https://github.com/hugsy/gef/issues) and fill up the forms with as much information as you can!
 
+## How can I use GEF to debug a process in a container?
+
+GEF can attach to a process running in a container using `gdb --pid=$PID`, where `$PID` is the ID of the running process *on the host*. To find this, you can use `docker top <container ID> -o pid | awk '!/PID/' | xargs -I'{}' pstree -psa {}` to view the process tree for the container.
+
+`sudo` may be required to attach to the process, which will depend on your system's security settings.
+
+Please note that cross-container debugging may have unexpected issues. Installing gdb and GEF inside the container, or using [the official GEF docker image](https://hub.docker.com/r/crazyhugsy/gef) may improve results.
+

--- a/gef.py
+++ b/gef.py
@@ -3499,6 +3499,9 @@ def new_objfile_handler(evt: Optional["gdb.NewObjFileEvent"]) -> None:
         else:
             gef.session.modules.append(binary)
     except FileNotFoundError as fne:
+        # Linux automatically maps the vDSO into our process, and GDB
+        # will give us the string 'system-supplied DSO' as a path.
+        # This is normal, so we shouldn't warn the user about it
         if "system-supplied DSO" not in path:
             warn(f"Failed to find objfile or not a valid file format: {str(fne)}")
     except RuntimeError as re:

--- a/gef.py
+++ b/gef.py
@@ -3485,10 +3485,10 @@ def new_objfile_handler(evt: Optional["gdb.NewObjFileEvent"]) -> None:
     reset_all_caches()
     path = evt.new_objfile.filename if evt else gdb.current_progspace().filename
     try:
-        if gef.session.root:
-            # If the process is in a container, replace the 'target:' placeholder
+        if gef.session.root and path.startswith("target:"):
+            # If the process is in a container, replace the "target:" prefix
             # with the actual root directory of the process.
-            path = path.replace('target:', str(gef.session.root))
+            path = path.replace("target:", str(gef.session.root), 1)
         target = pathlib.Path(path)
         FileFormatClasses = list(filter(lambda fmtcls: fmtcls.is_valid(target), __registered_file_formats__))
         GuessedFileFormatClass : Type[FileFormat] = FileFormatClasses.pop() if len(FileFormatClasses) else Elf

--- a/tests/api/gef_session.py
+++ b/tests/api/gef_session.py
@@ -15,6 +15,7 @@ from tests.utils import (
     gdb_run_cmd,
     qemuuser_session
 )
+import re
 
 GDBSERVER_PREFERED_HOST = "localhost"
 GDBSERVER_PREFERED_PORT = 1234
@@ -73,4 +74,4 @@ class GefSessionApi(GefUnitTestGeneric):
                 f"gef-remote --qemu-user --qemu-binary {target} {GDBSERVER_PREFERED_HOST} {port}"]
             res = gdb_run_cmd(f"pi gef.session.root", target=_target("default"), before=before)
             self.assertNoException(res)
-            assert "/proc/1/root" in res
+            assert re.search(r"\/proc\/[0-9]+/root", res)

--- a/tests/api/gef_session.py
+++ b/tests/api/gef_session.py
@@ -3,14 +3,21 @@
 """
 
 
+from logging import root
 import subprocess
+import os
 from tests.utils import (
     TMPDIR,
     gdb_test_python_method,
     _target,
     GefUnitTestGeneric,
+    gdbserver_session,
+    gdb_run_cmd,
+    qemuuser_session
 )
 
+GDBSERVER_PREFERED_HOST = "localhost"
+GDBSERVER_PREFERED_PORT = 1234
 
 class GefSessionApi(GefUnitTestGeneric):
     """`gef.session` test module."""
@@ -40,3 +47,30 @@ class GefSessionApi(GefUnitTestGeneric):
         self.assertTrue("'AT_PLATFORM'" in res)
         self.assertTrue("'AT_EXECFN':" in res)
         self.assertFalse("'AT_WHATEVER':" in res)
+
+    def test_root_dir(self):
+        func = "(s.st_dev, s.st_ino)"
+        res = gdb_test_python_method(func, target=_target("default"), before="s=os.stat(gef.session.root)")
+        self.assertNoException(res)
+        st_dev, st_ino = eval(res.split("\n")[-1])
+        stat_root = os.stat("/")
+        # Check that the `/` directory and the `session.root` directory are the same
+        assert (stat_root.st_dev == st_dev) and (stat_root.st_ino == st_ino)
+
+        port = GDBSERVER_PREFERED_PORT + 1
+        before = [f"gef-remote {GDBSERVER_PREFERED_HOST} {port}",
+                   "pi s = os.stat(gef.session.root)"]
+        with gdbserver_session(port=port) as _:
+            res = gdb_run_cmd(f"pi {func}", target=_target("default"), before=before)
+            self.assertNoException(res)
+            st_dev, st_ino = eval(res.split("\n")[-1])
+            assert (stat_root.st_dev == st_dev) and (stat_root.st_ino == st_ino)
+
+        port = GDBSERVER_PREFERED_PORT + 2
+        with qemuuser_session(port=port) as _:
+            target = _target("default")
+            before = [
+                f"gef-remote --qemu-user --qemu-binary {target} {GDBSERVER_PREFERED_HOST} {port}"]
+            res = gdb_run_cmd(f"pi gef.session.root", target=_target("default"), before=before)
+            self.assertNoException(res)
+            assert "/proc/1/root" in res


### PR DESCRIPTION
## Description/Motivation/Screenshots

When attaching to a process in a container, GDB prefixes file paths with `target:`, which means files can't be resolved. This also causes usage issues with output like
```
─────────────────────────────────────────────────────────────────────────────────── registers ────
[!] Command 'registers' failed to execute properly, reason: max() arg is an empty sequence
─────────────────────────────────────────────────────────────────────────────────────── stack ────
0x007ffd60a2b9b8│+0x0000: 0x007fdbeab206fa  →   pop rsi
0x007ffd60a2b9c0│+0x0008: 0x007fdbeab64b84  →  0x0000000000000000
0x007ffd60a2b9c8│+0x0010: 0x0000000000000000
0x007ffd60a2b9d0│+0x0018: 0x007ffd60a2ba28  →  0x00000000000003d6
0x007ffd60a2b9d8│+0x0020: 0x007fdbeab64b7c  →  0x0000000200000000
0x007ffd60a2b9e0│+0x0028: 0x00000000000000ee
0x007ffd60a2b9e8│+0x0030: 0x007fdbeab24782  →  <clock_nanosleep+77> pop rdx
0x007ffd60a2b9f0│+0x0038: 0x0000000000000000
─────────────────────────────────────────────────────────────────────────────── code:generic: ────
   0x7fdbeab23497                  mov    r9, QWORD PTR [rsp+0x10]
   0x7fdbeab2349c                  mov    QWORD PTR [rsp+0x8], r11
   0x7fdbeab234a1                  syscall 
[!] Command 'context' failed to execute properly, reason: 
gef>
```
This PR properly resolves file paths using `/proc/$PID/root` to access the process's filesystem root directory, making cross-container debugging much more usable.

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

 * [ ] x86-32
 * [X] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS        
 * [ ] POWERPC     
 * [ ] SPARC       
 * [ ] RISC-V 

**Note**: I'm not sure if this can be reasonably tested automatically, as it would require being able to spawn extra containers in CI *or* use of `chroot` which may not be available in the CI. If testing is required please let me know how I can go about implementing a test.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [X] My PR was done against the `dev` branch, not `main`.
- [X] My code follows the code style of this project.
- [X] My change includes a change to the documentation, if required.
- [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [X] I have read and agree to the **CONTRIBUTING** document.
