### PR TITLE
Add count option in heap chunks command to limit the number of chunks to process / output.

### DIFF
--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -98,7 +98,9 @@ gef➤ heap chunks --min-size 16 --max-size 32
 
 ![heap-chunks-size-filter](https://i.imgur.com/AWuCvFK.png)
 
-If heap chunks command gives too many chunks, we can use `--count` argument to limit the number
+The range is inclusive, so the above command will display all chunks with size >=16 and <=32.
+
+If heap chunks command still gives too many chunks, we can use `--count` argument to limit the number
 of the chunks in the output:
 
 ```text
@@ -106,8 +108,6 @@ gef➤ heap chunks --count 1
 ```
 
 ![heap-chunks-size-filter](https://i.imgur.com/EinuDAt.png)
-
-The range is inclusive, so the above command will display all chunks with size >=16 and <=32.
 
 ### `heap chunk` command
 

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -98,6 +98,15 @@ gef➤ heap chunks --min-size 16 --max-size 32
 
 ![heap-chunks-size-filter](https://i.imgur.com/AWuCvFK.png)
 
+If heap chunks command gives too many chunks, we can use `--count` argument to limit the number
+of the chunks in the output:
+
+```text
+gef➤ heap chunks --count 1
+```
+
+![heap-chunks-size-filter](https://i.imgur.com/EinuDAt.png)
+
 The range is inclusive, so the above command will display all chunks with size >=16 and <=32.
 
 ### `heap chunk` command

--- a/gef.py
+++ b/gef.py
@@ -6358,12 +6358,12 @@ class GlibcHeapArenaSummary:
             gef_print("{:<15s}\t{:<10d}\t{:<d}".format(chunk_flag, chunk_summary.count, chunk_summary.total_bytes))
 
 class GlibcHeapWalkContext:
-    def __init__(self, args: Any) -> None:
-        self.min_size = args.min_size
-        self.max_size = args.max_size
-        self.remaining_chunk_count = args.count
-        self.summary = args.summary
-        self.resolve_type = args.resolve
+    def __init__(self, min_size: int = 0, max_size: int = 0, count: int = -1, resolve_type: bool = False, summary: bool = False) -> None:
+        self.min_size = min_size
+        self.max_size = max_size
+        self.remaining_chunk_count = count
+        self.summary = summary
+        self.resolve_type = resolve_type
 
 @register
 class GlibcHeapChunksCommand(GenericCommand):
@@ -6384,7 +6384,7 @@ class GlibcHeapChunksCommand(GenericCommand):
     @only_if_gdb_running
     def do_invoke(self, _: List[str], **kwargs: Any) -> None:
         args = kwargs["arguments"]
-        ctx = GlibcHeapWalkContext(args)
+        ctx = GlibcHeapWalkContext(min_size=args.min_size, max_size=args.max_size, count=args.count, resolve_type=args.resolve, summary=args.summary)
         if args.all or not args.arena_address:
             for arena in gef.heap.arenas:
                 self.dump_chunks_arena(arena, print_arena=args.all, allow_unaligned=args.allow_unaligned, ctx=ctx)
@@ -6398,7 +6398,7 @@ class GlibcHeapChunksCommand(GenericCommand):
             err("Invalid arena")
             return
 
-    def dump_chunks_arena(self, arena: GlibcArena, print_arena: bool = False, allow_unaligned: bool = False, ctx: GlibcHeapWalkContext = None) -> None:
+    def dump_chunks_arena(self, arena: GlibcArena, print_arena: bool = False, allow_unaligned: bool = False, ctx: GlibcHeapWalkContext = GlibcHeapWalkContext()) -> None:
         heap_addr = arena.heap_addr(allow_unaligned=allow_unaligned)
         if heap_addr is None:
             err("Could not find heap for arena")
@@ -6415,7 +6415,7 @@ class GlibcHeapChunksCommand(GenericCommand):
                     break
         return
 
-    def dump_chunks_heap(self, start: int, end: int, arena: GlibcArena, allow_unaligned: bool = False, ctx: GlibcHeapWalkContext = None) -> bool:
+    def dump_chunks_heap(self, start: int, end: int, arena: GlibcArena, allow_unaligned: bool = False, ctx: GlibcHeapWalkContext = GlibcHeapWalkContext()) -> bool:
         nb = self["peek_nb_byte"]
         chunk_iterator = GlibcChunk(start, from_base=True, allow_unaligned=allow_unaligned)
         heap_summary = GlibcHeapArenaSummary(resolve_type=ctx.resolve_type)

--- a/tests/commands/heap.py
+++ b/tests/commands/heap.py
@@ -141,6 +141,21 @@ class HeapCommand(GefUnitTestGeneric):
         self.assertNoException(res)
         self.assertNotIn("Chunk(addr=", res)
 
+    def test_cmd_heap_chunks_with_count(self):
+        cmd = "heap chunks --count 1"
+        target = _target("heap")
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertIn("Chunk(addr=", res)
+
+        cmd = "heap chunks --count 0"
+        target = _target("heap")
+        self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
+        res = gdb_run_silent_cmd(cmd, target=target)
+        self.assertNoException(res)
+        self.assertNotIn("Chunk(addr=", res)
+
     def test_cmd_heap_bins_fast(self):
         cmd = "heap bins fast"
         before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]

--- a/tests/commands/heap.py
+++ b/tests/commands/heap.py
@@ -143,14 +143,14 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_chunks_with_count(self):
         cmd = "heap chunks --count 1"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn("Chunk(addr=", res)
 
         cmd = "heap chunks --count 0"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->

This change add `--count` option in heap chunks command to limit the number of chunks to process / output.

<!-- Why is this change required? What problem does it solve? -->

Currently, since we don't have the count limit, even with the size filter, we might get too many chunks in the output, especially when debugging large dumps.

<!-- Why is this patch will make a better world? -->

With this change, we can use `--count` option to give us only a few samples to check what might be happening, e.g. large buffers with certain special size.

<!-- How does this look? Add a screenshot if you can -->

Here is the screenshot that demos the usage (mixed with `--min-size`)L

![image](https://github.com/hugsy/gef/assets/1533278/2825d9fe-6973-43c0-b1db-0b88963b3256)

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [X] My change includes a change to the documentation, if required.
-  [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.
