### PR TITLE
Add min-size and max-size filter to heap chunks command

### DIFF
--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -77,6 +77,8 @@ Heap chunk command also supports filtering chunks by their size. To do so, simpl
 gef➤ heap chunks --min-size 16 --max-size 32
 ```
 
+![heap-chunks-size-filter](https://i.imgur.com/AWuCvFK.png)
+
 The range is inclusive, so the above command will display all chunks with a size >=16 and <=32.
 
 ### `heap chunk` command

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -74,6 +74,8 @@ Heap chunk command also supports filtering chunks by their size. To do so, simpl
 `--min-size` or `--max-size` argument:
 
 ```text
+gef➤ heap chunks --min-size 16
+gef➤ heap chunks --max-size 32
 gef➤ heap chunks --min-size 16 --max-size 32
 ```
 

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -74,14 +74,12 @@ Heap chunk command also supports filtering chunks by their size. To do so, simpl
 `--min-size` or `--max-size` argument:
 
 ```text
-gef➤ heap chunks --min-size 16
-gef➤ heap chunks --max-size 32
 gef➤ heap chunks --min-size 16 --max-size 32
 ```
 
 ![heap-chunks-size-filter](https://i.imgur.com/AWuCvFK.png)
 
-The range is inclusive, so the above command will display all chunks with a size >=16 and <=32.
+The range is inclusive, so the above command will display all chunks with size >=16 and <=32.
 
 ### `heap chunk` command
 

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -70,6 +70,15 @@ gef➤ heap chunks --summary
 
 ![heap-chunks-summary](https://i.imgur.com/3HTgtwX.png)
 
+Heap chunk command also supports filtering chunks by their size. To do so, simply provide the
+`--min-size` or `--max-size` argument:
+
+```text
+gef➤ heap chunks --min-size 16 --max-size 32
+```
+
+The range is inclusive, so the above command will display all chunks with a size >=16 and <=32.
+
 ### `heap chunk` command
 
 This command gives visual information of a Glibc malloc-ed chunked. Simply provide the address to

--- a/gef.py
+++ b/gef.py
@@ -6365,13 +6365,13 @@ class GlibcHeapChunksCommand(GenericCommand):
         args = kwargs["arguments"]
         if args.all or not args.arena_address:
             for arena in gef.heap.arenas:
-                self.dump_chunks_arena(arena, print_arena=args.all, allow_unaligned=args.allow_unaligned, summary=args.summary)
+                self.dump_chunks_arena(arena, print_arena=args.all, allow_unaligned=args.allow_unaligned, min_size=args.min_size, max_size=args.max_size, summary=args.summary)
                 if not args.all:
                     return
         try:
             arena_addr = parse_address(args.arena_address)
             arena = GlibcArena(f"*{arena_addr:#x}")
-            self.dump_chunks_arena(arena, allow_unaligned=args.allow_unaligned, summary=args.summary)
+            self.dump_chunks_arena(arena, allow_unaligned=args.allow_unaligned, min_size=args.min_size, max_size=args.max_size, summary=args.summary)
         except gdb.error:
             err("Invalid arena")
             return
@@ -6385,11 +6385,11 @@ class GlibcHeapChunksCommand(GenericCommand):
             gef_print(str(arena))
         if arena.is_main_arena():
             heap_end = arena.top + GlibcChunk(arena.top, from_base=True).size
-            self.dump_chunks_heap(heap_addr, heap_end, arena, allow_unaligned=allow_unaligned, summary=summary)
+            self.dump_chunks_heap(heap_addr, heap_end, arena, allow_unaligned=allow_unaligned, min_size=min_size, max_size=max_size, summary=summary)
         else:
             heap_info_structs = arena.get_heap_info_list() or []
             for heap_info in heap_info_structs:
-                if not self.dump_chunks_heap(heap_info.heap_start, heap_info.heap_end, arena, allow_unaligned=allow_unaligned, summary=summary):
+                if not self.dump_chunks_heap(heap_info.heap_start, heap_info.heap_end, arena, allow_unaligned=allow_unaligned, min_size=min_size, max_size=max_size, summary=summary):
                     break
         return
 

--- a/gef.py
+++ b/gef.py
@@ -6411,7 +6411,7 @@ class GlibcHeapChunksCommand(GenericCommand):
             if heap_corrupted:
                 err("Corrupted heap, cannot continue.")
                 return False
-            
+
             if not should_process:
                 continue
 
@@ -6431,7 +6431,7 @@ class GlibcHeapChunksCommand(GenericCommand):
     def should_process_chunk(self, chunk: GlibcChunk, min_size: int, max_size: int) -> bool:
         if chunk.size < min_size:
             return False
-        
+
         if max_size > 0 and chunk.size > max_size:
             return False
 

--- a/gef.py
+++ b/gef.py
@@ -6399,21 +6399,20 @@ class GlibcHeapChunksCommand(GenericCommand):
         heap_summary = GlibcHeapArenaSummary()
         for chunk in chunk_iterator:
             heap_corrupted = chunk.base_address > end
+            should_process = self.should_process_chunk(chunk, min_size, max_size)
 
             if not summary:
                 if chunk.base_address == arena.top:
-                    gef_print(
-                        f"{chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
+                    if should_process:
+                        gef_print(
+                            f"{chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
                     break
 
             if heap_corrupted:
                 err("Corrupted heap, cannot continue.")
                 return False
-
-            if chunk.size < min_size:
-                continue
-
-            if max_size > 0 and chunk.size > max_size:
+            
+            if not should_process:
                 continue
 
             if summary:
@@ -6426,6 +6425,15 @@ class GlibcHeapChunksCommand(GenericCommand):
 
         if summary:
             heap_summary.print()
+
+        return True
+
+    def should_process_chunk(self, chunk: GlibcChunk, min_size: int, max_size: int) -> bool:
+        if chunk.size < min_size:
+            return False
+        
+        if max_size > 0 and chunk.size > max_size:
+            return False
 
         return True
 

--- a/gef.py
+++ b/gef.py
@@ -6401,12 +6401,11 @@ class GlibcHeapChunksCommand(GenericCommand):
             heap_corrupted = chunk.base_address > end
             should_process = self.should_process_chunk(chunk, min_size, max_size)
 
-            if not summary:
-                if chunk.base_address == arena.top:
-                    if should_process:
-                        gef_print(
-                            f"{chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
-                    break
+            if not summary and chunk.base_address == arena.top:
+                if should_process:
+                    gef_print(
+                        f"{chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
+                break
 
             if heap_corrupted:
                 err("Corrupted heap, cannot continue.")
@@ -6432,7 +6431,7 @@ class GlibcHeapChunksCommand(GenericCommand):
         if chunk.size < min_size:
             return False
 
-        if max_size > 0 and chunk.size > max_size:
+        if 0 < max_size < chunk.size:
             return False
 
         return True

--- a/tests/commands/heap.py
+++ b/tests/commands/heap.py
@@ -103,6 +103,22 @@ class HeapCommand(GefUnitTestGeneric):
         self.assertIn("== Chunk distribution by size", res)
         self.assertIn("== Chunk distribution by flag", res)
 
+    def test_cmd_heap_chunks_min_size_filter(self):
+        cmd = "heap chunks --min-size 16"
+        target = _target("heap")
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertIn("Chunk(addr=", res)
+
+    def test_cmd_heap_chunks_max_size_filter(self):
+        cmd = "heap chunks --max-size 32"
+        target = _target("heap")
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertIn("Chunk(addr=", res)
+
     def test_cmd_heap_bins_fast(self):
         cmd = "heap bins fast"
         before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]

--- a/tests/commands/heap.py
+++ b/tests/commands/heap.py
@@ -112,7 +112,7 @@ class HeapCommand(GefUnitTestGeneric):
         self.assertIn("Chunk(addr=", res)
 
     def test_cmd_heap_chunks_max_size_filter(self):
-        cmd = "heap chunks --max-size 32"
+        cmd = "heap chunks --max-size 160"
         target = _target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)

--- a/tests/commands/heap.py
+++ b/tests/commands/heap.py
@@ -111,6 +111,13 @@ class HeapCommand(GefUnitTestGeneric):
         self.assertNoException(res)
         self.assertIn("Chunk(addr=", res)
 
+        cmd = "heap chunks --min-size 1048576"
+        target = _target("heap")
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertNotIn("Chunk(addr=", res)
+
     def test_cmd_heap_chunks_max_size_filter(self):
         cmd = "heap chunks --max-size 160"
         target = _target("heap")
@@ -118,6 +125,13 @@ class HeapCommand(GefUnitTestGeneric):
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn("Chunk(addr=", res)
+
+        cmd = "heap chunks --max-size 16"
+        target = _target("heap")
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertNotIn("Chunk(addr=", res)
 
     def test_cmd_heap_bins_fast(self):
         cmd = "heap bins fast"


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->
This change adds `--min-size` and `--max-size` filter to heap chunks command.

<!-- Why is this change required? What problem does it solve? -->
With heap summary, we can quickly use `--min-size` and `--max-size` filter to find some sample chunks for further analysis. 

<!-- Why is this patch will make a better world? -->

<!-- How does this look? Add a screenshot if you can -->
Here are the screenshots as demo:
![image](https://github.com/hugsy/gef/assets/1533278/c266caff-d7bb-4f4a-93aa-da48f3d59e92)

![image](https://github.com/hugsy/gef/assets/1533278/b4a6ccae-1716-4c11-9b48-7e4c2e589bd4)

![image](https://github.com/hugsy/gef/assets/1533278/2ec06074-6d51-4c13-bda6-ef0c5f60d729)


<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [X] My change includes a change to the documentation, if required.
-  [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.
