### PR TITLE
Fix hardcoded NOP instructions for ARM/AARCH64

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -10267,7 +10267,7 @@ class GefMemoryManager(GefManager):
         self.__maps = None
         return
 
-    def write(self, address: int, buffer: ByteString, length: Optional[int]) -> None:
+    def write(self, address: int, buffer: ByteString, length: Optional[int] = None) -> None:
         """Write `buffer` at address `address`."""
         length = length or len(buffer)
         gdb.selected_inferior().write_memory(address, buffer, length)

--- a/gef.py
+++ b/gef.py
@@ -2068,8 +2068,11 @@ def gdb_get_nth_previous_instruction_address(addr: int, n: int) -> Optional[int]
 def gdb_get_nth_next_instruction_address(addr: int, n: int) -> int:
     """Return the address (Integer) of the `n`-th instruction after `addr`."""
     # fixed-length ABI
+    if n == 0:
+        raise ValueError(f"`n` must be strictly positive")
+
     if gef.arch.instruction_length:
-        return addr + n * gef.arch.instruction_length
+        return addr + (n-1) * gef.arch.instruction_length
 
     # variable-length ABI
     insn = list(gdb_disassemble(addr, count=n))[-1]
@@ -6049,13 +6052,13 @@ class NopCommand(GenericCommand):
         args : argparse.Namespace = kwargs["arguments"]
         address = parse_address(args.address)
         nop = gef.arch.nop_insn
-        num_items = args.i or 1
-        fill_bytes = args.b
-        fill_nops = args.n
-        force_flag = args.f or False
+        num_items = int(args.i) or 1
+        fill_bytes = bool(args.b)
+        fill_nops = bool(args.n)
+        force_flag = bool(args.f) or False
 
         if fill_nops and fill_bytes:
-            err("only is possible specify --b or --n at same time")
+            err("--b and --n cannot be specified at the same time.")
             return
 
         total_bytes = 0

--- a/gef.py
+++ b/gef.py
@@ -2508,8 +2508,7 @@ class ARM(Architecture):
                      "$r7", "$r8", "$r9", "$r10", "$r11", "$r12", "$sp",
                      "$lr", "$pc", "$cpsr",)
 
-    # https://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0041c/Caccegih.html
-    nop_insn = b"\x01\x10\xa0\xe1" # mov r1, r1
+    nop_insn = b"\x00\xf0\x20\xe3" # hint #0
     return_register = "$r0"
     flag_register: str = "$cpsr"
     flags_table = {
@@ -2674,6 +2673,7 @@ class AARCH64(ARM):
         5: "t32",
         4: "m[4]",
     }
+    nop_insn = b"\x1f\x20\x03\xd5" # hint #0
     function_parameters = ("$x0", "$x1", "$x2", "$x3", "$x4", "$x5", "$x6", "$x7",)
     syscall_register = "$x8"
     syscall_instructions = ("svc $x0",)
@@ -10267,8 +10267,9 @@ class GefMemoryManager(GefManager):
         self.__maps = None
         return
 
-    def write(self, address: int, buffer: ByteString, length: int = 0x10) -> None:
+    def write(self, address: int, buffer: ByteString, length: Optional[int]) -> None:
         """Write `buffer` at address `address`."""
+        length = length or len(buffer)
         gdb.selected_inferior().write_memory(address, buffer, length)
 
     def read(self, addr: int, length: int = 0x10) -> bytes:

