### PR TITLE
Add config to override libc version.

### DIFF
--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -30,6 +30,14 @@ gef➤ gef config gef.bruteforce_main_arena True
 Note that this might take a few seconds to complete. If GEF does find the symbol you can then
 calculate the offset to the libc base address and save it in the config.
 
+Sometimes, the dump might not contain proper info to help GEF find the libc version, which results in
+failure to parse the arena information. In this case, you can try to force GEF to use a specific libc
+version with the following command:
+
+```text
+gef➤ gef config gef.libc_version 2.31
+```
+
 ### `heap chunks` command
 
 Displays all the chunks from the `heap` section of the current arena.

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -31,8 +31,8 @@ Note that this might take a few seconds to complete. If GEF does find the symbol
 calculate the offset to the libc base address and save it in the config.
 
 Sometimes, the dump might not contain proper info to help GEF find the libc version, which results in
-failure to parse the arena information. In this case, you can try to force GEF to use a specific libc
-version with the following command:
+failure to parse the arena information. In this case, you can try to provide GEF a specific libc
+version to use with the following command:
 
 ```text
 gef➤ gef config gef.libc_version 2.31

--- a/gef.py
+++ b/gef.py
@@ -9587,6 +9587,7 @@ class GefCommand(gdb.Command):
         gef.config["gef.show_deprecation_warnings"] = GefSetting(True, bool, "Toggle the display of the `deprecated` warnings")
         gef.config["gef.buffer"] = GefSetting(True, bool, "Internally buffer command output until completion")
         gef.config["gef.bruteforce_main_arena"] = GefSetting(False, bool, "Allow bruteforcing main_arena symbol if everything else fails")
+        gef.config["gef.libc_ver"] = GefSetting("", str, "Override the auto-detection of libc version")
         gef.config["gef.main_arena_offset"] = GefSetting("", str, "Offset from libc base address to main_arena symbol (int or hex). Set to empty string to disable.")
 
         self.commands : Dict[str, GenericCommand] = collections.OrderedDict()
@@ -11166,6 +11167,8 @@ class GefLibcManager(GefManager):
     def version(self) -> Optional[Tuple[int, int]]:
         if not is_alive():
             return None
+        if gef.config["gef.libc_ver"] != "":
+            return tuple([int(v) for v in gef.config["gef.libc_ver"].split(".")])
         if not self._version:
             self._version = GefLibcManager.find_libc_version()
         return self._version

--- a/gef.py
+++ b/gef.py
@@ -9587,7 +9587,7 @@ class GefCommand(gdb.Command):
         gef.config["gef.show_deprecation_warnings"] = GefSetting(True, bool, "Toggle the display of the `deprecated` warnings")
         gef.config["gef.buffer"] = GefSetting(True, bool, "Internally buffer command output until completion")
         gef.config["gef.bruteforce_main_arena"] = GefSetting(False, bool, "Allow bruteforcing main_arena symbol if everything else fails")
-        gef.config["gef.libc_ver"] = GefSetting("", str, "Override the auto-detection of libc version")
+        gef.config["gef.libc_version"] = GefSetting("", str, "Override the auto-detection of libc version")
         gef.config["gef.main_arena_offset"] = GefSetting("", str, "Offset from libc base address to main_arena symbol (int or hex). Set to empty string to disable.")
 
         self.commands : Dict[str, GenericCommand] = collections.OrderedDict()
@@ -11167,8 +11167,8 @@ class GefLibcManager(GefManager):
     def version(self) -> Optional[Tuple[int, int]]:
         if not is_alive():
             return None
-        if gef.config["gef.libc_ver"] != "":
-            return tuple([int(v) for v in gef.config["gef.libc_ver"].split(".")])
+        if gef.config["gef.libc_version"] != "":
+            return tuple([int(v) for v in gef.config["gef.libc_version"].split(".")])
         if not self._version:
             self._version = GefLibcManager.find_libc_version()
         return self._version

--- a/gef.py
+++ b/gef.py
@@ -11170,7 +11170,7 @@ class GefLibcManager(GefManager):
 
         if not self._version:
             self._version = GefLibcManager.find_libc_version()
-        
+
         # Whenever auto-detection fails, we use the user-provided version.
         if self._version == (0, 0) and gef.config["gef.libc_version"] != "":
             return tuple([int(v) for v in gef.config["gef.libc_version"].split(".")])

--- a/gef.py
+++ b/gef.py
@@ -9587,7 +9587,7 @@ class GefCommand(gdb.Command):
         gef.config["gef.show_deprecation_warnings"] = GefSetting(True, bool, "Toggle the display of the `deprecated` warnings")
         gef.config["gef.buffer"] = GefSetting(True, bool, "Internally buffer command output until completion")
         gef.config["gef.bruteforce_main_arena"] = GefSetting(False, bool, "Allow bruteforcing main_arena symbol if everything else fails")
-        gef.config["gef.libc_version"] = GefSetting("", str, "Override the auto-detection of libc version")
+        gef.config["gef.libc_version"] = GefSetting("", str, "Specify libc version when auto-detection fails")
         gef.config["gef.main_arena_offset"] = GefSetting("", str, "Offset from libc base address to main_arena symbol (int or hex). Set to empty string to disable.")
 
         self.commands : Dict[str, GenericCommand] = collections.OrderedDict()
@@ -11167,10 +11167,14 @@ class GefLibcManager(GefManager):
     def version(self) -> Optional[Tuple[int, int]]:
         if not is_alive():
             return None
-        if gef.config["gef.libc_version"] != "":
-            return tuple([int(v) for v in gef.config["gef.libc_version"].split(".")])
+
         if not self._version:
             self._version = GefLibcManager.find_libc_version()
+        
+        # Whenever auto-detection fails, we use the user-provided version.
+        if self._version == (0, 0) and gef.config["gef.libc_version"] != "":
+            return tuple([int(v) for v in gef.config["gef.libc_version"].split(".")])
+
         return self._version
 
     @staticmethod

--- a/tests/config/__init__.py
+++ b/tests/config/__init__.py
@@ -69,4 +69,3 @@ class TestGefConfigUnit(GefUnitTestGeneric):
         res = gdb_start_silent_cmd("python print(gef.libc.version)", before=["gef config gef.libc_version 2.31"])
         self.assertNoException(res)
         self.assertNotIn("[!]", res)
-        self.assertIn('(2, 31)', res)

--- a/tests/config/__init__.py
+++ b/tests/config/__init__.py
@@ -49,3 +49,19 @@ class TestGefConfigUnit(GefUnitTestGeneric):
         res = gdb_run_cmd("gef config gef.debug 0")
         self.assertNoException(res)
         self.assertNotIn("[!]", res)
+
+    def test_config_libc_version(self):
+        """Check setting libc version."""
+        res = gdb_run_cmd("gef config gef.libc_version")
+        self.assertNoException(res)
+        self.assertNotIn("[!]", res)
+
+        res = gdb_run_cmd("gef config gef.libc_version", before=["gef config gef.libc_version 2.31"])
+        self.assertNoException(res)
+        self.assertNotIn("[!]", res)
+        self.assertIn('gef.libc_version (str) = "2.31"', res)
+
+        res = gdb_run_cmd("gef config gef.libc_version", before=["gef config gef.libc_version 2.31", "gef config gef.libc_version ''"])
+        self.assertNoException(res)
+        self.assertNotIn("[!]", res)
+        self.assertIn('gef.libc_version (str) = ""', res)

--- a/tests/config/__init__.py
+++ b/tests/config/__init__.py
@@ -2,7 +2,7 @@
 Test GEF configuration parameters.
 """
 
-from tests.utils import gdb_run_cmd
+from tests.utils import gdb_run_cmd, gdb_start_silent_cmd
 from tests.utils import GefUnitTestGeneric
 
 
@@ -65,3 +65,8 @@ class TestGefConfigUnit(GefUnitTestGeneric):
         self.assertNoException(res)
         self.assertNotIn("[!]", res)
         self.assertIn('gef.libc_version (str) = ""', res)
+
+        res = gdb_start_silent_cmd("python print(gef.libc.version)", before=["gef config gef.libc_version 2.31"])
+        self.assertNoException(res)
+        self.assertNotIn("[!]", res)
+        self.assertIn('(2, 31)', res)


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->

This change add a config for force the libc version to a specific version.

<!-- Why is this change required? What problem does it solve? -->

This is helpful when debugging certain core dumps that doesn't have good memory map information, and could not find libc properly.

This shows up in our recent debugging, where we know the program is using libc 2.31, but it could not be detected properly due to memory map information missing.

The screenshot below shows the libc version missing problem, which results failures when dumping the heap:

- libc version missing:

  ![image](https://github.com/hugsy/gef/assets/1533278/6c5e58e8-39b9-4dfd-ac7e-6784ab0d4ce1)

- having trouble dump heap arenas (see top == 0, while arena pointer is right):

  ![image](https://github.com/hugsy/gef/assets/1533278/fcaf5269-04d0-43e7-87c1-eea4825e6a88)

<!-- Why is this patch will make a better world? -->

This change allows us to force the libc version into a specific version, which solves this problem.

<!-- How does this look? Add a screenshot if you can -->

Here is the screenshots that demos the fix:

![image](https://github.com/hugsy/gef/assets/1533278/0b7be845-90c1-4ec3-989d-e7865446f432)

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.
