### PR TITLE
Memory map provider

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -10393,10 +10393,11 @@ class GefMemoryManager(GefManager):
     @property
     def maps(self) -> List[Section]:
         if not self.__maps:
-            self.__maps = self.__parse_maps()
+            self.__maps = self._parse_maps()
         return self.__maps
 
-    def __parse_maps(self) -> List[Section]:
+    @staticmethod
+    def _parse_maps() -> List[Section]:
         """Return the mapped memory sections. If the current arch has its maps
         method defined, then defer to that to generated maps, otherwise, try to
         figure it out from procfs, then info sections, then monitor info

--- a/gef.py
+++ b/gef.py
@@ -10490,8 +10490,6 @@ class GefMemoryManager(GefManager):
         stream = StringIO(gdb.execute("monitor info mem", to_string=True))
 
         for line in stream:
-            if not line:
-                break
             try:
                 ranges, off, perms = line.split()
                 off = int(off, 16)

--- a/gef.py
+++ b/gef.py
@@ -10378,33 +10378,32 @@ class GefMemoryManager(GefManager):
             self.__maps = self._parse_maps()
         return self.__maps
 
-    @staticmethod
-    def _parse_maps() -> List[Section]:
+    @classmethod
+    def _parse_maps(cls) -> List[Section]:
         """Return the mapped memory sections. If the current arch has its maps
         method defined, then defer to that to generated maps, otherwise, try to
         figure it out from procfs, then info sections, then monitor info
         mem."""
         if gef.arch.maps is not None:
-            maps = list(gef.arch.maps())
-            return maps
+            return list(gef.arch.maps())
 
         try:
-            return list(self.parse_procfs_maps())
+            return list(cls.parse_procfs_maps())
         except:
             pass
 
         try:
-            return list(self.parse_gdb_info_sections())
+            return list(cls.parse_gdb_info_sections())
         except:
             pass
 
         try:
-            return list(self.parse_monitor_info_mem())
+            return list(cls.parse_monitor_info_mem())
         except:
             pass
 
         warn("Cannot get memory map")
-        return []
+        return None
 
     @staticmethod
     def parse_procfs_maps() -> Generator[Section, None, None]:

--- a/gef.py
+++ b/gef.py
@@ -10420,6 +10420,9 @@ class GefMemoryManager(GefManager):
         except:
             pass
 
+        warn("Cannot get memory map")
+        return []
+
     @staticmethod
     def parse_procfs_maps() -> Generator[Section, None, None]:
         """Get the memory mapping from procfs."""

--- a/gef.py
+++ b/gef.py
@@ -2821,13 +2821,23 @@ class X86(Architecture):
     _ptrsize = 4
     _endianness = Endianness.LITTLE_ENDIAN
 
-    # TODO: How do I show that this is a GefMemoryMapProvider?
+    # TODO: Delete this, this is for testing only
     @staticmethod
-    def x():
-        yield from itertools.chain(GefMemoryManager.parse_procfs_maps(),
-                                   # GefMemoryManager.parse_gdb_info_sections(),
-                                   GefMemoryManager.parse_monitor_info_mem())
-    maps: GefMemoryMapProvider = x
+    def maps():
+        try:
+            return list(GefMemoryManager.parse_procfs_maps())
+        except:
+            pass
+
+        try:
+            return list(GefMemoryManager.parse_gdb_info_sections())
+        except:
+            pass
+
+        try:
+            return list(GefMemoryManager.parse_monitor_info_mem())
+        except:
+            pass
 
     def flag_register_to_human(self, val: Optional[int] = None) -> str:
         reg = self.flag_register
@@ -10410,23 +10420,13 @@ class GefMemoryManager(GefManager):
         except:
             pass
 
-        # This provides duplicates
-        # return list(itertools.chain(
-        #     self.parse_procfs_maps(),
-        #     self.parse_monitor_info_mem(),
-        #     self.parse_gdb_info_sections(),
-        #     ))
-
-    # TODO: GefMemoryMapProvider
-    # TODO: Might be easier to just return nothing on error so we can 'chain' to the next
     @staticmethod
     def parse_procfs_maps() -> Generator[Section, None, None]:
         """Get the memory mapping from procfs."""
         procfs_mapfile = gef.session.maps
         if not procfs_mapfile:
             is_remote = gef.session.remote is not None
-            # raise FileNotFoundError(f"Missing {'remote ' if is_remote else ''}procfs map file")
-            return
+            raise FileNotFoundError(f"Missing {'remote ' if is_remote else ''}procfs map file")
         with procfs_mapfile.open("r") as fd:
             for line in fd:
                 line = line.strip()

--- a/gef.py
+++ b/gef.py
@@ -2821,24 +2821,6 @@ class X86(Architecture):
     _ptrsize = 4
     _endianness = Endianness.LITTLE_ENDIAN
 
-    # TODO: Delete this, this is for testing only
-    @staticmethod
-    def maps():
-        try:
-            return list(GefMemoryManager.parse_procfs_maps())
-        except:
-            pass
-
-        try:
-            return list(GefMemoryManager.parse_gdb_info_sections())
-        except:
-            pass
-
-        try:
-            return list(GefMemoryManager.parse_monitor_info_mem())
-        except:
-            pass
-
     def flag_register_to_human(self, val: Optional[int] = None) -> str:
         reg = self.flag_register
         if not val:

--- a/gef.py
+++ b/gef.py
@@ -10480,11 +10480,11 @@ class GefMemoryManager(GefManager):
 
     @staticmethod
     def parse_monitor_info_mem() -> Generator[Section, None, None]:
-        """Get the memory mapping from GDB's command `monitor info mem`"""
-        try:
-            stream = StringIO(gdb.execute("monitor info mem", to_string=True))
-        except Exception:
-            return
+        """Get the memory mapping from GDB's command `monitor info mem`
+        This can raise an exception, which the memory manager takes to mean
+        that this method does not work to get a map.
+        """
+        stream = StringIO(gdb.execute("monitor info mem", to_string=True))
 
         for line in stream:
             if not line:

--- a/tests/api/misc.py
+++ b/tests/api/misc.py
@@ -101,6 +101,14 @@ class MiscFunctionTest(GefUnitTestGeneric):
         self.assertNoException(res)
         assert "Section" in res
 
+        # The parse maps function should automatically get called when we start
+        # up, and we should be able to view the maps via the `gef.memory.maps`
+        # property.
+        func = "gef.memory.maps"
+        res = gdb_test_python_method(func)
+        self.assertNoException(res)
+        assert "Section" in res
+
 
     @pytest.mark.slow
     @pytest.mark.online

--- a/tests/api/misc.py
+++ b/tests/api/misc.py
@@ -12,7 +12,12 @@ from tests.utils import (
     _target,
     gdb_start_silent_cmd,
     gdb_test_python_method,
+    gdb_run_cmd,
+    gdbserver_session,
+    qemuuser_session,
     GefUnitTestGeneric,
+    GDBSERVER_DEFAULT_HOST,
+    GDBSERVER_DEFAULT_PORT,
 )
 
 
@@ -25,7 +30,6 @@ class MiscFunctionTest(GefUnitTestGeneric):
         self.assertIn("/gdb", lines[-1])
         res = gdb_test_python_method("which('__IDontExist__')")
         self.assertIn("Missing file `__IDontExist__`", res)
-
 
     def test_func_gef_convenience(self):
         func = "gef_convenience('meh')"
@@ -41,18 +45,62 @@ class MiscFunctionTest(GefUnitTestGeneric):
         res = gdb_test_python_method(func)
         self.assertException(res)
 
+    def test_func_parse_permissions(self):
+        func = "Permission.from_info_sections('ALLOC LOAD READONLY CODE HAS_CONTENTS')"
+        res = gdb_test_python_method(func)
+        self.assertNoException(res)
+
+        func = "Permission.from_process_maps('r--')"
+        res = gdb_test_python_method(func)
+        self.assertNoException(res)
+
+        func = "Permission.from_monitor_info_mem('-r-')"
+        res = gdb_test_python_method(func)
+        self.assertNoException(res)
+
+        func = "Permission.from_info_mem('rw')"
+        res = gdb_test_python_method(func)
+        self.assertNoException(res)
+
     def test_func_parse_maps(self):
-        func = "Permission.from_info_sections(' [10]     0x555555574000->0x55555557401b at 0x00020000: .init ALLOC LOAD READONLY CODE HAS_CONTENTS')"
+        func = "list(GefMemoryManager.parse_procfs_maps())"
         res = gdb_test_python_method(func)
         self.assertNoException(res)
+        assert "Section" in res
 
-        func = "Permission.from_process_maps('0x0000555555554000 0x0000555555574000 0x0000000000000000 r-- /usr/bin/bash')"
+        func = "list(GefMemoryManager.parse_gdb_info_sections())"
         res = gdb_test_python_method(func)
         self.assertNoException(res)
+        assert "Section" in res
 