--- a/gef.py
+++ b/gef.py
@@ -2017,6 +2017,9 @@ def gdb_disassemble(start_pc: int, **kwargs: int) -> Generator[Instruction, None
     arch = frame.architecture()
 
     for insn in arch.disassemble(start_pc, **kwargs):
+        assert isinstance(insn["addr"], int)
+        assert isinstance(insn["length"], int)
+        assert isinstance(insn["asm"], str)
         address = insn["addr"]
         asm = insn["asm"].rstrip().split(None, 1)
         if len(asm) > 1:

--- a/tests/commands/nop.py
+++ b/tests/commands/nop.py
@@ -24,14 +24,14 @@ class NopCommand(GefUnitTestGeneric):
     def test_cmd_nop_no_arg(self):
 
         res = gdb_start_silent_cmd(
-            "pi gef.memory.write(gef.arch.pc, p32(0xfeebfeeb))", 
+            "pi gef.memory.write(gef.arch.pc, p32(0xfeebfeeb))",
             after=(
                 self.cmd,
-                "pi print(gef.memory.read(gef.arch.pc, 4))", 
+                "pi print(gef.memory.read(gef.arch.pc, 4))",
             )
         )
         self.assertNoException(res)
-        self.assertIn(r"\x90\x90\xeb\xfe", res) 
+        self.assertIn(r"\x90\x90\xeb\xfe", res)
 
 
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
@@ -39,30 +39,30 @@ class NopCommand(GefUnitTestGeneric):
 
         res = gdb_start_silent_cmd(f"{self.cmd} --b --n")
         self.assertNoException(res)
-        self.assertIn(r"-b or --n at same time", res) 
+        self.assertIn(r"--b and --n cannot be specified at the same time.", res)
 
 
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_no_arg_break_instruction(self):
         res = gdb_start_silent_cmd(
             (r"pi gef.arch.nop_insn=b'\x90\x91\x92'",
-             "pi gef.memory.write(gef.arch.pc, p32(0xfeebfeeb))"), 
+             "pi gef.memory.write(gef.arch.pc, p32(0xfeebfeeb))"),
 
             after=(
                 self.cmd,
-                "pi print(gef.memory.read(gef.arch.pc, 4))", 
+                "pi print(gef.memory.read(gef.arch.pc, 4))",
             )
         )
         self.assertNoException(res)
         self.assertIn(r"will result in LAST-NOP (byte nr 0x2)", res)
-        self.assertNotIn(r"\x90\x90\xeb\xfe", res) 
+        self.assertNotIn(r"\x90\x90\xeb\xfe", res)
 
 
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_force_arg_break_instruction(self):
         res = gdb_start_silent_cmd(
             (r"pi gef.arch.nop_insn=b'\x90\x91\x92'",
-             "pi gef.memory.write(gef.arch.pc, p32(0xfeebfeeb))"), 
+             "pi gef.memory.write(gef.arch.pc, p32(0xfeebfeeb))"),
 
             after=(
                 f"{self.cmd} --f",
@@ -71,36 +71,36 @@ class NopCommand(GefUnitTestGeneric):
         )
         self.assertNoException(res)
         self.assertIn(r"will result in LAST-NOP (byte nr 0x2)", res)
-        self.assertIn(r"\x90\x91\xeb\xfe", res) 
+        self.assertIn(r"\x90\x91\xeb\xfe", res)
 
 
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_i_arg(self):
 
         res = gdb_start_silent_cmd(
-            "pi gef.memory.write(gef.arch.pc+1, p64(0xfeebfeebfeebfeeb))", 
+            "pi gef.memory.write(gef.arch.pc+1, p64(0xfeebfeebfeebfeeb))",
             after=(
                 f"{self.cmd} --i 2 $pc+1",
-                "pi print(gef.memory.read(gef.arch.pc+1, 8))",  
+                "pi print(gef.memory.read(gef.arch.pc+1, 8))",
             )
         )
         self.assertNoException(res)
-        self.assertIn(r"\x90\x90\x90\x90\xeb\xfe\xeb\xfe", res) 
+        self.assertIn(r"\x90\x90\x90\x90\xeb\xfe\xeb\xfe", res)
 
 
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_i_arg_reaching_unmapped_area(self):
 
         res = gdb_start_silent_cmd(
-            "pi gef.memory.write(gef.arch.pc+1, p64(0xfeebfeebfeebfeeb))", 
+            "pi gef.memory.write(gef.arch.pc+1, p64(0xfeebfeebfeebfeeb))",
             after=(
                 f"{self.cmd} --i 2000000000000000000000000000000000000 $pc+1",
-                "pi print(gef.memory.read(gef.arch.pc+1, 8))", 
+                "pi print(gef.memory.read(gef.arch.pc+1, 8))",
             )
         )
         self.assertIn(r"reaching unmapped area", res)
         self.assertNoException(res)
