### PR TITLE
Rename _target to debug_target for building test cases.

### DIFF
--- a/tests/api/gef_disasemble.py
+++ b/tests/api/gef_disasemble.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from tests.utils import ARCH, _target, gdb_run_silent_cmd
+from tests.utils import ARCH, debug_target, gdb_run_silent_cmd
 from tests.utils import GefUnitTestGeneric
 
 
@@ -14,7 +14,7 @@ class GefDisassembleApiFunction(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ("x86_64", "i686"), reason=f"Skipped for {ARCH}")
     def test_func_gef_disassemble(self):
         cmd = "gef_disassemble(0x2337100, 4, 4)"
-        res = gdb_run_silent_cmd(f"pi os.linesep.join([str(i) for i in {cmd}])", target=_target("mmap-known-address"))
+        res = gdb_run_silent_cmd(f"pi os.linesep.join([str(i) for i in {cmd}])", target=debug_target("mmap-known-address"))
         self.assertNoException(res)
         self.assertIn(
             ' 0x23370fc                  int3   \\n 0x23370fd                  int3   \\n 0x23370fe                  int3   \\n 0x23370ff                  int3   \\n 0x2337100                  int3   \\n 0x2337101                  int3   \\n 0x2337102                  int3   \\n 0x2337103                  int3   ', res)
@@ -24,7 +24,7 @@ class GefDisassembleApiFunction(GefUnitTestGeneric):
         # Regression test for issue #922
         cmd = "gef_disassemble(0x2337000, 4, 4)"
         res = gdb_run_silent_cmd(
-            f"pi os.linesep.join([str(i) for i in {cmd}])", target=_target("mmap-known-address"))
+            f"pi os.linesep.join([str(i) for i in {cmd}])", target=debug_target("mmap-known-address"))
         self.assertNoException(res)
         self.assertIn(
             '0x2337000                  int3   \\n 0x2337001                  int3   \\n 0x2337002                  int3   \\n 0x2337003                  int3   ', res)

--- a/tests/api/gef_heap.py
+++ b/tests/api/gef_heap.py
@@ -5,12 +5,12 @@
 import pytest
 import random
 
-from tests.utils import ARCH, _target, gdb_test_python_method, is_64b
+from tests.utils import ARCH, debug_target, gdb_test_python_method, is_64b
 from tests.utils import GefUnitTestGeneric
 
 
 def result_as_int(res: str) -> int:
-    return int(gdb_test_python_method(res, target=_target("heap")).splitlines()[-1])
+    return int(gdb_test_python_method(res, target=debug_target("heap")).splitlines()[-1])
 
 TCACHE_BINS = 64
 

