### PR TITLE
[CI] Make coverage generate pull request comment instead of blocking validation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: CI Coverage
+
+on: [pull_request]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run test coverage
+      id: get-coverage
+      env:
+        ALLOWED_MARGIN: 0.01
+        MIN_COVERAGE: 70
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gdb-multiarch python3-dev python3-pip python3-wheel python3-setuptools git cmake gcc g++ pkg-config libglib2.0-dev gdbserver qemu-user
+        sudo python3 -m pip install --upgrade pip
+        echo PY_VER=`gdb -q -nx -ex "pi print('.'.join(map(str, sys.version_info[:2])))" -ex quit` >> $GITHUB_ENV
+        echo GEF_CI_NB_CPU=`grep -c ^processor /proc/cpuinfo` >> $GITHUB_ENV
+        echo GEF_CI_ARCH=`uname --processor` >> $GITHUB_ENV
+        python${{ env.PY_VER }} -m pip install --user --upgrade -r tests/requirements.txt
+        current_score=$(curl --silent https://hugsy.github.io/gef/coverage/gef_py.html | grep pc_cov | sed 's?.*<span class="pc_cov">\([^%]*\)%</span>?\1?g')
+        bash scripts/generate-coverage-docs.sh
+        new_score=$(cat docs/coverage/gef_py.html | grep pc_cov | sed 's?.*<span class="pc_cov">\([^%]*\)%</span>?\1?g')
+        cat >> /tmp/msg << EOF
+        New coverage score: ${new_score}%
+        Current score: ${current_score}%
+        EOF
+        echo "msg=\"$(cat /tmp/msg)\"" >> $GITHUB_OUTPUT
+
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.pulls.createComment({
+            pull_number: context.pull.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: steps.get-coverage.outputs.msg
+          })

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,10 +24,13 @@ jobs:
         current_score=$(curl --silent https://hugsy.github.io/gef/coverage/gef_py.html | grep pc_cov | sed 's?.*<span class="pc_cov">\([^%]*\)%</span>?\1?g')
         bash scripts/generate-coverage-docs.sh
         new_score=$(cat docs/coverage/gef_py.html | grep pc_cov | sed 's?.*<span class="pc_cov">\([^%]*\)%</span>?\1?g')
-        cat >> /tmp/msg << EOF
+        commit=$(git rev-parse HEAD)
+        cat > /tmp/msg << EOF
+        Commit:${commit}
         New coverage score: ${new_score}%
         Current score: ${current_score}%
         EOF
+        cat /tmp/msg
         echo "msg=\"$(cat /tmp/msg)\"" >> $GITHUB_OUTPUT
 
     - uses: actions/github-script@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Run test coverage
-      id: get-coverage
+      id: get_coverage
       env:
         ALLOWED_MARGIN: 0.01
         MIN_COVERAGE: 70
@@ -24,21 +24,27 @@ jobs:
         current_score=$(curl --silent https://hugsy.github.io/gef/coverage/gef_py.html | grep pc_cov | sed 's?.*<span class="pc_cov">\([^%]*\)%</span>?\1?g')
         bash scripts/generate-coverage-docs.sh
         new_score=$(cat docs/coverage/gef_py.html | grep pc_cov | sed 's?.*<span class="pc_cov">\([^%]*\)%</span>?\1?g')
+        diff_score=$(python -c "print(${new_score} - ${current_score})")
         commit=$(git rev-parse HEAD)
-        cat > /tmp/msg << EOF
-        Commit:${commit}
-        New coverage score: ${new_score}%
-        Current score: ${current_score}%
-        EOF
-        cat /tmp/msg
-        echo "msg=\"$(cat /tmp/msg)\"" >> $GITHUB_OUTPUT
+        echo "commit=${commit}" >> $GITHUB_OUTPUT
+        echo "new_coverage_score=${new_score}" >> $GITHUB_OUTPUT
+        echo "current_coverage_score=${current_score}" >> $GITHUB_OUTPUT
+        echo "diff_score=${diff_score}" >> $GITHUB_OUTPUT
 
     - uses: actions/github-script@v6
+      env:
+        COMMIT: ${{ steps.get_coverage.outputs.commit }}
+        SCORE_OLD: ${{ steps.get_coverage.outputs.current_coverage_score }}
+        SCORE_NEW: ${{ steps.get_coverage.outputs.new_coverage_score }}
+        SCORE_DIFF: ${{ steps.get_coverage.outputs.diff_score }}
       with:
         script: |
-          github.rest.pulls.createComment({
-            pull_number: context.pull.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: steps.get-coverage.outputs.msg
-          })
+          const comment = `## 🤖 Coverage Update
+
+            * Commit: ${process.env.COMMIT}
+            * Current Coverage: ${process.env.SCORE_OLD}%
+            * New Coverage: ${process.env.SCORE_NEW}%
+            * Diff: ${process.env.SCORE_DIFF} 
+          `;
+          const { owner, repo, number } = context.issue;
+          await github.rest.issues.createComment({ owner, repo, issue_number: number, body: comment });

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,15 +74,3 @@ jobs:
       run: |
         python${{ env.PY_VER }} -m pylint --rcfile=$(pwd)/.pylintrc gef.py tests/*/*.py
 
-    - name: Run test coverage
-      if: matrix.os == 'ubuntu-22.04'
-      env:
-        ALLOWED_MARGIN: 0.01
-        MIN_COVERAGE: 70
-      run: |
-        current_score=$(curl --silent https://hugsy.github.io/gef/coverage/gef_py.html | grep pc_cov | sed 's?.*<span class="pc_cov">\([^%]*\)%</span>?\1?g')
-        bash scripts/generate-coverage-docs.sh
-        new_score=$(cat docs/coverage/gef_py.html | grep pc_cov | sed 's?.*<span class="pc_cov">\([^%]*\)%</span>?\1?g')
-        echo "New coverage score: ${new_score}% (current ${current_score}%)"
-        python${{ env.PY_VER }} -c "( ${new_score} < ${{ env.MIN_COVERAGE}} ) and exit(1)"
-        python${{ env.PY_VER }} -c "(( abs( ${current_score}-${new_score}) / ${current_score} ) >= ${{ env.ALLOWED_MARGIN}}) and exit(2)"


### PR DESCRIPTION
## Description/Motivation/Screenshots

Move coverage to separate job on CI, to only send coverage results as comment to the PR (instead of failing it if lower).

This will give us a per-commit improvement for the PR. Based on that info, we can then decide to approve or reject if the drop is too high. This is less aggressive that failing the CI tests.

## Against which architecture was this tested ?

N/A (CI only)


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
