### PR TITLE
reset_architecture: Return after setting arch to a specified arch

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3618,6 +3618,7 @@ def reset_architecture(arch: Optional[str] = None) -> None:
             gef.arch = arches[arch]()
         except KeyError:
             raise OSError(f"Specified arch {arch.upper()} is not supported")
+        return
 
     gdb_arch = get_arch()
 


### PR DESCRIPTION
If you `reset_architecture("something")` it'll set the arch, but then continue to try to figure out the architecture.