-        self.assertNotIn(r"\x90\x90\x90\x90\xeb\xfe\xeb\xfe", res) 
+        self.assertNotIn(r"\x90\x90\x90\x90\xeb\xfe\xeb\xfe", res)
 
 
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
@@ -116,10 +116,10 @@ class NopCommand(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_nop(self):
         res = gdb_start_silent_cmd(
-            "pi gef.memory.write(gef.arch.pc, p32(0x9191))", 
+            "pi gef.memory.write(gef.arch.pc, p32(0x9191))",
             after=(
                 f"{self.cmd} --n",
-                "pi print(gef.memory.read(gef.arch.pc, 2))",  
+                "pi print(gef.memory.read(gef.arch.pc, 2))",
             )
         )
         self.assertIn(r"\x90\x91", res)
@@ -129,10 +129,10 @@ class NopCommand(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_nop_break_instruction(self):
         res = gdb_start_silent_cmd(
-           "pi gef.memory.write(gef.arch.pc, p16(0xfeeb))",  
+           "pi gef.memory.write(gef.arch.pc, p16(0xfeeb))",
             after=(
                 f"{self.cmd} --n",
-                "pi print(gef.memory.read(gef.arch.pc, 2))",  
+                "pi print(gef.memory.read(gef.arch.pc, 2))",
             )
         )
         self.assertIn(r"will result in LAST-INSTRUCTION", res)
@@ -143,10 +143,10 @@ class NopCommand(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_nop_break_instruction_force(self):
         res = gdb_start_silent_cmd(
-           "pi gef.memory.write(gef.arch.pc, p16(0xfeeb))",  
+           "pi gef.memory.write(gef.arch.pc, p16(0xfeeb))",
             after=(
                 f"{self.cmd} --n --f",
-                "pi print(gef.memory.read(gef.arch.pc, 2))",  
+                "pi print(gef.memory.read(gef.arch.pc, 2))",
             )
         )
         self.assertIn(r"will result in LAST-INSTRUCTION", res)
@@ -157,10 +157,10 @@ class NopCommand(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_nop_arg(self):
         res = gdb_start_silent_cmd(
-           "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))",  
+           "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))",
             after=(
                 f"{self.cmd} --i 4 --n",
-                "pi print(gef.memory.read(gef.arch.pc, 8))",  
+                "pi print(gef.memory.read(gef.arch.pc, 8))",
             )
         )
         self.assertIn(r"b'\x90\x90\x90\x90\xeb\xfe\xeb\xfe'", res)
@@ -171,7 +171,7 @@ class NopCommand(GefUnitTestGeneric):
     def test_cmd_nop_nop_arg_multibnop_breaks(self):
         res = gdb_start_silent_cmd(
             (r"pi gef.arch.nop_insn=b'\x90\x91\x92'",
-             "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))"), 
+             "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))"),
 
             after=(
                 f"{self.cmd} --n",
@@ -180,14 +180,14 @@ class NopCommand(GefUnitTestGeneric):
         )
         self.assertNoException(res)
         self.assertIn(r"will result in LAST-INSTRUCTION", res)
-        self.assertIn(r"b'\xeb\xfe\xeb\xfe\xeb\xfe\xeb\xfe'", res) 
+        self.assertIn(r"b'\xeb\xfe\xeb\xfe\xeb\xfe\xeb\xfe'", res)
 
 
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_nop_arg_multibnop_breaks_force(self):
         res = gdb_start_silent_cmd(
             (r"pi gef.arch.nop_insn=b'\x90\x91\x92'",
-             "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))"), 
+             "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))"),
 
             after=(
                 f"{self.cmd} --n --f",
@@ -196,16 +196,16 @@ class NopCommand(GefUnitTestGeneric):
         )
         self.assertNoException(res)
         self.assertIn(r"will result in LAST-INSTRUCTION", res)
-        self.assertIn(r"b'\x90\x91\x92\xfe\xeb\xfe\xeb\xfe'", res) 
+        self.assertIn(r"b'\x90\x91\x92\xfe\xeb\xfe\xeb\xfe'", res)
 
 
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_bytes(self):
         res = gdb_start_silent_cmd(
-            "pi gef.memory.write(gef.arch.pc, p16(0x9191))", 
+            "pi gef.memory.write(gef.arch.pc, p16(0x9191))",
             after=(
                 f"{self.cmd} --b",
-                "pi print(gef.memory.read(gef.arch.pc, 2))",  
+                "pi print(gef.memory.read(gef.arch.pc, 2))",
             )
         )
 
@@ -216,10 +216,10 @@ class NopCommand(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_bytes_break_instruction(self):
         res = gdb_start_silent_cmd(
-           "pi gef.memory.write(gef.arch.pc, p16(0xfeeb))",  
+           "pi gef.memory.write(gef.arch.pc, p16(0xfeeb))",
             after=(
                 f"{self.cmd} --b",
-                "pi print(gef.memory.read(gef.arch.pc, 2))",  
+                "pi print(gef.memory.read(gef.arch.pc, 2))",
             )
         )
 
@@ -231,10 +231,10 @@ class NopCommand(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_bytes_break_instruction_force(self):
         res = gdb_start_silent_cmd(
-           "pi gef.memory.write(gef.arch.pc, p16(0xfeeb))",  
+           "pi gef.memory.write(gef.arch.pc, p16(0xfeeb))",
             after=(
                 f"{self.cmd} --b --f",
-                "pi print(gef.memory.read(gef.arch.pc, 2))",  
+                "pi print(gef.memory.read(gef.arch.pc, 2))",
             )
         )
         self.assertIn(r"will result in LAST-INSTRUCTION", res)
@@ -245,10 +245,10 @@ class NopCommand(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_bytes_arg(self):
         res = gdb_start_silent_cmd(
-           "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))",  
+           "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))",
             after=(
                 f"{self.cmd} --i 2 --b --f",
-                "pi print(gef.memory.read(gef.arch.pc, 8))",  
+                "pi print(gef.memory.read(gef.arch.pc, 8))",
             )
         )
         self.assertIn(r"b'\x90\x90\xeb\xfe\xeb\xfe\xeb\xfe'", res)
@@ -259,11 +259,11 @@ class NopCommand(GefUnitTestGeneric):
     def test_cmd_nop_bytes_arg_nops_no_fit(self):
         res = gdb_start_silent_cmd(
             (r"pi gef.arch.nop_insn=b'\x90\x91\x92'",
-             "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))"), 
+             "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))"),
 
             after=(
                 f"{self.cmd} --i 4 --b",
-                "pi print(gef.memory.read(gef.arch.pc, 8))",  
+                "pi print(gef.memory.read(gef.arch.pc, 8))",
             )
         )
         self.assertIn(r"b'\xeb\xfe\xeb\xfe\xeb\xfe\xeb\xfe'", res)
@@ -274,12 +274,12 @@ class NopCommand(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ("i686", "x86_64"), reason=f"Skipped for {ARCH}")
     def test_cmd_nop_bytes_arg_nops_no_fit_force(self):
         res = gdb_start_silent_cmd(
-            (r"pi gef.arch.nop_insn=b'\x90\x91\x92'", 
-             "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))"), 
+            (r"pi gef.arch.nop_insn=b'\x90\x91\x92'",
+             "pi gef.memory.write(gef.arch.pc, p64(0xfeebfeebfeebfeeb))"),
 
             after=(
                 f"{self.cmd} --i 5 --b --f",
-                "pi print(gef.memory.read(gef.arch.pc, 8))",  
+                "pi print(gef.memory.read(gef.arch.pc, 8))",
             )
         )
         self.assertIn(r"b'\x90\x91\x92\x90\x91\xfe\xeb\xfe'", res)


### PR DESCRIPTION
## Description/Motivation/Screenshots

Fixes ARM and ARM64 NOP instructions

Fixes an off-by-one in `gdb_get_nth_next_instruction_address()` for fixed-size instruction archs.

Result: `nop` works fine on ARM/AARCH64

![image](https://github.com/hugsy/gef/assets/590234/ab1a8e7b-3045-4d6b-a146-0387324e4a38)

## Against which architecture was this tested ?

"Tested" indicates that the PR works *and* the unit test (see `docs/testing.md`) run passes without issue.

 * [x] x86-32
 * [x] x86-64
 * [x] ARM
 * [x] AARCH64
 * [ ] MIPS
 * [ ] POWERPC
 * [ ] SPARC
 * [ ] RISC-V


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
- [x] My PR was done against the `dev` branch, not `main`.
- [x] My code follows the code style of this project.
- [x] My change includes a change to the documentation, if required.
- [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
- [x] I have read and agree to the **CONTRIBUTING** document.
