### PR TITLE
[target-remote] Basic support for the `target remote` command

### DIFF
--- a/docs/commands/gef-remote.md
+++ b/docs/commands/gef-remote.md
@@ -6,8 +6,10 @@ does a limited job (80's bandwith FTW) to collect more information about the tar
 process of debugging more cumbersome. GEF greatly improves that state with the `gef-remote` command.
 
 📝 **Note**: If using GEF, `gef-remote` **must** be your way or debugging remote processes, never
-`target remote`. Maintainers will not provide support or help if you decide to use the traditional
-`target remote` command. For many reasons, you **cannot** use `target remote` alone with GEF.
+`target remote`. Maintainers will provide minimal support or help if you decide to use the
+traditional `target remote` command. For many reasons, you **should not** use `target remote` alone
+with GEF. It is still important to note that the default `target remote` command has been
+overwritten by a minimal copy `gef-remote`, in order to make most tools relying on this command work.
 
 `gef-remote` can function in 2 ways:
 

--- a/gef.py
+++ b/gef.py
@@ -11141,7 +11141,7 @@ def target_remote_posthook():
     if gef.session.remote_initializing:
         return
 
-    gef.session.remote = GefRemoteSessionManager('', 0)
+    gef.session.remote = GefRemoteSessionManager("", 0)
     if not gef.session.remote.setup():
         raise EnvironmentError(f"Failed to create a proper environment for {gef.session.remote}")
 

--- a/gef.py
+++ b/gef.py
@@ -11229,6 +11229,7 @@ if __name__ == "__main__":
     gdb.execute(f"define target hook-remote\n{hook}\nend")
     gdb.execute(f"define target hook-extended-remote\n{hook}\nend")
 
+    # Register a post-hook for `target remote` that initialize the remote session
     gdb.execute("""
         define target hookpost-remote
         pi target_remote_posthook()

--- a/tests/commands/gef_remote.py
+++ b/tests/commands/gef_remote.py
@@ -38,6 +38,7 @@ class GefRemoteCommand(GefUnitTestGeneric):
                 f"RemoteSession(target='{GDBSERVER_PREFERED_HOST}:{port}', local='/tmp/", res)
             self.assertIn(", qemu_user=True)", res)
 
+
     def test_cmd_target_remote(self):
         port = GDBSERVER_PREFERED_PORT + 3
         before = [f"target remote {GDBSERVER_PREFERED_HOST}:{port}"]
@@ -48,4 +49,3 @@ class GefRemoteCommand(GefUnitTestGeneric):
             self.assertIn(
                 f"RemoteSession(target=':0', local='/tmp/", res)
             self.assertIn(", qemu_user=False)", res)
-

--- a/tests/commands/gef_remote.py
+++ b/tests/commands/gef_remote.py
@@ -37,3 +37,15 @@ class GefRemoteCommand(GefUnitTestGeneric):
             self.assertIn(
                 f"RemoteSession(target='{GDBSERVER_PREFERED_HOST}:{port}', local='/tmp/", res)
             self.assertIn(", qemu_user=True)", res)
+
+    def test_cmd_target_remote(self):
+        port = GDBSERVER_PREFERED_PORT + 3
+        before = [f"target remote {GDBSERVER_PREFERED_HOST}:{port}"]
+        with gdbserver_session(port=port) as _:
+            res = gdb_run_cmd(
+                "pi print(gef.session.remote)", before=before)
+            self.assertNoException(res)
+            self.assertIn(
+                f"RemoteSession(target=':0', local='/tmp/", res)
+            self.assertIn(", qemu_user=False)", res)
+


### PR DESCRIPTION
## Description

As mentioned in Gallopsled/pwntools#2264, gef does not work properly with many tools that rely on the `target remote` command.
In this PR, I propose a fix that uses a remote posthook in order to instantiate and setup the GefRemoteSessionManager after the connection being established.

Note that this isn't a perfect solution since we do not have all the information needed for a proper instantiation of the GefRemoteSessionManager, but it seems to be a good workaround in order to make tools like `pwntools` work correctly with gef.

