### PR TITLE
prompt ascii changed

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -152,7 +152,7 @@ VERTICAL_LINE                          = "│"
 CROSS                                  = "✘ "
 TICK                                   = "✓ "
 BP_GLYPH                               = "●"
-GEF_PROMPT                             = "gef➤  "
+GEF_PROMPT                             = "gef>  "
 GEF_PROMPT_ON                          = f"\001\033[1;32m\002{GEF_PROMPT}\001\033[0m\002"
 GEF_PROMPT_OFF                         = f"\001\033[1;31m\002{GEF_PROMPT}\001\033[0m\002"
 
@@ -10263,7 +10263,6 @@ def __gef_prompt__(current_prompt: Callable[[Callable], str]) -> str:
         prompt += Color.boldify("(remote) ")
     prompt += GEF_PROMPT_ON if is_alive() else GEF_PROMPT_OFF
     return prompt
-
 
 class GefManager(metaclass=abc.ABCMeta):
     def reset_caches(self) -> None:


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->
This patch is the solution to a problem that I faced while running gef for gdb on cloud servers (I use them to use different CPU Architectures). For the last 6 months, I have been facing this problem and today was the day when I finally got the motivation to track down the problem. I am pretty sure that many gef users face the problem of getting a Unicode Encode Error and not using the goodness of gef tool. This was something that I solved in this patch.

<!-- Why is this change required? What problem does it solve? -->
The Unicode Encode Error occurs right from the start, the moment when gef is installed. Now this is not in every case, like gef was working fine with my local machine but fails in certain systems due to the error. This one-word change solved the problem of this error. A beginner who is trying to run gef first time on a machine that would throw this error might face an issue like this and end up not using the power of gef. The prompt arrow was causing the Unicode Encode Error. The Prompt had an error with the ASCII character "➤" and I replaced it with ">" which is common in the case of most of the terminals. This small change ran the gef, that I had abandoned for more than 6 months.

<!-- Why is this patch will make a better world? -->
We all need to use the goodness of gef and beginners must start by using gef. But this small error of prompt pointer makes the tool unusable, and hence this will cause the user base to go down. By changing the prompt (I know that the earlier prompt was cool), the error can be fixed and the debugger is ready to be used and learned by a beginner. The practical usage is more useful. I don't want any other person to stop using this tool for more than 6 months due to a single character error. 

<!-- How does this look? Add a screenshot if you can -->

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [ ] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
