### PR TITLE
Add option to disable output buffering

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -234,7 +234,7 @@ def highlight_text(text: str) -> str:
 def gef_print(*args: str, end="\n", sep=" ", **kwargs: Any) -> None:
     """Wrapper around print(), using string buffering feature."""
     parts = [highlight_text(a) for a in args]
-    if gef.ui.stream_buffer and not is_debug():
+    if buffer_output() and gef.ui.stream_buffer and not is_debug():
         gef.ui.stream_buffer.write(sep.join(parts) + end)
         return
 
@@ -1880,6 +1880,11 @@ def hexdump(source: ByteString, length: int = 0x10, separator: str = ".", show_r
 def is_debug() -> bool:
     """Check if debug mode is enabled."""
     return gef.config["gef.debug"] is True
+
+
+def buffer_output() -> bool:
+    """Check if output should be buffered until command completion."""
+    return gef.config["gef.buffer"] is True
 
 
 def hide_context() -> bool:
@@ -9336,6 +9341,7 @@ class GefCommand(gdb.Command):
         gef.config["gef.disable_color"] = GefSetting(False, bool, "Disable all colors in GEF")
         gef.config["gef.tempdir"] = GefSetting(GEF_TEMP_DIR, str, "Directory to use for temporary/cache content")
         gef.config["gef.show_deprecation_warnings"] = GefSetting(True, bool, "Toggle the display of the `deprecated` warnings")
+        gef.config["gef.buffer"] = GefSetting(True, bool, "Internally buffer command output until completion")
 
         self.commands : Dict[str, GenericCommand] = collections.OrderedDict()
         self.functions : Dict[str, GenericFunction] = collections.OrderedDict()


### PR DESCRIPTION
## Description/Motivation/Screenshots

Closes #910 
Allows disabling Gef's internal buffer, which can improve usage of long-running commands (such as #906). 

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (see `docs/testing.md`) run passes without issue.

 * [ ] x86-32
 * [X] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS
 * [ ] POWERPC
 * [ ] SPARC
 * [ ] RISC-V


## Checklist

- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [X] I have read and agree to the **CONTRIBUTING** document.