-        func = "Permission.from_info_mem('ffffff2a65e0b000-ffffff2a65e0c000 0000000000001000 -r-')"
+        # When in a gef-remote session `parse_gdb_info_sections` should work to
+        # query the memory maps
+        port = GDBSERVER_DEFAULT_PORT + 1
+        before = [f"gef-remote {GDBSERVER_DEFAULT_HOST} {port}"]
+        with gdbserver_session(port=port) as _:
+            func = "list(GefMemoryManager.parse_gdb_info_sections())"
+            res = gdb_test_python_method(func)
+            self.assertNoException(res)
+            assert "Section" in res
+
+        # When in a gef-remote qemu-user session `parse_gdb_info_sections`
+        # should work to query the memory maps
+        port = GDBSERVER_DEFAULT_PORT + 2
+        target = _target("default")
+        before = [
+            f"gef-remote --qemu-user --qemu-binary {target} {GDBSERVER_DEFAULT_HOST} {port}"]
+        with qemuuser_session(port=port) as _:
+            func = "list(GefMemoryManager.parse_gdb_info_sections())"
+            res = gdb_test_python_method(func)
+            self.assertNoException(res)
+            assert "Section" in res
+
+        # Running the _parse_maps method should just find the correct one
+        func = "list(GefMemoryManager._parse_maps())"
         res = gdb_test_python_method(func)
         self.assertNoException(res)
+        assert "Section" in res
+
 
     @pytest.mark.slow
     @pytest.mark.online

--- a/tests/commands/gef_remote.py
+++ b/tests/commands/gef_remote.py
@@ -3,45 +3,49 @@
 """
 
 
-from tests.utils import (GefUnitTestGeneric, _target, gdb_run_cmd,
-                         gdbserver_session, qemuuser_session)
-
-GDBSERVER_PREFERED_HOST = "localhost"
-GDBSERVER_PREFERED_PORT = 1234
+from tests.utils import (
+    GefUnitTestGeneric,
+    _target,
+    gdb_run_cmd,
+    gdbserver_session,
+    qemuuser_session,
+    GDBSERVER_DEFAULT_HOST,
+    GDBSERVER_DEFAULT_PORT,
+)
 
 class GefRemoteCommand(GefUnitTestGeneric):
     """`gef_remote` command test module"""
 
 
     def test_cmd_gef_remote(self):
-        port = GDBSERVER_PREFERED_PORT + 1
-        before = [f"gef-remote {GDBSERVER_PREFERED_HOST} {port}"]
+        port = GDBSERVER_DEFAULT_PORT + 1
+        before = [f"gef-remote {GDBSERVER_DEFAULT_HOST} {port}"]
         with gdbserver_session(port=port) as _:
             res = gdb_run_cmd(
                 "pi print(gef.session.remote)", before=before)
             self.assertNoException(res)
             self.assertIn(
-                f"RemoteSession(target='{GDBSERVER_PREFERED_HOST}:{port}', local='/tmp/", res)
+                f"RemoteSession(target='{GDBSERVER_DEFAULT_HOST}:{port}', local='/tmp/", res)
             self.assertIn(", qemu_user=False)", res)
 
 
     def test_cmd_gef_remote_qemu_user(self):
-        port = GDBSERVER_PREFERED_PORT + 2
+        port = GDBSERVER_DEFAULT_PORT + 2
         target = _target("default")
         before = [
-            f"gef-remote --qemu-user --qemu-binary {target} {GDBSERVER_PREFERED_HOST} {port}"]
+            f"gef-remote --qemu-user --qemu-binary {target} {GDBSERVER_DEFAULT_HOST} {port}"]
         with qemuuser_session(port=port) as _:
             res = gdb_run_cmd(
                 "pi print(gef.session.remote)", before=before)
             self.assertNoException(res)
             self.assertIn(
-                f"RemoteSession(target='{GDBSERVER_PREFERED_HOST}:{port}', local='/tmp/", res)
+                f"RemoteSession(target='{GDBSERVER_DEFAULT_HOST}:{port}', local='/tmp/", res)
             self.assertIn(", qemu_user=True)", res)
 
 
     def test_cmd_target_remote(self):
-        port = GDBSERVER_PREFERED_PORT + 3
-        before = [f"target remote {GDBSERVER_PREFERED_HOST}:{port}"]
+        port = GDBSERVER_DEFAULT_PORT + 3
+        before = [f"target remote {GDBSERVER_DEFAULT_HOST}:{port}"]
         with gdbserver_session(port=port) as _:
             res = gdb_run_cmd(
                 "pi print(gef.session.remote)", before=before)


### PR DESCRIPTION
## Description

This change allows architectures to provide their own memory map by defining `maps` in the architecture. If set, then `GefMemoryManager` will defer to it when building maps.

This can be used for e.g. architectures that are built for use with gdbserver.

It also adds `parse_info_mem` (Renaming the old one to `parse_monitor_info_mem`) which parses the maps from this command. The Black Magic Probe provides memory maps of its targets via this command.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
