### PR TITLE
Fix 'context_regs' not showing regs in order

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6772,11 +6772,10 @@ class DetailRegistersCommand(GenericCommand):
 
         args : argparse.Namespace = kwargs["arguments"]
         if args.registers and args.registers[0]:
-            requested_regs = set(args.registers)
-            valid_regs = set(gef.arch.all_registers) & requested_regs
-            if valid_regs:
-                regs = valid_regs
-            invalid_regs = requested_regs - valid_regs
+            all_regs = gef.arch.all_registers
+            requested_regs = args.registers
+            regs = [x for x in requested_regs if x in all_regs]
+            invalid_regs = [x for x in requested_regs if x not in all_regs]
             if invalid_regs:
                 err(f"invalid registers for architecture: {', '.join(invalid_regs)}")
 
@@ -7354,10 +7353,10 @@ class ContextCommand(GenericCommand):
 
     def context_regs(self) -> None:
         self.context_title("registers")
-        ignored_registers = set(self["ignore_registers"].split())
+        ignored_registers = self["ignore_registers"].split()
 
         if self["show_registers_raw"] is False:
-            regs = set(gef.arch.all_registers)
+            regs = [x for x in gef.arch.all_registers if x not in ignored_registers]
             printable_registers = " ".join(regs - ignored_registers)
             gdb.execute(f"registers {printable_registers}")
             return

--- a/gef.py
+++ b/gef.py
@@ -6774,8 +6774,8 @@ class DetailRegistersCommand(GenericCommand):
         if args.registers and args.registers[0]:
             all_regs = gef.arch.all_registers
             requested_regs = args.registers
-            regs = [reg for reg in requested_regs if x in all_regs]
-            invalid_regs = [reg for reg in requested_regs if x not in all_regs]
+            regs = [reg for reg in requested_regs if reg in all_regs]
+            invalid_regs = [reg for reg in requested_regs if reg not in all_regs]
             if invalid_regs:
                 err(f"invalid registers for architecture: {', '.join(invalid_regs)}")
 
@@ -7356,7 +7356,7 @@ class ContextCommand(GenericCommand):
         ignored_registers = self["ignore_registers"].split()
 
         if self["show_registers_raw"] is False:
-            regs = [reg for reg in gef.arch.all_registers if x not in ignored_registers]
+            regs = [reg for reg in gef.arch.all_registers if reg not in ignored_registers]
             printable_registers = " ".join(regs)
             gdb.execute(f"registers {printable_registers}")
             return

--- a/gef.py
+++ b/gef.py
@@ -6774,8 +6774,8 @@ class DetailRegistersCommand(GenericCommand):
         if args.registers and args.registers[0]:
             all_regs = gef.arch.all_registers
             requested_regs = args.registers
-            regs = [x for x in requested_regs if x in all_regs]
-            invalid_regs = [x for x in requested_regs if x not in all_regs]
+            regs = [reg for reg in requested_regs if x in all_regs]
+            invalid_regs = [reg for reg in requested_regs if x not in all_regs]
             if invalid_regs:
                 err(f"invalid registers for architecture: {', '.join(invalid_regs)}")
 
@@ -7356,8 +7356,8 @@ class ContextCommand(GenericCommand):
         ignored_registers = self["ignore_registers"].split()
 
         if self["show_registers_raw"] is False:
-            regs = [x for x in gef.arch.all_registers if x not in ignored_registers]
-            printable_registers = " ".join(regs - ignored_registers)
+            regs = [reg for reg in gef.arch.all_registers if x not in ignored_registers]
+            printable_registers = " ".join(regs)
             gdb.execute(f"registers {printable_registers}")
             return
 


### PR DESCRIPTION
## Description

Reverted from `set` to list comprehension so ordering of requested registers is maintained.
Ordering of registers is based on the order provided. The default will use `gef.arch.all_registers` which is correctly ordered, and the order provided by the user if manually called.
Changed so that if all requested registers are invalid it returns nothing rather than every register.

Patch required as previous change meant registers were placed into an unsorted `set` object leading to indeterminate ordering.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [X] My change includes a change to the documentation, if required.
-  [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.

fixes #986