### PR TITLE
gef-remote: Fix issue with remote path having a space

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -10902,7 +10902,7 @@ class GefRemoteSessionManager(GefSessionManager):
             return True
         tgt.parent.mkdir(parents=True, exist_ok=True)
         dbg(f"[remote] downloading '{src}' -> '{tgt}'")
-        gdb.execute(f"remote get {src} {tgt.absolute()}")
+        gdb.execute(f"remote get '{src}' '{tgt.absolute()}'")
         return tgt.exists()
 
     def connect(self, pid: int) -> bool:


### PR DESCRIPTION
## Description
Should fix #901's second issue, where we have trouble figuring out the memory map when the remote's path has a space in it.

It's due to how we generate a GDB command.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
