### PR TITLE
Run validate CI step with Python 3.11

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
+      with:
+        python-version: "3.11"
     - uses: pre-commit/action@v3.0.0
 
   docs_link_check:


### PR DESCRIPTION
Python 3.12 doesn't work because of some lib being deprecated.