### PR TITLE
add site/ directory generated by mkdocs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ debug.log
 .coverage
 htmlcov
 .benchmarks
+site/


### PR DESCRIPTION
add site/ directory generated by mkdocs to .gitignore

"Tested" indicates that the PR works *and* the unit test (see `docs/testing.md`) run passes without issue.

 * [x] x86-32
 * [x] x86-64
 * [x] ARM
 * [x] AARCH64
 * [x] MIPS
 * [x] POWERPC
 * [x] SPARC
 * [x] RISC-V


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
