### PR TITLE
Fix clear-screen timing when showing context

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7379,6 +7379,9 @@ class ContextCommand(GenericCommand):
         if redirect and os.access(redirect, os.W_OK):
             enable_redirect_output(to_file=redirect)
 
+        if self["clear_screen"] and len(argv) == 0:
+            clear_screen(redirect)
+
         for section in current_layout:
             if section[0] == "-":
                 continue
@@ -7399,9 +7402,6 @@ class ContextCommand(GenericCommand):
                 pass
 
         self.context_title("")
-
-        if self["clear_screen"] and len(argv) == 0:
-            clear_screen(redirect)
 
         if redirect and os.access(redirect, os.W_OK):
             disable_redirect_output()


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->

The change is to fix the timing of clearing the screen for showing debugging context.

<!-- Why is this change required? What problem does it solve? -->

According to doc, when enabled, before showing the debugging context, screen will be cleaned.

```
Clear the screen before showing the context sections when breaking:
gef➤ gef config context.clear_screen 1
```

This is helpful to keep the debug experience focused, but the timing seems to be broken with the current code.

Currently, clearing screen will happen after all contexts are shown. Hence, whenever a breakpoint is hit, all contexts will be off the screen leaving only the input prompt as screenshot shows below.

The screenshot here shows the screen output after a breakpoint it hit:
![image](https://github.com/hugsy/gef/assets/1533278/add83a36-1ca4-4a97-95c6-a82c032e5541)


<!-- Why is this patch will make a better world? -->

This change moves the clear screen to the time before showing the context, hence fixing the problem.

<!-- How does this look? Add a screenshot if you can -->

Here is the screenshot after the fix:
![image](https://github.com/hugsy/gef/assets/1533278/7ee33bca-6570-404f-86ae-491fddacb315)


<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [ ] My change includes a change to the documentation, if required.
-  [ ] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.