--- a/tests/api/gef_session.py
+++ b/tests/api/gef_session.py
@@ -9,7 +9,7 @@ import subprocess
 from tests.utils import (
     TMPDIR,
     gdb_test_python_method,
-    _target,
+    debug_target,
     GefUnitTestGeneric,
     gdbserver_session,
     gdb_run_cmd,
@@ -23,24 +23,24 @@ class GefSessionApi(GefUnitTestGeneric):
     """`gef.session` test module."""
 
     def test_func_get_filepath(self):
-        res = gdb_test_python_method("gef.session.file", target=_target("default"))
+        res = gdb_test_python_method("gef.session.file", target=debug_target("default"))
         self.assertNoException(res)
         target = TMPDIR / "foo bar"
-        subprocess.call(["cp", _target("default"), target])
+        subprocess.call(["cp", debug_target("default"), target])
         res = gdb_test_python_method("gef.session.file", target=target)
         self.assertNoException(res)
         subprocess.call(["rm", target])
 
 
     def test_func_get_pid(self):
-        res = gdb_test_python_method("gef.session.pid", target=_target("default"))
+        res = gdb_test_python_method("gef.session.pid", target=debug_target("default"))
         self.assertNoException(res)
         self.assertTrue(int(res.splitlines()[-1]))
 
 
     def test_func_auxiliary_vector(self):
         func = "gef.session.auxiliary_vector"
-        res = gdb_test_python_method(func, target=_target("default"))
+        res = gdb_test_python_method(func, target=debug_target("default"))
         self.assertNoException(res)
         # we need at least ("AT_PLATFORM", "AT_EXECFN") right now
         self.assertTrue("'AT_PLATFORM'" in res)
@@ -49,7 +49,7 @@ class GefSessionApi(GefUnitTestGeneric):
 
     def test_root_dir_local(self):
         func = "(s.st_dev, s.st_ino)"
-        res = gdb_test_python_method(func, target=_target("default"), before="s=os.stat(gef.session.root)")
+        res = gdb_test_python_method(func, target=debug_target("default"), before="s=os.stat(gef.session.root)")
         self.assertNoException(res)
         st_dev, st_ino = eval(res.split("\n")[-1])
         stat_root = os.stat("/")
@@ -63,7 +63,7 @@ class GefSessionApi(GefUnitTestGeneric):
         port = random.randint(1025, 65535)
         before = [f"gef-remote {host} {port}", "pi s=os.stat(gef.session.root)"]
         with gdbserver_session(port=port):
-            res = gdb_run_cmd(f"pi {func}", target=_target("default"), before=before)
+            res = gdb_run_cmd(f"pi {func}", target=debug_target("default"), before=before)
             self.assertNoException(res)
             st_dev, st_ino = eval(res.split("\n")[-1])
             assert (stat_root.st_dev == st_dev) and (stat_root.st_ino == st_ino)
@@ -72,9 +72,9 @@ class GefSessionApi(GefUnitTestGeneric):
         host = GDBSERVER_DEFAULT_HOST
         port = random.randint(1025, 65535)
         with qemuuser_session(port=port):
-            target = _target("default")
+            target = debug_target("default")
             before = [
                 f"gef-remote --qemu-user --qemu-binary {target} {host} {port}"]
-            res = gdb_run_cmd(f"pi gef.session.root", target=_target("default"), before=before)
+            res = gdb_run_cmd(f"pi gef.session.root", target=debug_target("default"), before=before)
             self.assertNoException(res)
             assert re.search(r"\/proc\/[0-9]+/root", res)

--- a/tests/api/misc.py
+++ b/tests/api/misc.py
@@ -9,7 +9,7 @@ import os
 import pytest
 
 from tests.utils import (
-    _target,
+    debug_target,
     gdb_start_silent_cmd,
     gdb_test_python_method,
     gdb_run_cmd,
@@ -33,7 +33,7 @@ class MiscFunctionTest(GefUnitTestGeneric):
 
     def test_func_gef_convenience(self):
         func = "gef_convenience('meh')"
-        res = gdb_test_python_method(func, target=_target("default"))
+        res = gdb_test_python_method(func, target=debug_target("default"))
         self.assertNoException(res)
 
     def test_func_parse_address(self):
@@ -86,7 +86,7 @@ class MiscFunctionTest(GefUnitTestGeneric):
         # When in a gef-remote qemu-user session `parse_gdb_info_sections`
         # should work to query the memory maps
         port = GDBSERVER_DEFAULT_PORT + 2
-        target = _target("default")
+        target = debug_target("default")
         before = [
             f"gef-remote --qemu-user --qemu-binary {target} {GDBSERVER_DEFAULT_HOST} {port}"]
         with qemuuser_session(port=port) as _:

--- a/tests/commands/canary.py
+++ b/tests/commands/canary.py
@@ -3,7 +3,7 @@
 """
 
 
-from tests.utils import gdb_start_silent_cmd, gdb_run_cmd, _target, gdb_test_python_method
+from tests.utils import gdb_start_silent_cmd, gdb_run_cmd, debug_target, gdb_test_python_method
 from tests.utils import GefUnitTestGeneric
 import pytest
 import platform
@@ -16,7 +16,7 @@ class CanaryCommand(GefUnitTestGeneric):
 
     def test_cmd_canary(self):
         self.assertFailIfInactiveSession(gdb_run_cmd("canary"))
-        res = gdb_start_silent_cmd("canary", target=_target("canary"))
+        res = gdb_start_silent_cmd("canary", target=debug_target("canary"))
         self.assertNoException(res)
         self.assertIn("The canary of process", res)
         res = gdb_test_python_method("gef.session.canary[0] == gef.session.original_canary[0]")
@@ -26,6 +26,6 @@ class CanaryCommand(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH != "x86_64", reason=f"Not implemented for {ARCH}")
     def test_overwrite_canary(self):
         patch = r"pi gef.memory.write(gef.arch.canary_address(), p64(0xdeadbeef))"
-        res = gdb_start_silent_cmd(patch, target=_target("canary"), after=["canary"])
+        res = gdb_start_silent_cmd(patch, target=debug_target("canary"), after=["canary"])
         self.assertNoException(res)
         self.assertIn("0xdeadbeef", res)

--- a/tests/commands/checksec.py
+++ b/tests/commands/checksec.py
@@ -4,7 +4,7 @@ checksec command test module
 
 from tests.utils import (
     gdb_run_cmd,
-    _target,
+    debug_target,
     GefUnitTestGeneric
 )
 
@@ -17,14 +17,14 @@ class ChecksecCommand(GefUnitTestGeneric):
         res = gdb_run_cmd(cmd)
         self.assertNoException(res)
 
-        target = _target("checksec-no-canary")
+        target = debug_target("checksec-no-canary")
         res = gdb_run_cmd(cmd, target=target)
         self.assertIn("Canary                        : ✘", res)
 
-        target = _target("checksec-no-nx")
+        target = debug_target("checksec-no-nx")
         res = gdb_run_cmd(cmd, target=target)
         self.assertIn("NX                            : ✘", res)
 
-        target = _target("checksec-no-pie")
+        target = debug_target("checksec-no-pie")
         res = gdb_run_cmd(cmd, target=target)
         self.assertIn("PIE                           : ✘", res)

--- a/tests/commands/format_string_helper.py
+++ b/tests/commands/format_string_helper.py
@@ -3,7 +3,7 @@
 """
 
 
-from tests.utils import _target, gdb_run_cmd
+from tests.utils import debug_target, gdb_run_cmd
 from tests.utils import GefUnitTestGeneric
 
 
@@ -13,7 +13,7 @@ class FormatStringHelperCommand(GefUnitTestGeneric):
 
     def test_cmd_format_string_helper(self):
         cmd = "format-string-helper"
-        target = _target("format-string-helper")
+        target = debug_target("format-string-helper")
         res = gdb_run_cmd(cmd,
                           after=["set args testtest",
                                  "run",],

--- a/tests/commands/gef_remote.py
+++ b/tests/commands/gef_remote.py
@@ -5,7 +5,7 @@
 
 from tests.utils import (
     GefUnitTestGeneric,
-    _target,
+    debug_target,
     gdb_run_cmd,
     gdbserver_session,
     qemuuser_session,
@@ -31,7 +31,7 @@ class GefRemoteCommand(GefUnitTestGeneric):
 
     def test_cmd_gef_remote_qemu_user(self):
         port = GDBSERVER_DEFAULT_PORT + 2
-        target = _target("default")
+        target = debug_target("default")
         before = [
             f"gef-remote --qemu-user --qemu-binary {target} {GDBSERVER_DEFAULT_HOST} {port}"]
         with qemuuser_session(port=port) as _:

--- a/tests/commands/got.py
+++ b/tests/commands/got.py
@@ -6,7 +6,7 @@ import pytest
 
 from tests.utils import (
     ARCH,
-    _target,
+    debug_target,
     gdb_run_cmd,
     gdb_start_silent_cmd,
     GefUnitTestGeneric,
@@ -20,7 +20,7 @@ class GotCommand(GefUnitTestGeneric):
 
     def test_cmd_got(self):
         cmd = "got"
-        target = _target("format-string-helper")
+        target = debug_target("format-string-helper")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_start_silent_cmd(cmd, target=target)
         self.assertIn("printf", res)

--- a/tests/commands/heap.py
+++ b/tests/commands/heap.py
@@ -2,7 +2,7 @@
 Heap commands test module
 """
 
-from tests.utils import (ARCH, GefUnitTestGeneric, _target, findlines,
+from tests.utils import (ARCH, GefUnitTestGeneric, debug_target, findlines,
                          gdb_run_cmd, gdb_run_silent_cmd, gdb_start_silent_cmd,
                          is_32b, is_64b)
 
@@ -20,7 +20,7 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_arenas(self):
         cmd = "heap arenas"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_start_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -29,7 +29,7 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_set_arena(self):
         cmd = "heap set-arena &main_arena"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target, after=["heap arenas"])
         self.assertNoException(res)
@@ -38,7 +38,7 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_chunk_no_arg(self):
         cmd = "heap chunk p1"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -46,7 +46,7 @@ class HeapCommand(GefUnitTestGeneric):
 
 
     def test_cmd_heap_chunk_with_number(self):
-        target = _target("heap")
+        target = debug_target("heap")
         cmd = "heap chunk --number 2 p1"
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
@@ -57,7 +57,7 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_chunks(self):
         cmd = "heap chunks"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -65,7 +65,7 @@ class HeapCommand(GefUnitTestGeneric):
         self.assertIn("top chunk", res)
 
         cmd = "heap chunks"
-        target = _target("heap-non-main")
+        target = debug_target("heap-non-main")
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn("Chunk(addr=", res)
@@ -73,7 +73,7 @@ class HeapCommand(GefUnitTestGeneric):
         chunks = [line for line in res.splitlines() if "Chunk(addr=" in line]
 
         cmd = "python gdb.execute(f'heap chunks {int(list(gef.heap.arenas)[1]):#x}')"
-        target = _target("heap-non-main")
+        target = debug_target("heap-non-main")
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertNotIn("using '&main_arena' instead", res)
@@ -88,7 +88,7 @@ class HeapCommand(GefUnitTestGeneric):
         py_cmd = 'gdb.execute(f"heap set-arena {int(list(gef.heap.arenas)[1]):#x}")'
         before = ['run', 'python ' + py_cmd]
         cmd = "heap chunks"
-        target = _target("heap-multiple-heaps")
+        target = debug_target("heap-multiple-heaps")
         res = gdb_run_silent_cmd(cmd, before=before, target=target)
         self.assertNoException(res)
         self.assertIn("Chunk(addr=", res)
@@ -96,7 +96,7 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_chunks_summary(self):
         cmd = "heap chunks --summary"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -113,14 +113,14 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_chunks_min_size_filter(self):
         cmd = "heap chunks --min-size 16"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn("Chunk(addr=", res)
 
         cmd = "heap chunks --min-size 1048576"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -128,14 +128,14 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_chunks_max_size_filter(self):
         cmd = "heap chunks --max-size 160"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn("Chunk(addr=", res)
 
         cmd = "heap chunks --max-size 16"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -144,7 +144,7 @@ class HeapCommand(GefUnitTestGeneric):
     def test_cmd_heap_bins_fast(self):
         cmd = "heap bins fast"
         before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]
-        target = _target("heap-fastbins")
+        target = debug_target("heap-fastbins")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, before=before, target=target))
         res = gdb_run_silent_cmd(cmd, before=before, target=target)
         self.assertNoException(res)
@@ -155,7 +155,7 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_bins_large(self):
         cmd = "heap bins large"
-        target = _target("heap-bins")
+        target = debug_target("heap-bins")
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn("Found 1 chunks in 1 large non-empty bins", res)
@@ -166,7 +166,7 @@ class HeapCommand(GefUnitTestGeneric):
     def test_cmd_heap_bins_non_main(self):
         cmd = "python gdb.execute(f'heap bins fast {gef.heap.main_arena.next:#x}')"
         before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]
-        target = _target("heap-non-main")
+        target = debug_target("heap-non-main")
         res = gdb_run_silent_cmd(cmd, before=before, target=target)
         self.assertNoException(res)
         self.assertIn("size=0x20", res)
@@ -175,7 +175,7 @@ class HeapCommand(GefUnitTestGeneric):
     def test_cmd_heap_bins_small(self):
         cmd = "heap bins small"
         before = ["set environment GLIBC_TUNABLES glibc.malloc.tcache_count=0"]
-        target = _target("heap-bins")
+        target = debug_target("heap-bins")
         res = gdb_run_silent_cmd(cmd, before=before, target=target)
         self.assertNoException(res)
         self.assertIn("Found 1 chunks in 1 small non-empty bins", res)
@@ -185,7 +185,7 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_bins_tcache(self):
         cmd = "heap bins tcache"
-        target = _target("heap-non-main")
+        target = debug_target("heap-non-main")
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         tcachelines = findlines("Tcachebins[idx=", res)
@@ -200,7 +200,7 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_bins_tcache_all(self):
         cmd = "heap bins tcache all"
-        target = _target("heap-tcache")
+        target = debug_target("heap-tcache")
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         # ensure there's 2 tcachebins
@@ -218,7 +218,7 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_bins_unsorted(self):
         cmd = "heap bins unsorted"
-        target = _target("heap-bins")
+        target = debug_target("heap-bins")
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
         self.assertIn("Found 1 chunks in unsorted bin", res)

--- a/tests/commands/heap.py
+++ b/tests/commands/heap.py
@@ -105,7 +105,7 @@ class HeapCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_chunks_summary_with_type_resolved(self):
         cmd = "heap chunks --summary --resolve"
-        target = _target("class")
+        target = debug_target("class")
         res = gdb_run_silent_cmd(cmd, target=target, before=["b B<TraitA, TraitB>::Run()"])
         self.assertNoException(res)
         self.assertIn("== Chunk distribution by size", res)

--- a/tests/commands/heap_analysis.py
+++ b/tests/commands/heap_analysis.py
@@ -3,7 +3,7 @@
 """
 
 
-from tests.utils import _target, gdb_run_cmd, gdb_start_silent_cmd
+from tests.utils import debug_target, gdb_run_cmd, gdb_start_silent_cmd
 from tests.utils import GefUnitTestGeneric
 
 
@@ -13,7 +13,7 @@ class HeapAnalysisCommand(GefUnitTestGeneric):
 
     def test_cmd_heap_analysis(self):
         cmd = "heap-analysis-helper"
-        target = _target("heap-analysis")
+        target = debug_target("heap-analysis")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd))
         res = gdb_start_silent_cmd(cmd, after=["continue"], target=target)
         self.assertNoException(res)

--- a/tests/commands/memory.py
+++ b/tests/commands/memory.py
@@ -6,7 +6,7 @@ from tests.utils import (
     GefUnitTestGeneric,
     gdb_run_cmd,
     gdb_start_silent_cmd,
-    _target,
+    debug_target,
 )
 
 
@@ -28,7 +28,7 @@ class MemoryCommand(GefUnitTestGeneric):
         self.assertNoException(res)
         res = gdb_start_silent_cmd("memory watch $pc")
         self.assertNoException(res)
-        target = _target("memwatch")
+        target = debug_target("memwatch")
         res = gdb_start_silent_cmd("memory watch &myglobal",
                                    before=["set args 0xdeadbeef"],
                                    after=["continue"],

--- a/tests/commands/nop.py
+++ b/tests/commands/nop.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from tests.utils import (ARCH, GefUnitTestGeneric, _target, findlines,
+from tests.utils import (ARCH, GefUnitTestGeneric, debug_target, findlines,
                          gdb_run_cmd, gdb_run_silent_cmd, gdb_start_silent_cmd)
 
 
@@ -107,7 +107,7 @@ class NopCommand(GefUnitTestGeneric):
     def test_cmd_nop_invalid_end_address(self):
         res = gdb_run_silent_cmd(
             f"{self.cmd} --i 5 0x1337000+0x1000-4",
-            target=_target("mmap-known-address")
+            target=debug_target("mmap-known-address")
         )
         self.assertNoException(res)
         self.assertIn("reaching unmapped area", res)
@@ -293,7 +293,7 @@ class NopCommand(GefUnitTestGeneric):
         # Make sure we error out if writing nops into an unmapped or RO area
         res = gdb_run_silent_cmd(
             f"{self.cmd} --b --i 5 0x1337000+0x1000-4",
-            target=_target("mmap-known-address")
+            target=debug_target("mmap-known-address")
         )
         self.assertNoException(res)
         self.assertIn("Cannot patch instruction at 0x1337ffc: reaching unmapped area", res)
@@ -302,7 +302,7 @@ class NopCommand(GefUnitTestGeneric):
         # an unmapped area. Make sure that we can now.
         res = gdb_run_silent_cmd(
             f"{self.cmd} --b --i 4 0x1337000+0x1000-4",
-            target=_target("mmap-known-address"),
+            target=debug_target("mmap-known-address"),
             after="pi print(f'*** *mem={u32(gef.memory.read(0x1337ffc, 4)):#x}')",
         )
         self.assertNoException(res)

--- a/tests/commands/patch.py
+++ b/tests/commands/patch.py
@@ -3,7 +3,7 @@ patch command test module
 """
 
 
-from tests.utils import _target, gdb_run_cmd, gdb_run_silent_cmd, gdb_start_silent_cmd_last_line
+from tests.utils import debug_target, gdb_run_cmd, gdb_run_silent_cmd, gdb_start_silent_cmd_last_line
 from tests.utils import GefUnitTestGeneric
 
 
@@ -46,7 +46,7 @@ class PatchCommand(GefUnitTestGeneric):
 
 
     def test_cmd_patch_qword_symbol(self):
-        target = _target("bss")
+        target = debug_target("bss")
         before = gdb_run_silent_cmd("deref -l 1 $sp", target=target)
         after = gdb_run_silent_cmd("patch qword $sp &msg", after=["deref -l 1 $sp"], target=target)
         self.assertNoException(before)

--- a/tests/commands/pattern.py
+++ b/tests/commands/pattern.py
@@ -3,7 +3,7 @@ Pattern commands test module
 """
 import pytest
 
-from tests.utils import ARCH, GefUnitTestGeneric, _target, gdb_run_cmd, is_64b
+from tests.utils import ARCH, GefUnitTestGeneric, debug_target, gdb_run_cmd, is_64b
 
 
 class PatternCommand(GefUnitTestGeneric):
@@ -24,7 +24,7 @@ class PatternCommand(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ("x86_64", "aarch64", "i686", "armv7l"),
                         reason=f"Skipped for {ARCH}")
     def test_cmd_pattern_search(self):
-        target = _target("pattern")
+        target = debug_target("pattern")
         if ARCH == "aarch64":
             lookup_register = "$x30"
             expected_offsets = (16, 16, 5, 9)

--- a/tests/commands/pcustom.py
+++ b/tests/commands/pcustom.py
@@ -9,7 +9,7 @@ from tests.utils import (
     gdb_run_cmd,
     gdb_run_silent_cmd,
     is_64b,
-    _target,
+    debug_target,
     GEF_DEFAULT_TEMPDIR,
     GefUnitTestGeneric,
 )
@@ -75,7 +75,7 @@ class PcustomCommand(GefUnitTestGeneric):
                     self.assertIn("0004   b                     c_long  /* size=0x4 */", res)
 
                 # with address
-                res = gdb_run_silent_cmd("pcustom goo_t 0x1337100", target=_target("pcustom"),
+                res = gdb_run_silent_cmd("pcustom goo_t 0x1337100", target=debug_target("pcustom"),
                                         before=[f"gef config pcustom.struct_path {dirpath}",])
                 self.assertNoException(res)
                 if is_64b():
@@ -102,7 +102,7 @@ class PcustomCommand(GefUnitTestGeneric):
                 self.assertIn("No structure named 'meh_t' found", res)
 
                 # bad structure name with address
-                res = gdb_run_silent_cmd("pcustom meh_t 0x1337100", target=_target("pcustom"),
+                res = gdb_run_silent_cmd("pcustom meh_t 0x1337100", target=debug_target("pcustom"),
                                         before=[f"gef config pcustom.struct_path {dirpath}",])
                 self.assertNoException(res)
                 self.assertIn("No structure named 'meh_t' found", res)

--- a/tests/commands/pie.py
+++ b/tests/commands/pie.py
@@ -2,7 +2,7 @@
 `pie` command test module
 """
 
-from tests.utils import (GefUnitTestGeneric, _target, find_symbol, gdb_run_cmd,
+from tests.utils import (GefUnitTestGeneric, debug_target, find_symbol, gdb_run_cmd,
                          removeuntil)
 
 
@@ -11,7 +11,7 @@ class PieCommand(GefUnitTestGeneric):
 
 
     def setUp(self) -> None:
-        target = _target("default")
+        target = debug_target("default")
         self.pie_offset = find_symbol(target, "main")
         self.assertGreater(self.pie_offset, 0)
         return super().setUp()

--- a/tests/commands/process_search.py
+++ b/tests/commands/process_search.py
@@ -3,7 +3,7 @@
 """
 
 
-from tests.utils import _target, gdb_start_silent_cmd
+from tests.utils import debug_target, gdb_start_silent_cmd
 from tests.utils import GefUnitTestGeneric
 
 
@@ -12,7 +12,7 @@ class ProcessSearchCommand(GefUnitTestGeneric):
 
 
     def test_cmd_process_search(self):
-        target = _target("pattern")
+        target = debug_target("pattern")
         res = gdb_start_silent_cmd("process-search", target=target,
                                    before=["set args w00tw00t"])
         self.assertNoException(res)

--- a/tests/commands/scan.py
+++ b/tests/commands/scan.py
@@ -3,7 +3,7 @@ scan command test module
 """
 
 
-from tests.utils import GefUnitTestGeneric, _target, gdb_run_cmd, gdb_start_silent_cmd
+from tests.utils import GefUnitTestGeneric, debug_target, gdb_run_cmd, gdb_start_silent_cmd
 
 
 class ScanCommand(GefUnitTestGeneric):
@@ -12,7 +12,7 @@ class ScanCommand(GefUnitTestGeneric):
 
     def test_cmd_scan(self):
         cmd = "scan libc stack"
-        target = _target("checksec-no-pie")
+        target = debug_target("checksec-no-pie")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd))
         res = gdb_start_silent_cmd(cmd, target=target)
         self.assertNoException(res)

--- a/tests/commands/skipi.py
+++ b/tests/commands/skipi.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from tests.utils import (ARCH, GefUnitTestGeneric, _target, findlines,
+from tests.utils import (ARCH, GefUnitTestGeneric, debug_target, findlines,
                          gdb_run_cmd, gdb_run_silent_cmd, gdb_start_silent_cmd)
 
 

--- a/tests/commands/xinfo.py
+++ b/tests/commands/xinfo.py
@@ -3,7 +3,7 @@ xinfo command test module
 """
 
 
-from tests.utils import GefUnitTestGeneric, gdb_run_cmd, gdb_start_silent_cmd, gdb_run_silent_cmd, _target
+from tests.utils import GefUnitTestGeneric, gdb_run_cmd, gdb_start_silent_cmd, gdb_run_silent_cmd, debug_target
 
 
 class XinfoCommand(GefUnitTestGeneric):
@@ -21,7 +21,7 @@ class XinfoCommand(GefUnitTestGeneric):
 
     def test_cmd_xinfo_on_class(self):
         cmd = "xinfo $pc"
-        target = _target("class")
+        target = debug_target("class")
         res = gdb_run_silent_cmd(cmd, target=target, before=["b B<TraitA, TraitB>::Run()"])
         self.assertNoException(res)
         self.assertIn("Symbol: B<TraitA, TraitB>::Run", res)

--- a/tests/functions/elf_sections.py
+++ b/tests/functions/elf_sections.py
@@ -3,7 +3,7 @@ GDB function test module for ELF section convenience functions
 """
 
 
-from tests.utils import _target, gdb_run_cmd, gdb_run_silent_cmd, gdb_start_silent_cmd, is_64b
+from tests.utils import debug_target, gdb_run_cmd, gdb_run_silent_cmd, gdb_start_silent_cmd, is_64b
 from tests.utils import GefUnitTestGeneric
 
 
@@ -31,7 +31,7 @@ class ElfSectionGdbFunction(GefUnitTestGeneric):
     def test_func_bss(self):
         """`$_bss()` GDB function test"""
         cmd = "deref $_bss()"
-        target = _target("bss")
+        target = debug_target("bss")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -41,7 +41,7 @@ class ElfSectionGdbFunction(GefUnitTestGeneric):
     def test_func_got(self):
         """`$_got()` GDB function test"""
         cmd = "deref $_got()"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)
@@ -51,7 +51,7 @@ class ElfSectionGdbFunction(GefUnitTestGeneric):
     def test_func_heap(self):
         """`$_heap()` GDB function test"""
         cmd = "deref $_heap()"
-        target = _target("heap")
+        target = debug_target("heap")
         self.assertFailIfInactiveSession(gdb_run_cmd(cmd, target=target))
         res = gdb_run_silent_cmd(cmd, target=target)
         self.assertNoException(res)

--- a/tests/regressions/registers_register_order.py
+++ b/tests/regressions/registers_register_order.py
@@ -4,7 +4,7 @@ from tests.utils import (
     GefUnitTestGeneric,
     gdb_start_silent_cmd,
     gdb_run_silent_cmd,
-    _target,
+    debug_target,
     ARCH
 )
 
@@ -33,7 +33,7 @@ class RegressionRegisterOrder(GefUnitTestGeneric):
     @pytest.mark.skipif(ARCH not in ["x86_64",], reason=f"Skipped for {ARCH}")
     def test_context_correct_registers_refresh_with_frames(self):
         """Ensure registers are correctly refreshed when changing frame (PR #668)"""
-        target = _target("nested")
+        target = debug_target("nested")
         lines = gdb_run_silent_cmd("registers", after=["frame 5", "registers"],
                                    target=target).splitlines()
         rips = [x for x in lines if x.startswith("$rip")]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -222,7 +222,7 @@ def gdb_time_python_method(meth: str, setup: str,
     return float(lines[-1])
 
 
-def _target(name: str, extension: str = ".out") -> pathlib.Path:
+def debug_target(name: str, extension: str = ".out") -> pathlib.Path:
     target = TMPDIR / f"{name}{extension}"
     if not target.exists():
         subprocess.run(["make", "-C", "tests/binaries", target.name])
@@ -231,13 +231,13 @@ def _target(name: str, extension: str = ".out") -> pathlib.Path:
     return target
 
 
-def start_gdbserver(exe: Union[str, pathlib.Path] = _target("default"),
+def start_gdbserver(exe: Union[str, pathlib.Path] = debug_target("default"),
                     host: str = GDBSERVER_DEFAULT_HOST,
                     port: int = GDBSERVER_DEFAULT_PORT) -> subprocess.Popen:
     """Start a gdbserver on the target binary.
 
     Args:
-        exe (str, optional): the binary to execute. Defaults to _target("default").
+        exe (str, optional): the binary to execute. Defaults to debug_target("default").
         port (int, optional): the port to make gdbserver listen on. Defaults to 1234.
 
     Returns:
@@ -261,7 +261,7 @@ def stop_gdbserver(gdbserver: subprocess.Popen) -> None:
 
 @contextlib.contextmanager
 def gdbserver_session(*args, **kwargs):
-    exe = kwargs.get("exe", "") or _target("default")
+    exe = kwargs.get("exe", "") or debug_target("default")
     host = kwargs.get("host", GDBSERVER_DEFAULT_HOST)
     port = kwargs.get("port", GDBSERVER_DEFAULT_PORT)
     sess = start_gdbserver(exe, host, port)
@@ -272,7 +272,7 @@ def gdbserver_session(*args, **kwargs):
         stop_gdbserver(sess)
 
 
-def start_qemuuser(exe: Union[str, pathlib.Path] = _target("default"),
+def start_qemuuser(exe: Union[str, pathlib.Path] = debug_target("default"),
                    port: int = GDBSERVER_DEFAULT_PORT) -> subprocess.Popen:
     return subprocess.Popen(["qemu-x86_64", "-g", str(port), exe],
                             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -286,7 +286,7 @@ def stop_qemuuser(process: subprocess.Popen) -> None:
 
 @contextlib.contextmanager
 def qemuuser_session(*args, **kwargs):
-    exe = kwargs.get("exe", "") or _target("default")
+    exe = kwargs.get("exe", "") or debug_target("default")
     port = kwargs.get("port", 0) or GDBSERVER_DEFAULT_PORT
     sess = start_qemuuser(exe, port)
     try:


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->

This change renames the tests.utils._target function to tests.utils.debug_target

<!-- Why is this change required? What problem does it solve? -->

Currently, many tests are required to access the `_target` function in test_utils for building proper test cases. Hence, it is better to remove the _ prefix for this function, give it a more proper name, really make it public.

This requirement comes from the discussion here: https://github.com/hugsy/gef/pull/1028#discussion_r1433369804.

<!-- Why is this patch will make a better world? -->

<!-- How does this look? Add a screenshot if you can -->

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [-] My change includes a change to the documentation, if required.
-  [-] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.
