### PR TITLE
Remove outdated sentence in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,7 @@ be used mostly by exploit developers and reverse-engineers, to provide
 additional features to GDB using the Python API to assist during the process of
 dynamic analysis and exploit development.
 
-It has full support for both Python2 and Python3 indifferently (as more and more
-distros start pushing `gdb` compiled with Python3 support).
+It requires Python 3, but [`gef-legacy`](https://github.com/hugsy/gef-legacy) can be used if Python 2 support is needed.
 
 ![gef-context](https://i.imgur.com/E3EuQPs.png)
 


### PR DESCRIPTION
## Description/Motivation/Screenshots

I removed a sentence on the home page which states that GEF supports both Python 2 and Python 3 since Python 2 is no longer supported.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
