### PR TITLE
[Installers] Use latest tag, not main

### DIFF
--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -5,9 +5,11 @@
 #
 set -e
 
-usage() { echo "Usage: $0 [-b <main|OtherBranchName>] [-p <path_to_install>]" 1>&2; exit 1; }
+usage() { echo "Usage: $0 [-b <OtherBranchName|tag>] [-p <path_to_install>]" 1>&2; exit 1; }
 
-branch="main"
+latest_tag=$(curl -s "https://api.github.com/repos/hugsy/gef/tags" | grep "name" | head -1 | sed -e 's/"name": "\([^"]*\)",/\1/' -e 's/\s*//')
+
+branch=${latest_tag}
 while getopts ":b:p:" o; do
     case "${o}" in
         b)

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -7,7 +7,7 @@ set -e
 
 usage() { echo "Usage: $0 [-b <OtherBranchName|tag>] [-p <path_to_install>]" 1>&2; exit 1; }
 
-latest_tag=$(curl -s "https://api.github.com/repos/hugsy/gef/tags" | grep "name" | head -1 | sed -e 's/"name": "\([^"]*\)",/\1/' -e 's/\s*//')
+latest_tag=$(curl -s "https://api.github.com/repos/hugsy/gef/tags" | grep "name" | head -1 | sed -e 's/"name": "\([^"]*\)",/\1/' -e 's/ *//')
 
 branch=${latest_tag}
 while getopts ":b:p:" o; do

--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -21,7 +21,7 @@ if [ -f "${HOME}/.gdbinit" ]; then
 fi
 
 if [ $wget_found -eq 1 ]; then
-    latest_tag=$(wget -q -O- "https://api.github.com/repos/hugsy/gef/tags" | grep "name" | head -1 | sed -e 's/"name": "\([^"]*\)",/\1/' -e 's/\s*//')
+    latest_tag=$(wget -q -O- "https://api.github.com/repos/hugsy/gef/tags" | grep "name" | head -1 | sed -e 's/"name": "\([^"]*\)",/\1/' -e 's/ *//')
 
     # Get the hash of the commit
     branch="${latest_tag}"
@@ -30,7 +30,7 @@ if [ $wget_found -eq 1 ]; then
     # Download the file
     wget -q "https://github.com/hugsy/gef/raw/${branch}/gef.py" -O "${HOME}/.gef-${ref}.py"
 elif [ $curl_found -eq 1 ]; then
-    latest_tag=$(curl -s "https://api.github.com/repos/hugsy/gef/tags" | grep "name" | head -1 | sed -e 's/"name": "\([^"]*\)",/\1/' -e 's/\s*//')
+    latest_tag=$(curl -s "https://api.github.com/repos/hugsy/gef/tags" | grep "name" | head -1 | sed -e 's/"name": "\([^"]*\)",/\1/' -e 's/ *//')
 
     # Get the hash of the commit
     branch="${latest_tag}"

--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-branch="main"
 curl_found=0
 wget_found=0
 
@@ -22,13 +21,19 @@ if [ -f "${HOME}/.gdbinit" ]; then
 fi
 
 if [ $wget_found -eq 1 ]; then
+    latest_tag=$(wget -q -O- "https://api.github.com/repos/hugsy/gef/tags" | grep "name" | head -1 | sed -e 's/"name": "\([^"]*\)",/\1/' -e 's/\s*//')
+
     # Get the hash of the commit
+    branch="${latest_tag}"
     ref=$(wget -q -O- https://api.github.com/repos/hugsy/gef/git/ref/heads/${branch} | grep '"sha"' | tr -s ' ' | cut -d ' ' -f 3 | tr -d "," | tr -d '"')
 
     # Download the file
     wget -q "https://github.com/hugsy/gef/raw/${branch}/gef.py" -O "${HOME}/.gef-${ref}.py"
 elif [ $curl_found -eq 1 ]; then
+    latest_tag=$(curl -s "https://api.github.com/repos/hugsy/gef/tags" | grep "name" | head -1 | sed -e 's/"name": "\([^"]*\)",/\1/' -e 's/\s*//')
+
     # Get the hash of the commit
+    branch="${latest_tag}"
     ref=$(curl --silent https://api.github.com/repos/hugsy/gef/git/ref/heads/${branch} | grep '"sha"' | tr -s ' ' | cut -d ' ' -f 3 | tr -d "," | tr -d '"')
 
     # Download the file


### PR DESCRIPTION
## Description

Make install scripts use the latest tag for scripted installation, not `main` by default.
Even though it should always be stable, `main` may be broken between releases, especially with its extras integration. It's safer to always point new users only to the latest known stable point.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
