### PR TITLE
Fix gdb.execute not quoting paths

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1935,14 +1935,15 @@ class DisableContextOutputContext:
 
 
 class RedirectOutputContext:
-    def __init__(self, to: str = "/dev/null") -> None:
-        self.redirection_target_file = to
+    def __init__(self, to_file: str = "/dev/null") -> None:
+        if " " in to_file: raise Exception("Target filepath cannot contain spaces")
+        self.redirection_target_file = to_file
         return
 
     def __enter__(self) -> None:
         """Redirect all GDB output to `to_file` parameter. By default, `to_file` redirects to `/dev/null`."""
         gdb.execute("set logging overwrite")
-        gdb.execute(f"set logging file '{self.redirection_target_file}'")
+        gdb.execute(f"set logging file {self.redirection_target_file}")
         gdb.execute("set logging redirect on")
         gdb.execute("set logging on")
         return
@@ -1956,8 +1957,9 @@ class RedirectOutputContext:
 
 def enable_redirect_output(to_file: str = "/dev/null") -> None:
     """Redirect all GDB output to `to_file` parameter. By default, `to_file` redirects to `/dev/null`."""
+    if " " in to_file: raise Exception("Target filepath cannot contain spaces")
     gdb.execute("set logging overwrite")
-    gdb.execute(f"set logging file '{to_file}'")
+    gdb.execute(f"set logging file {to_file}")
     gdb.execute("set logging redirect on")
     gdb.execute("set logging on")
     return
@@ -8786,7 +8788,7 @@ class TraceRunCommand(GenericCommand):
     def trace(self, loc_start: int, loc_end: int, depth: int) -> None:
         info(f"Tracing from {loc_start:#x} to {loc_end:#x} (max depth={depth:d})")
         logfile = f"{self['tracefile_prefix']}{loc_start:#x}-{loc_end:#x}.txt"
-        with RedirectOutputContext(to=logfile):
+        with RedirectOutputContext(to_file=logfile):
             hide_context()
             self.start_tracing(loc_start, loc_end, depth)
             unhide_context()
@@ -9184,7 +9186,7 @@ class FormatStringSearchCommand(GenericCommand):
 
         nb_installed_breaks = 0
 
-        with RedirectOutputContext(to="/dev/null"):
+        with RedirectOutputContext(to_file="/dev/null"):
             for function_name in dangerous_functions:
                 argument_number = dangerous_functions[function_name]
                 FormatStringBreakpoint(function_name, argument_number)

--- a/gef.py
+++ b/gef.py
@@ -2140,7 +2140,7 @@ def gef_execute_gdb_script(commands: str) -> None:
 
     fname = pathlib.Path(fname)
     if fname.is_file() and os.access(fname, os.R_OK):
-        gdb.execute(f"source '{fname}'")
+        gdb.execute(f"source {fname}")
         fname.unlink()
     return
 
@@ -10160,7 +10160,7 @@ class GefTmuxSetup(gdb.Command):
         gdb.execute(f"!'{tmux}' select-pane -L")
 
         ok(f"Setting `context.redirect` to '{pty}'...")
-        gdb.execute(f"gef config context.redirect '{pty}'")
+        gdb.execute(f"gef config context.redirect {pty}")
         ok("Done!")
         return
 
@@ -10186,7 +10186,7 @@ class GefTmuxSetup(gdb.Command):
         with open(tty_path, "r") as f:
             pty = f.read().strip()
         ok(f"Setting `context.redirect` to '{pty}'...")
-        gdb.execute(f"gef config context.redirect '{pty}'")
+        gdb.execute(f"gef config context.redirect {pty}")
         ok("Done!")
         os.unlink(script_path)
         os.unlink(tty_path)
@@ -10243,7 +10243,7 @@ class GefInstallExtraScriptCommand(gdb.Command):
                 fd.flush()
 
         old_command_set = set(gef.gdb.commands)
-        gdb.execute(f"source '{fpath}'")
+        gdb.execute(f"source {fpath}")
         new_command_set = set(gef.gdb.commands)
         new_commands = [f"`{c[0]}`" for c in (new_command_set - old_command_set)]
         ok(f"Installed file '{fpath}', new command(s) available: {', '.join(new_commands)}")
@@ -11211,4 +11211,4 @@ if __name__ == "__main__":
     # restore saved breakpoints (if any)
     bkp_fpath = pathlib.Path(gef.config["gef.autosave_breakpoints_file"]).expanduser().absolute()
     if bkp_fpath.exists() and bkp_fpath.is_file():
-        gdb.execute(f"source '{bkp_fpath}'")
+        gdb.execute(f"source {bkp_fpath}")

--- a/gef.py
+++ b/gef.py
@@ -1936,7 +1936,7 @@ class DisableContextOutputContext:
 
 class RedirectOutputContext:
     def __init__(self, to_file: str = "/dev/null") -> None:
-        if " " in to_file: raise Exception("Target filepath cannot contain spaces")
+        if " " in to_file: raise ValueEror("Target filepath cannot contain spaces")
         self.redirection_target_file = to_file
         return
 
@@ -1957,7 +1957,7 @@ class RedirectOutputContext:
 
 def enable_redirect_output(to_file: str = "/dev/null") -> None:
     """Redirect all GDB output to `to_file` parameter. By default, `to_file` redirects to `/dev/null`."""
-    if " " in to_file: raise Exception("Target filepath cannot contain spaces")
+    if " " in to_file: raise ValueEror("Target filepath cannot contain spaces")
     gdb.execute("set logging overwrite")
     gdb.execute(f"set logging file {to_file}")
     gdb.execute("set logging redirect on")


### PR DESCRIPTION
## Description

As I looked into #901, I found that we often don't quote filepaths in `gdb.execute`. This began lazy grep that tries to ID where we do this, and fixes where we can. Noticed that we cannot use quotes in the filename when setting up logging, so it instead restricts the logging path to one without spaces.

This is mostly untested.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
