### PR TITLE
Restore `autosave_breakpoints_file` behavior

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2022 crazy rabbidz
+Copyright (c) 2013-2023 crazy rabbidz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/gef.py
+++ b/gef.py
@@ -3573,7 +3573,7 @@ def exit_handler(_: "gdb.ExitedEvent") -> None:
     if bkp_fpath.exists():
         warn(f"{bkp_fpath} exists, content will be overwritten")
 
-    with bkp_fpath.open("w+") as fd:
+    with bkp_fpath.open("w") as fd:
         for bp in gdb.breakpoints():
             if not bp.enabled or not bp.is_valid:
                 continue


### PR DESCRIPTION
## Description/Motivation/Screenshots

The behavior of the autosave file for breakpoints got broken in #839. This PR restores it.

Fixes #965 

It also updates all 2022 references in the code to 2023

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (see `docs/testing.md`) run passes without issue.

 * [x] x86-32
 * [x] x86-64
 * [x] ARM
 * [x] AARCH64
 * [ ] MIPS
 * [ ] POWERPC
 * [ ] SPARC
 * [ ] RISC-V


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
