### PR TITLE
Dump memory usage when listing arenas, and add summary option in heap chunks command.

### DIFF
--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -68,7 +68,7 @@ To get a higher level overview of the chunks you can use the `--summary` flag to
 gef➤ heap chunks --summary
 ```
 
-![heap-chunks-summary](https://i.imgur.com/DjFkzLc.png)
+![heap-chunks-summary](https://i.imgur.com/3HTgtwX.png)
 
 ### `heap chunk` command
 

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -62,6 +62,14 @@ re-aligns the chunks data start addresses to match Glibc's behavior. To be able 
 chunks as well, you can disable this with the `--allow-unaligned` flag. Note that this might result
 in incorrect output.
 
+To get a higher level overview of the chunks you can use the `--summary` flag too.
+
+```text
+gef➤ heap chunks --summary
+```
+
+![heap-chunks-summary](https://i.imgur.com/DjFkzLc.png)
+
 ### `heap chunk` command
 
 This command gives visual information of a Glibc malloc-ed chunked. Simply provide the address to

--- a/gef.py
+++ b/gef.py
@@ -6322,7 +6322,7 @@ class GlibcHeapArenaSummary:
             self.flag_distribution["NON_MAIN_ARENA"].process_chunk(chunk)
 
     def print(self) -> None:
-        gef_print("== Chunk distribution by size (in bytes) ==")
+        gef_print("== Chunk distribution by size ==")
         gef_print("{:<10s}\t{:<10s}\t{:s}".format("ChunkBytes", "Count", "TotalBytes"))
         for chunk_size, chunk_summary in sorted(self.size_distribution.items(), key=lambda x: x[1].total_bytes, reverse=True):
             gef_print("{:<10d}\t{:<10d}\t{:<d}".format(chunk_size, chunk_summary.count, chunk_summary.total_bytes))

--- a/gef.py
+++ b/gef.py
@@ -1375,7 +1375,8 @@ class GlibcArena:
 
     def __str__(self) -> str:
         properties = f"base={self.__address:#x}, top={self.top:#x}, " \
-                f"last_remainder={self.last_remainder:#x}, next={self.next:#x}"
+                f"last_remainder={self.last_remainder:#x}, next={self.next:#x}, " \
+                f"mem={self.system_mem}, mempeak={self.max_system_mem}"
         return (f"{Color.colorify('Arena', 'blue bold underline')}({properties})")
 
     def __repr__(self) -> str:
@@ -6286,6 +6287,50 @@ class GlibcHeapChunkCommand(GenericCommand):
             gef_print(current_chunk.psprint())
         return
 
+class GlibcHeapChunkSummary:
+    def __init__(self):
+        self.count = 0
+        self.total_size = 0
+
+    def process_chunk(self, chunk: GlibcChunk) -> None:
+        self.count += 1
+        self.total_size += chunk.size
+
+class GlibcHeapArenaSummary:
+    def __init__(self) -> None:
+        self.size_distribution = {}
+        self.flag_distribution = {
+            "PREV_INUSE": GlibcHeapChunkSummary(),
+            "IS_MMAPPED": GlibcHeapChunkSummary(),
+            "NON_MAIN_ARENA": GlibcHeapChunkSummary()
+        }
+
+    def process_chunk(self, chunk: GlibcChunk) -> None:
+        per_size_summary = self.size_distribution.get(chunk.size, None)
+        if per_size_summary is None:
+            per_size_summary = GlibcHeapChunkSummary()
+            self.size_distribution[chunk.size] = per_size_summary
+        per_size_summary.process_chunk(chunk)
+
+        if chunk.has_p_bit():
+            self.flag_distribution["PREV_INUSE"].process_chunk(chunk)
+        if chunk.has_m_bit():
+            self.flag_distribution["IS_MAPPED"].process_chunk(chunk)
+        if chunk.has_n_bit():
+            self.flag_distribution["NON_MAIN_ARENA"].process_chunk(chunk)
+
+    def print(self) -> None:
+        gef_print(f"== Chunk distribution by size ==")
+        gef_print("{:<10s}\t{:<10s}\t{:s}".format("ChunkSize", "Count", "TotalSize"))
+        for chunk_size, chunk_summary in sorted(self.size_distribution.items(), key=lambda x: x[1].total_size, reverse=True):
+            gef_print("{:<10d}\t{:<10d}\t{:<d}".format(chunk_size, chunk_summary.count, chunk_summary.total_size))
+
+        gef_print(f"\n== Chunk distribution by flag ==")
+        gef_print("{:<15s}\t{:<10s}\t{:s}".format("Flag", "TotalCount", "TotalSize"))
+        for chunk_flag, chunk_summary in self.flag_distribution.items():
+            gef_print("{:<15s}\t{:<10d}\t{:<d}".format(chunk_flag, chunk_summary.count, chunk_summary.total_size))
+
+        gef_print("")
 
 @register
 class GlibcHeapChunksCommand(GenericCommand):
@@ -6293,7 +6338,7 @@ class GlibcHeapChunksCommand(GenericCommand):
     the base address of a different arena can be passed"""
 
     _cmdline_ = "heap chunks"
-    _syntax_  = f"{_cmdline_} [-h] [--all] [--allow-unaligned] [arena_address]"
+    _syntax_  = f"{_cmdline_} [-h] [--all] [--allow-unaligned] [--summary] [arena_address]"
     _example_ = (f"\n{_cmdline_}"
                  f"\n{_cmdline_} 0x555555775000")
 
@@ -6302,24 +6347,24 @@ class GlibcHeapChunksCommand(GenericCommand):
         self["peek_nb_byte"] = (16, "Hexdump N first byte(s) inside the chunk data (0 to disable)")
         return
 
-    @parse_arguments({"arena_address": ""}, {("--all", "-a"): True, "--allow-unaligned": True})
+    @parse_arguments({"arena_address": ""}, {("--all", "-a"): True, "--allow-unaligned": True, ("--summary", "-s"): True})
     @only_if_gdb_running
     def do_invoke(self, _: List[str], **kwargs: Any) -> None:
         args = kwargs["arguments"]
         if args.all or not args.arena_address:
             for arena in gef.heap.arenas:
-                self.dump_chunks_arena(arena, print_arena=args.all, allow_unaligned=args.allow_unaligned)
+                self.dump_chunks_arena(arena, print_arena=args.all, allow_unaligned=args.allow_unaligned, summary=args.summary)
                 if not args.all:
                     return
         try:
             arena_addr = parse_address(args.arena_address)
             arena = GlibcArena(f"*{arena_addr:#x}")
-            self.dump_chunks_arena(arena, allow_unaligned=args.allow_unaligned)
+            self.dump_chunks_arena(arena, allow_unaligned=args.allow_unaligned, summary=args.summary)
         except gdb.error:
             err("Invalid arena")
             return
 
-    def dump_chunks_arena(self, arena: GlibcArena, print_arena: bool = False, allow_unaligned: bool = False) -> None:
+    def dump_chunks_arena(self, arena: GlibcArena, print_arena: bool = False, allow_unaligned: bool = False, summary: bool = False) -> None:
         heap_addr = arena.heap_addr(allow_unaligned=allow_unaligned)
         if heap_addr is None:
             err("Could not find heap for arena")
@@ -6328,31 +6373,45 @@ class GlibcHeapChunksCommand(GenericCommand):
             gef_print(str(arena))
         if arena.is_main_arena():
             heap_end = arena.top + GlibcChunk(arena.top, from_base=True).size
-            self.dump_chunks_heap(heap_addr, heap_end, arena, allow_unaligned=allow_unaligned)
+            self.dump_chunks_heap(heap_addr, heap_end, arena, allow_unaligned=allow_unaligned, summary=summary)
         else:
             heap_info_structs = arena.get_heap_info_list() or []
             for heap_info in heap_info_structs:
-                if not self.dump_chunks_heap(heap_info.heap_start, heap_info.heap_end, arena, allow_unaligned=allow_unaligned):
+                if not self.dump_chunks_heap(heap_info.heap_start, heap_info.heap_end, arena, allow_unaligned=allow_unaligned, summary=summary):
                     break
         return
 
-    def dump_chunks_heap(self, start: int, end: int, arena: GlibcArena, allow_unaligned: bool = False) -> bool:
+    def dump_chunks_heap(self, start: int, end: int, arena: GlibcArena, allow_unaligned: bool = False, summary: bool = False) -> bool:
         nb = self["peek_nb_byte"]
         chunk_iterator = GlibcChunk(start, from_base=True, allow_unaligned=allow_unaligned)
+        heap_summary = GlibcHeapArenaSummary()
         for chunk in chunk_iterator:
-            if chunk.base_address == arena.top:
-                gef_print(
-                    f"{chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
-                break
+            is_heap_corrupted = chunk.base_address > end
 
-            if chunk.base_address > end:
-                err("Corrupted heap, cannot continue.")
-                return False
+            if summary:
+                if is_heap_corrupted:
+                    err("Corrupted heap, cannot continue.")
+                    return False
 
-            line = str(chunk)
-            if nb:
-                line += f"\n    [{hexdump(gef.memory.read(chunk.data_address, nb), nb, base=chunk.data_address)}]"
-            gef_print(line)
+                heap_summary.process_chunk(chunk)
+            else:
+                if chunk.base_address == arena.top:
+                    gef_print(
+                        f"{chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
+                    break
+
+                if is_heap_corrupted:
+                    err("Corrupted heap, cannot continue.")
+                    return False
+
+                line = str(chunk)
+                if nb:
+                    line += f"\n    [{hexdump(gef.memory.read(chunk.data_address, nb), nb, base=chunk.data_address)}]"
+                gef_print(line)
+
+        if summary:
+            heap_summary.print()
+
         return True
 
 

--- a/gef.py
+++ b/gef.py
@@ -6389,22 +6389,19 @@ class GlibcHeapChunksCommand(GenericCommand):
         for chunk in chunk_iterator:
             heap_corrupted = chunk.base_address > end
 
-            if summary:
-                if heap_corrupted:
-                    err("Corrupted heap, cannot continue.")
-                    return False
-
-                heap_summary.process_chunk(chunk)
-            else:
+            if not summary:
                 if chunk.base_address == arena.top:
                     gef_print(
                         f"{chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
                     break
 
-                if heap_corrupted:
-                    err("Corrupted heap, cannot continue.")
-                    return False
+            if heap_corrupted:
+                err("Corrupted heap, cannot continue.")
+                return False
 
+            if summary:
+                heap_summary.process_chunk(chunk)
+            else:
                 line = str(chunk)
                 if nb:
                     line += f"\n    [{hexdump(gef.memory.read(chunk.data_address, nb), nb, base=chunk.data_address)}]"

--- a/tests/commands/heap.py
+++ b/tests/commands/heap.py
@@ -94,6 +94,14 @@ class HeapCommand(GefUnitTestGeneric):
         self.assertIn("Chunk(addr=", res)
         self.assertIn("top chunk", res)
 
+    def test_cmd_heap_chunks_summary(self):
+        cmd = "heap chunks --summary"
+        target = _target("heap")
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertIn("== Chunk distribution by size", res)
+        self.assertIn("== Chunk distribution by flag", res)
 
     def test_cmd_heap_bins_fast(self):
         cmd = "heap bins fast"


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->

This change adds 2 things:
1. When listing the arenas, it shows the memory usage and peak memory usage
2. It adds `--summary` option to `heap chunks` command. Instead of dumping all chunks, it dumps the summary of all the chunks, grouped by size and flags.

<!-- Why is this change required? What problem does it solve? -->

This helps us to get a high level of the distribution of the objects on the heap, which helps debugging memory issues.


<!-- Why is this patch will make a better world? -->


For example, this is one of our recent memory analysis:

1. With memory usage showing in the arena list, we immediately know the main arena is causing the problem here.

    ```
    gef➤  heap arenas
    Arena(base=0x7f5b3ebd1b80, top=0x55f4c0a36d60, last_remainder=0x55f47c4147a0, next=0x7f5b08000020, mem=1274572800, mempeak=2359623680)
    Arena(base=0x7f5b08000020, top=0x7f5b08051260, last_remainder=0x7f5b08017030, next=0x7f5b10000020, mem=1966080, mempeak=1966080)
    ...
    ```

2. With `--summary` options, we immediately know that some huge chunks are the ones causing the problem, and none of them are mmap.

    ```
    gef➤  heap chunks --summary
    == Chunk distribution by size ==
    ChunkSize       Count           TotalSize
    273520528       1               273520528
    203880320       1               203880320
    127695760       1               127695760
    85921744        1               85921744
    71068752        1               71068752
    ...

    == Chunk distribution by flag ==
    Flag            TotalCount      TotalSize
    PREV_INUSE      105702          1270695520
    IS_MMAPPED      0               0
    NON_MAIN_ARENA  0               0
    ```

<!-- How does this look? Add a screenshot if you can -->

Here are the screenshots as proof.

Arena list:
![image](https://github.com/hugsy/gef/assets/1533278/9737b828-9a5b-41d4-bffa-07d5e46f7998)

Heap summary:
![image](https://github.com/hugsy/gef/assets/1533278/f405a482-d8af-41ea-9317-2235f46f487d)

![image](https://github.com/hugsy/gef/assets/1533278/afc4d39d-f0c5-4130-bcf4-e99090cb948e)

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [X] My change includes a change to the documentation, if required.
-  [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.
