### PR TITLE
add new nop command features

### DIFF
--- a/docs/commands/nop.md
+++ b/docs/commands/nop.md
@@ -3,21 +3,50 @@
 The `nop` command allows you to easily patch instructions with nops.
 
 ```
-nop [LOCATION] [--n NUM_ITEMS] [--b]
+nop [LOCATION] [--i ITEMS] [--f] [--n] [--b]
 ```
 
-`LOCATION` address/symbol to patch
+`LOCATION` address/symbol to patch (by default this command replaces whole instructions)
 
-`--n NUM_ITEMS` Instead of writing one instruction/nop, patch the specified number of
-instructions/nops (full instruction size by default)
+`--i ITEMS` number of items to insert (default 1)
 
-`--b` Instead of writing full instruction size, patch the specified number of nops
+`--f` Force patch even when the selected settings could overwrite partial instructions
 
+`--n` Instead of replacing whole instructions, insert ITEMS nop instructions, no matter how many instructions it overwrites
+
+`--b` Instead of replacing whole instructions, fill ITEMS bytes with nops
+
+nop the current instruction ($pc):
 ```bash
 gef➤ 	nop
+```
+
+nop an instruction at $pc+3 address:
+```bash
 gef➤ 	nop $pc+3
-gef➤ 	nop --n 2 $pc+3
+```
+
+nop two instructions at address $pc+3:
+```bash
+gef➤ 	nop --i 2 $pc+3
+```
+
+Replace 1 byte with nop at current instruction ($pc):
+```bash
 gef➤ 	nop --b
+```
+
+Replace 1 byte with nop at address $pc+3:
+```bash
 gef➤ 	nop --b $pc+3
-gef➤ 	nop --b --n 2 $pc+3
+```
+
+Replace 2 bytes with nop(s) (breaking the last instruction) at address $pc+3:
+```bash
+gef➤ 	nop --f --b --i 2 $pc+3
+```
+
+Patch 2 nops at address $pc+3:
+```bash
+gef➤ 	nop --n --i 2 $pc+3
 ```


### PR DESCRIPTION
## Description/Motivation/Screenshots

```
The `nop` command allows you to easily patch instructions with nops.

```
nop [LOCATION] [--i ITEMS] [--f] [--n] [--b]
```

`LOCATION` address/symbol to patch (by default this command replaces whole instructions)

`--i ITEMS` number of items to insert (default 1)

`--f` Force patch even when the selected settings could overwrite partial instructions

`--n` Instead of replacing whole instructions, insert ITEMS nop instructions, no matter how many instructions it overwrites

`--b` Instead of replacing whole instructions, fill ITEMS bytes with nops

gef➤ 	nop
gef➤ 	nop $pc+3
gef➤ 	nop --i 2 $pc+3
gef➤ 	nop --b
gef➤ 	nop --b $pc+3
gef➤ 	nop --f --b --i 2 $pc+3
gef➤ 	nop --n --i 2 $pc+3

```

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (see `docs/testing.md`) run passes without issue.

 * [x] x86-32
 * [x] x86-64
 * [ ] ARM
 * [ ] AARCH64
 * [ ] MIPS
 * [ ] POWERPC
 * [ ] SPARC
 * [ ] RISC-V


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
