### PR TITLE
Add backwards memory examination for the dereference command

### DIFF
--- a/docs/commands/dereference.md
+++ b/docs/commands/dereference.md
@@ -70,3 +70,16 @@ gef➤  dereference $sp -l 7 -r $rbp
 0x00007ffe6ddaa408│-0x0008: 0xa42456b3ee465800
 0x00007ffe6ddaa410│+0x0000: 0x0000000000000000    ← $rbp
 ```
+
+Just like with `x`, you can pass a negative number of addresses to dereference, to examine memory backwards
+from the start address:
+```
+gef➤  dereference $sp -l 3
+0x00007fffffffcf90│+0x0010: 0x00007ffff7f5aaa0  →  0x0000000000000000
+0x00007fffffffcf88│+0x0008: 0x00000000000204a0
+0x00007fffffffcf80│+0x0000: 0x00005555555a6b60  →  0x0000000000000000    ← $rsp
+gef➤  dereference $sp -l -3
+0x00007fffffffcf80│+0x0000: 0x00005555555a6b60  →  0x0000000000000000    ← $rsp
+0x00007fffffffcf78│-0x0008: 0x0000000000000020 (" "?)
+0x00007fffffffcf70│-0x0010: 0x000000000000000a ("\n"?)
+```

--- a/gef.py
+++ b/gef.py
@@ -8324,7 +8324,7 @@ class DereferenceCommand(GenericCommand):
                 to_insnum = nb * (self.repeat_count + 1)
             else:
                 from_insnum = nb * (self.repeat_count + 1) + 1
-                to_insnum = (0 + self.repeat_count * nb) + 1
+                to_insnum = (self.repeat_count * nb) + 1
 
         start_address = align_address(target_addr)
         base_offset = start_address - align_address(ref_addr)

--- a/gef.py
+++ b/gef.py
@@ -8310,23 +8310,21 @@ class DereferenceCommand(GenericCommand):
             return
 
         if gef.config["context.grow_stack_down"] is True:
+            insnum_step = -1
             if nb > 0:
                 from_insnum = nb * (self.repeat_count + 1) - 1
                 to_insnum = self.repeat_count * nb - 1
-                insnum_step = -1
             else:
-                from_insnum = 0 + self.repeat_count * nb
+                from_insnum = self.repeat_count * nb
                 to_insnum = nb * (self.repeat_count + 1)
-                insnum_step = -1
         else:
+            insnum_step = 1
             if nb > 0:
-                from_insnum = 0 + self.repeat_count * nb
+                from_insnum = self.repeat_count * nb
                 to_insnum = nb * (self.repeat_count + 1)
-                insnum_step = 1
             else:
                 from_insnum = nb * (self.repeat_count + 1) + 1
                 to_insnum = (0 + self.repeat_count * nb) + 1
-                insnum_step = 1
 
         start_address = align_address(target_addr)
         base_offset = start_address - align_address(ref_addr)

--- a/tests/commands/dereference.py
+++ b/tests/commands/dereference.py
@@ -34,7 +34,6 @@ class DereferenceCommand(GefUnitTestGeneric):
         ]
         res = gdb_start_silent_cmd(cmd=setup, after=cmd)
         self.assertNoException(res)
-        print(res)
 
         """
         Assuming the default config of grow_stack_down = False, $sp should look like this:
@@ -58,7 +57,6 @@ class DereferenceCommand(GefUnitTestGeneric):
         ]
         res = gdb_start_silent_cmd(cmd=setup, after=cmd)
         self.assertNoException(res)
-        print(res)
 
         """
         Assuming the default config of grow_stack_down = False, $sp should look like this:

--- a/tests/commands/dereference.py
+++ b/tests/commands/dereference.py
@@ -39,11 +39,11 @@ class DereferenceCommand(GefUnitTestGeneric):
         Assuming the default config of grow_stack_down = False, $sp should look like this:
         0x00007fffffffd270│+0x0000: 0x0000000000000000   ← $rsp
         0x00007fffffffd278│+0x0008: "AAAAAAAA"
-        Hence, we want to look at the second last line of the output
+        Hence, we want to look at the last line of the output
         """
         res = res.splitlines()[-1]
-        self.assertTrue("AAAAAAAA" in res)
-        self.assertTrue("BBBBBBBB" not in res)
+        self.assertIn("AAAAAAAA", res)
+        self.assertNotIn("BBBBBBBB", res)
 
 
     def test_cmd_dereference_backwards(self):
@@ -62,8 +62,8 @@ class DereferenceCommand(GefUnitTestGeneric):
         Assuming the default config of grow_stack_down = False, $sp should look like this:
         0x00007fffffffd268│-0x0008: "BBBBBBBB"
         0x00007fffffffd270│+0x0000: 0x0000000000000000   ← $rsp
-        Hence, we want to look at the last line of the output
+        Hence, we want to look at the second last line of the output
         """
         res = res.splitlines()[-2]
-        self.assertTrue("AAAAAAAA" not in res)
-        self.assertTrue("BBBBBBBB" in res)
+        self.assertNotIn("AAAAAAAA", res)
+        self.assertIn("BBBBBBBB", res)

--- a/tests/commands/dereference.py
+++ b/tests/commands/dereference.py
@@ -21,3 +21,47 @@ class DereferenceCommand(GefUnitTestGeneric):
         res = gdb_start_silent_cmd("dereference 0x0")
         self.assertNoException(res)
         self.assertIn("Unmapped address", res)
+
+
+    def test_cmd_dereference_forwards(self):
+        self.assertFailIfInactiveSession(gdb_run_cmd("dereference"))
+
+        cmd = "dereference $sp -l 2"
+        setup = [
+            "set {char[9]} ($sp+0x8) = { 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x00 }",
+            "set {char[9]} ($sp-0x8) = { 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x00 }"
+        ]
+        res = gdb_start_silent_cmd(cmd=setup, after=cmd)
+        self.assertNoException(res)
+
+        """
+        Assuming the default config of grow_stack_down = True, $sp should look like this:
+        0x00007fffffffd278│+0x0008: "AAAAAAAA"
+        0x00007fffffffd270│+0x0000: 0x0000000000000000   ← $rsp
+        Hence, we want to look at the second last line of the output
+        """
+        res = res.splitlines()[-2]
+        self.assertTrue("AAAAAAAA" in res)
+        self.assertTrue("BBBBBBBB" not in res)
+
+
+    def test_cmd_dereference_backwards(self):
+        self.assertFailIfInactiveSession(gdb_run_cmd("dereference"))
+
+        cmd = "dereference $sp -l -2"
+        setup = [
+            "set {char[9]} ($sp+0x8) = { 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x00 }",
+            "set {char[9]} ($sp-0x8) = { 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x00 }"
+        ]
+        res = gdb_start_silent_cmd(cmd=setup, after=cmd)
+        self.assertNoException(res)
+
+        """
+        Assuming the default config of grow_stack_down = True, $sp should look like this:
+        0x00007fffffffd270│+0x0000: 0x0000000000000000   ← $rsp
+        0x00007fffffffd268│-0x0008: "BBBBBBBB"
+        Hence, we want to look at the last line of the output
+        """
+        res = res.splitlines()[-1]
+        self.assertTrue("AAAAAAAA" not in res)
+        self.assertTrue("BBBBBBBB" in res)

--- a/tests/commands/dereference.py
+++ b/tests/commands/dereference.py
@@ -28,19 +28,21 @@ class DereferenceCommand(GefUnitTestGeneric):
 
         cmd = "dereference $sp -l 2"
         setup = [
+            "gef config context.grow_stack_down False",
             "set {char[9]} ($sp+0x8) = { 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x00 }",
             "set {char[9]} ($sp-0x8) = { 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x00 }"
         ]
         res = gdb_start_silent_cmd(cmd=setup, after=cmd)
         self.assertNoException(res)
+        print(res)
 
         """
-        Assuming the default config of grow_stack_down = True, $sp should look like this:
-        0x00007fffffffd278│+0x0008: "AAAAAAAA"
+        Assuming the default config of grow_stack_down = False, $sp should look like this:
         0x00007fffffffd270│+0x0000: 0x0000000000000000   ← $rsp
+        0x00007fffffffd278│+0x0008: "AAAAAAAA"
         Hence, we want to look at the second last line of the output
         """
-        res = res.splitlines()[-2]
+        res = res.splitlines()[-1]
         self.assertTrue("AAAAAAAA" in res)
         self.assertTrue("BBBBBBBB" not in res)
 
@@ -50,18 +52,20 @@ class DereferenceCommand(GefUnitTestGeneric):
 
         cmd = "dereference $sp -l -2"
         setup = [
+            "gef config context.grow_stack_down False",
             "set {char[9]} ($sp+0x8) = { 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x00 }",
             "set {char[9]} ($sp-0x8) = { 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x00 }"
         ]
         res = gdb_start_silent_cmd(cmd=setup, after=cmd)
         self.assertNoException(res)
+        print(res)
 
         """
-        Assuming the default config of grow_stack_down = True, $sp should look like this:
-        0x00007fffffffd270│+0x0000: 0x0000000000000000   ← $rsp
+        Assuming the default config of grow_stack_down = False, $sp should look like this:
         0x00007fffffffd268│-0x0008: "BBBBBBBB"
+        0x00007fffffffd270│+0x0000: 0x0000000000000000   ← $rsp
         Hence, we want to look at the last line of the output
         """
-        res = res.splitlines()[-1]
+        res = res.splitlines()[-2]
         self.assertTrue("AAAAAAAA" not in res)
         self.assertTrue("BBBBBBBB" in res)


### PR DESCRIPTION
## Description/Motivation/Screenshots

<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- Why is this patch will make a better world? -->
<!-- How does this look? Add a screenshot if you can -->
This commit extends the `dereference` command, allowing to examine memory backwards via a negative `--length` value, analogous to the behaviour of `x`.

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (see `docs/testing.md`) run passes without issue.

 * [ ] x86-32
 * [x] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS
 * [ ] POWERPC
 * [ ] SPARC
 * [ ] RISC-V


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
