### PR TITLE
Do not quote paths when running 'source'

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -9540,7 +9540,7 @@ class GefCommand(gdb.Command):
         def load_plugin(fpath: pathlib.Path) -> bool:
             try:
                 dbg(f"Loading '{fpath}'")
-                gdb.execute(f"source '{fpath}'")
+                gdb.execute(f"source {fpath}")
             except Exception as e:
                 warn(f"Exception while loading {fpath}: {str(e)}")
                 return False
@@ -10180,7 +10180,7 @@ class GefTmuxSetup(gdb.Command):
             f.write(f"screen bash -c 'tty > {tty_path}; clear; cat'\n")
             f.write("focus left\n")
 
-        gdb.execute(f"!'{screen}' -r '{sty}' -m -d -X source '{script_path}'")
+        gdb.execute(f"!'{screen}' -r '{sty}' -m -d -X source {script_path}")
         # artificial delay to make sure `tty_path` is populated
         time.sleep(0.25)
         with open(tty_path, "r") as f:


### PR DESCRIPTION
## Description

gdb's `source` doesn't understand quotes. Annoying.

We should be OK not quoting it since the config has a hook to ensure the path doesn't have spaces.

Discovered by @southball

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
