### PR TITLE
[CI] Use `pull_request_target` for coverage trigger

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,13 @@
 name: CI Coverage for PR
 
-on:
-  pull_request:
+on: [ pull_request_target ]
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest    
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,7 @@ on: [ pull_request, pull_request_target ]
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 name: CI Coverage for PR
 
-on: [ pull_request_target ]
+on: [ pull_request, pull_request_target ]
 
 jobs:
   coverage:


### PR DESCRIPTION
## Description

Purely CI PR: use `pull_request_target` with custom permission to ensure external PRs can still trigger the coverage script.