### PR TITLE
show basename in source: split line

### DIFF
--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -195,6 +195,26 @@ gef➤  gef config context.ignore_registers "$cs $ds $gs"
 gef➤  gef config context.show_source_code_variable_values 0
 ```
 
+*  Control how source file path is displayed.
+
+When displaying the source file name, above the source code view, the following
+settings can be changed:
+
+```text
+gef➤  gef config context.show_full_source_file_name_max_len 30
+gef➤  gef config context.show_prefix_source_path_name_len 10
+gef➤  gef config context.show_basename_source_file_name_max_len 20
+```
+
+In this example, if the file path length is less than or equal to 30 it will be
+displayed in its entirety. If however, it's more than 30 characters in length,
+it will be truncated.
+
+Truncation first splits the path into the prefix part and file name part. The
+`show_prefix_source_path_name_len` controls how many characters of the prefix
+path to show, and the `show_basename_source_file_name_max_len` controls how
+many characters from the file name to show.
+
 *  Show better definitions for call to libc functions.
 
 ```text

--- a/gef.py
+++ b/gef.py
@@ -7663,8 +7663,11 @@ class ContextCommand(GenericCommand):
 
         nb_line = self["nb_lines_code"]
         fn = symtab.filename
-        if len(fn) > 20:
-            fn = f"{fn[:15]}[...]{os.path.splitext(fn)[1]}"
+        if len(fn) > 30:
+            base = os.path.basename(fn)
+            if len(base) > 20:
+                base = f"{base[-10:]}"
+            fn = f"{fn[:15]}[...]{base}"
         title = f"source:{fn}+{line_num + 1}"
         cur_line_color = gef.config["theme.source_current_line"]
         self.context_title(title)

--- a/gef.py
+++ b/gef.py
@@ -7220,6 +7220,9 @@ class ContextCommand(GenericCommand):
         super().__init__()
         self["enable"] = (True, "Enable/disable printing the context when breaking")
         self["show_source_code_variable_values"] = (True, "Show extra PC context info in the source code")
+        self["show_full_source_file_name_max_len"] = (30, "Show full source path name, if less than this value")
+        self["show_basename_source_file_name_max_len"] = (20, "Show the source basename in full, if less than this value")
+        self["show_prefix_source_path_name_len"] = (10, "When truncating source path, show this many path prefix characters")
         self["show_stack_raw"] = (False, "Show the stack pane as raw hexdump (no dereference)")
         self["show_registers_raw"] = (False, "Show the registers pane with raw values (no dereference)")
         self["show_opcodes_size"] = (0, "Number of bytes of opcodes to display next to the disassembly")
@@ -7661,13 +7664,17 @@ class ContextCommand(GenericCommand):
         bp_locations = [b.location for b in breakpoints if b.location and file_base_name in b.location]
         past_lines_color = gef.config["theme.old_context"]
 
+        show_full_path_max = self["show_full_source_file_name_max_len"]
+        show_basename_path_max = self["show_basename_source_file_name_max_len"]
+        show_prefix_path_len = self["show_prefix_source_path_name_len"]
+
         nb_line = self["nb_lines_code"]
         fn = symtab.filename
-        if len(fn) > 30:
+        if len(fn) > show_full_path_max:
             base = os.path.basename(fn)
-            if len(base) > 20:
-                base = f"{base[-10:]}"
-            fn = f"{fn[:15]}[...]{base}"
+            if len(base) > show_basename_path_max:
+                base = base[-show_basename_path_max:]
+            fn = fn[:15] + "[...]" + base
         title = f"source:{fn}+{line_num + 1}"
         cur_line_color = gef.config["theme.source_current_line"]
         self.context_title(title)


### PR DESCRIPTION
This patch modifies the text shown above the source window as part of the `context_source()` function.

I'm working on a complex C++ project, with many directories and files.
Before this change I would get a split with...
`────────────────────────── source:/server/externa[...].cpp+130 ────`
which does not tell me anything about what file I am in, other than its extension.

After the change, I get something like this:
`─────────────── source:/server/externa[...]SendReceive.hpp+110 ────`

Depending on the length of the path the following may be shown:
* `if len(fn) <= 30`
    * show the full path
* `elif len(basename(fn)) < 20`
    * show `<first 15 chars>[...]<basename>`
* else
    * show `<first 15 chars>[...]<last 10 chars>`

