### PR TITLE
Fix searching when connected to `qemu-system` instance

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3352,15 +3352,15 @@ def get_os() -> str:
 def is_qemu() -> bool:
     if not is_remote_debug():
         return False
-    response = gdb.execute('maintenance packet Qqemu.sstepbits', to_string=True, from_tty=False)
-    return 'ENABLE=' in response
+    response = gdb.execute("maintenance packet Qqemu.sstepbits", to_string=True, from_tty=False)
+    return "ENABLE=" in response
 
 
 @lru_cache()
 def is_qemu_usermode() -> bool:
     if not is_qemu():
         return False
-    response = gdb.execute('maintenance packet qOffsets', to_string=True, from_tty=False)
+    response = gdb.execute("maintenance packet qOffsets", to_string=True, from_tty=False)
     return "Text=" in response
 
 
@@ -3368,8 +3368,8 @@ def is_qemu_usermode() -> bool:
 def is_qemu_system() -> bool:
     if not is_qemu():
         return False
-    response = gdb.execute('maintenance packet qOffsets', to_string=True, from_tty=False)
-    return 'received: ""' in response
+    response = gdb.execute("maintenance packet qOffsets", to_string=True, from_tty=False)
+    return "received: \"\"" in response
 
 
 def get_filepath() -> Optional[str]:

--- a/gef.py
+++ b/gef.py
@@ -627,26 +627,26 @@ class Permission(enum.Flag):
         perm_str += "x" if self & Permission.EXECUTE else "-"
         return perm_str
 
-    @staticmethod
-    def from_info_sections(*args: str) -> "Permission":
-        perm = Permission(0)
+    @classmethod
+    def from_info_sections(cls, *args: str) -> "Permission":
+        perm = cls(0)
         for arg in args:
             if "READONLY" in arg: perm |= Permission.READ
             if "DATA" in arg: perm |= Permission.WRITE
             if "CODE" in arg: perm |= Permission.EXECUTE
         return perm
 
-    @staticmethod
-    def from_process_maps(perm_str: str) -> "Permission":
-        perm = Permission(0)
+    @classmethod
+    def from_process_maps(cls, perm_str: str) -> "Permission":
+        perm = cls(0)
         if perm_str[0] == "r": perm |= Permission.READ
         if perm_str[1] == "w": perm |= Permission.WRITE
         if perm_str[2] == "x": perm |= Permission.EXECUTE
         return perm
 
-    @staticmethod
-    def from_info_mem(perm_str: str) -> "Permission":
-        perm = Permission(0)
+    @classmethod
+    def from_info_mem(cls, perm_str: str) -> "Permission":
+        perm = cls(0)
         # perm_str[0] shows if this is a user page, which
         # we don't track
         if perm_str[1] == "r": perm |= Permission.READ
@@ -10281,11 +10281,10 @@ class GefMemoryManager(GefManager):
                 # FORMAT
                 # ffffff2a65e0b000-ffffff2a65e0c000 0000000000001000 -r-
                 # ^--- start       ^--- end         ^--- offset      ^^^-- perms
-                # `perms` are `urw`, for 'usermode', 'readable', 'writable'
-                ranges, off, perms = line.split(' ')
+                # `perms` are `urw`, for "usermode", "readable", "writable"
+                ranges, off, perms = line.split(" ")
                 off = int(off, 16)
-                start, end = ranges.split('-')
-                start, end = int(start, 16), int(end, 16)
+                start, end = [int(s, 16) for s in ranges.split("-")]
             except ValueError as e:
                 continue
 

--- a/gef.py
+++ b/gef.py
@@ -10274,16 +10274,11 @@ class GefMemoryManager(GefManager):
 
     def __parse_info_mem(self) -> Generator[Section, None, None]:
         """Get the memory mapping from GDB's command `monitor info mem`"""
-        stream = StringIO(gdb.execute("monitor info mem", to_string=True))
-        for line in stream:
+        for line in StringIO(gdb.execute("monitor info mem", to_string=True)):
             if not line:
                 break
             try:
-                # FORMAT
-                # ffffff2a65e0b000-ffffff2a65e0c000 0000000000001000 -r-
-                # ^--- start       ^--- end         ^--- offset      ^^^-- perms
-                # `perms` are `urw`, for "usermode", "readable", "writable"
-                ranges, off, perms = line.split(" ")
+                ranges, off, perms = line.split()
                 off = int(off, 16)
                 start, end = [int(s, 16) for s in ranges.split("-")]
             except ValueError as e:

--- a/gef.py
+++ b/gef.py
@@ -10283,6 +10283,7 @@ class GefMemoryManager(GefManager):
                 # ^--- start       ^--- end         ^--- offset      ^^^-- perms
                 # `perms` are `urw`, for 'usermode', 'readable', 'writable'
                 ranges, off, perms = line.split(' ')
+                off = int(off, 16)
                 start, end = ranges.split('-')
                 start, end = int(start, 16), int(end, 16)
             except ValueError as e:

--- a/tests/api/misc.py
+++ b/tests/api/misc.py
@@ -41,6 +41,18 @@ class MiscFunctionTest(GefUnitTestGeneric):
         res = gdb_test_python_method(func)
         self.assertException(res)
 
+    def test_func_parse_maps(self):
+        func = "Permission.from_info_sections(' [10]     0x555555574000->0x55555557401b at 0x00020000: .init ALLOC LOAD READONLY CODE HAS_CONTENTS')"
+        res = gdb_test_python_method(func)
+        self.assertNoException(res)
+
+        func = "Permission.from_process_maps('0x0000555555554000 0x0000555555574000 0x0000000000000000 r-- /usr/bin/bash')"
+        res = gdb_test_python_method(func)
+        self.assertNoException(res)
+
+        func = "Permission.from_info_mem('ffffff2a65e0b000-ffffff2a65e0c000 0000000000001000 -r-')"
+        res = gdb_test_python_method(func)
+        self.assertNoException(res)
 
     @pytest.mark.slow
     @pytest.mark.online


### PR DESCRIPTION
## Description/Motivation/Screenshots

Fixes #905 
Detects when we're connected to a QEMU kernel instance, and uses `monitor info mem` to retrieve the real kernel memory mappings for searching within.

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (see `docs/testing.md`) run passes without issue.

 * [ ] x86-32
 * [X] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS
 * [ ] POWERPC
 * [ ] SPARC
 * [ ] RISC-V


## Checklist

- [X] My PR was done against the `dev` branch, not `main`.
- [X] My code follows the code style of this project.
- [X] My change includes a change to the documentation, if required.
- [ ] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [X] I have read and agree to the **CONTRIBUTING** document.

I will add tests shortly, just leaving this initial draft.
