### PR TITLE
Determine the actual canary location

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -10526,17 +10526,21 @@ class GefSessionManager(GefManager):
         except NotImplementedError:
             # Fall back to `AT_RANDOM`, which is the original source
             # of the canary value but not the canonical location
-            auxval = self.auxiliary_vector
-            if not auxval:
-                return None
-            canary_location = auxval["AT_RANDOM"]
-            canary = gef.memory.read_integer(canary_location)
-            warn("Canary was read from auxiliary vector")
-            # The canary is created by reading a word from `AT_RANDOM`
-            # and zeroing the lowest byte
-            canary &= ~0xFF
-
+            return self.original_canary
         return canary, canary_location
+
+    @property
+    def original_canary(self) -> Optional[Tuple[int, int]]:
+        """Return a tuple of the initial canary address and value, read from the
+        auxiliary vector."""
+        auxval = self.auxiliary_vector
+        if not auxval:
+            return None
+        canary_location = auxval["AT_RANDOM"]
+        canary = gef.memory.read_integer(canary_location)
+        canary &= ~0xFF
+        return canary, canary_location
+
 
     @property
     def maps(self) -> Optional[pathlib.Path]:

--- a/tests/commands/canary.py
+++ b/tests/commands/canary.py
@@ -5,7 +5,7 @@
 
 from tests.utils import gdb_start_silent_cmd, gdb_run_cmd, _target
 from tests.utils import GefUnitTestGeneric
-
+import platform
 
 class CanaryCommand(GefUnitTestGeneric):
     """`canary` command test module"""
@@ -16,3 +16,11 @@ class CanaryCommand(GefUnitTestGeneric):
         res = gdb_start_silent_cmd("canary", target=_target("canary"))
         self.assertNoException(res)
         self.assertIn("The canary of process", res)
+        # On other platforms, we read the canary from the auxiliary vector -
+        # overwriting this value does not overwrite the in-use canary so it
+        # is not tested
+        if platform.machine() == "x86_64":
+            patch = r"pi gef.memory.write(gef.arch.canary_address(), b'\xef\xbe\xad\xde')"
+            res = gdb_start_silent_cmd(patch, target=_target("canary"), after=["canary"])
+            self.assertNoException(res)
+            self.assertIn("0xdeadbeef", res)

--- a/tests/commands/canary.py
+++ b/tests/commands/canary.py
@@ -20,7 +20,7 @@ class CanaryCommand(GefUnitTestGeneric):
         # overwriting this value does not overwrite the in-use canary so it
         # is not tested
         if platform.machine() == "x86_64":
-            patch = r"pi gef.memory.write(gef.arch.canary_address(), b'\xef\xbe\xad\xde')"
+            patch = r"pi gef.memory.write(gef.arch.canary_address(), b'\xef\xbe\xad\xde\x00\x00\x00\x00')"
             res = gdb_start_silent_cmd(patch, target=_target("canary"), after=["canary"])
             self.assertNoException(res)
             self.assertIn("0xdeadbeef", res)

--- a/tests/commands/canary.py
+++ b/tests/commands/canary.py
@@ -3,9 +3,12 @@
 """
 
 
-from tests.utils import gdb_start_silent_cmd, gdb_run_cmd, _target
+from tests.utils import gdb_start_silent_cmd, gdb_run_cmd, _target, gdb_test_python_method
 from tests.utils import GefUnitTestGeneric
+import pytest
 import platform
+
+ARCH = platform.machine()
 
 class CanaryCommand(GefUnitTestGeneric):
     """`canary` command test module"""
@@ -16,11 +19,13 @@ class CanaryCommand(GefUnitTestGeneric):
         res = gdb_start_silent_cmd("canary", target=_target("canary"))
         self.assertNoException(res)
         self.assertIn("The canary of process", res)
-        # On other platforms, we read the canary from the auxiliary vector -
-        # overwriting this value does not overwrite the in-use canary so it
-        # is not tested
-        if platform.machine() == "x86_64":
-            patch = r"pi gef.memory.write(gef.arch.canary_address(), b'\xef\xbe\xad\xde\x00\x00\x00\x00')"
-            res = gdb_start_silent_cmd(patch, target=_target("canary"), after=["canary"])
-            self.assertNoException(res)
-            self.assertIn("0xdeadbeef", res)
+        res = gdb_test_python_method("gef.session.canary[0] == gef.session.original_canary[0]")
+        self.assertNoException(res)
+        self.assertIn("True", res)
+
+    @pytest.mark.skipif(ARCH != "x86_64", reason=f"Not implemented for {ARCH}")
+    def test_overwrite_canary(self):
+        patch = r"pi gef.memory.write(gef.arch.canary_address(), p64(0xdeadbeef))"
+        res = gdb_start_silent_cmd(patch, target=_target("canary"), after=["canary"])
+        self.assertNoException(res)
+        self.assertIn("0xdeadbeef", res)


### PR DESCRIPTION
## Description/Motivation/Screenshots

This PR adds arch-specific methods to find the *actual* canary location, as stored in `$fs_base+0x28` on x86_64.
This allows printing the in-use canary location, which can help with exploits that involve overwriting the canonical canary.

I wasn't able to find a way to read the `gs` segment on 32-bit, so currently this PR only adds functionality to x86_64.

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (see `docs/testing.md`) run passes without issue.

 * [ ] x86-32
 * [X] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS
 * [ ] POWERPC
 * [ ] SPARC
 * [ ] RISC-V


## Checklist

- [X] My PR was done against the `dev` branch, not `main`.
- [X] My code follows the code style of this project.
- [X] My change includes a change to the documentation, if required.
- [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [X] I have read and agree to the **CONTRIBUTING** document.
