### PR TITLE
Add option to resolve type when dumping heap summary.

### DIFF
--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -70,6 +70,17 @@ gef➤ heap chunks --summary
 
 ![heap-chunks-summary](https://i.imgur.com/3HTgtwX.png)
 
+Sometimes, multiple types of objects could have the same size, hence it might not be enough only
+knowing the chunk size when debugging issues like memory leaks. GEF supports using the vtable to
+determine the type of the object stored in the chunk. To enable this feature, use `--resolve` along
+with the `--summary` flag.
+
+```text
+gef➤ heap chunks --summary --resolve
+```
+
+![heap-chunks-summary-resolve](https://i.imgur.com/2Mm0JF6.png)
+
 Heap chunk command also supports filtering chunks by their size. To do so, simply provide the
 `--min-size` or `--max-size` argument:
 

--- a/gef.py
+++ b/gef.py
@@ -1717,7 +1717,7 @@ class GlibcChunk:
             if sym is not None and "vtable for" in sym[0]:
                 return sym[0].replace("vtable for ", "")
 
-        return "<Unknown Type>"
+        return ""
 
 
 class GlibcFastChunk(GlibcChunk):

--- a/tests/commands/heap.py
+++ b/tests/commands/heap.py
@@ -103,6 +103,14 @@ class HeapCommand(GefUnitTestGeneric):
         self.assertIn("== Chunk distribution by size", res)
         self.assertIn("== Chunk distribution by flag", res)
 
+    def test_cmd_heap_chunks_summary_with_type_resolved(self):
+        cmd = "heap chunks --summary --resolve"
+        target = _target("class")
+        res = gdb_run_silent_cmd(cmd, target=target, before=["b B<TraitA, TraitB>::Run()"])
+        self.assertNoException(res)
+        self.assertIn("== Chunk distribution by size", res)
+        self.assertIn("B<TraitA, TraitB>", res)
+
     def test_cmd_heap_chunks_min_size_filter(self):
         cmd = "heap chunks --min-size 16"
         target = _target("heap")


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->

This change adds `--resolve` option to resolve the type and categorize the chunks, using vtable in the chunk. 

<!-- Why is this change required? What problem does it solve? -->

Since multiple types of objects could share the same size, also it is impossible for anyone to remember the size of all the objects in the system, categorize and output the chunks by object type will become very handy when debugging issues like memory leaks.

<!-- Why is this patch will make a better world? -->

<!-- How does this look? Add a screenshot if you can -->

Here is a screenshot to show how the change works:

![image](https://github.com/hugsy/gef/assets/1533278/b16a7cc2-dfd5-466d-b554-4d7a9d63ba6a)

In this test process, we can see we created 23423 Task objects, which pops up and might indicate a leak.

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [X] My change includes a change to the documentation, if required.
-  [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.
