### PR TITLE
gef.sh: Fix `which: command not found`

### DIFF
--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -6,9 +6,9 @@ curl_found=0
 wget_found=0
 
 # check dependencies
-if [ "$(which curl)" ]; then
+if [ "$(command -v curl)" ]; then
 	curl_found=1
-elif [ "$(which wget)" ]; then
+elif [ "$(command -v wget)" ]; then
 	wget_found=1
 else
 	echo "Please install cURL or wget and run again"


### PR DESCRIPTION
## Description

This is mainly because Arch Linux no longer ships `which` in `base`:

```console
$ bash -c "$(curl -fsSL https://gef.blah.cat/sh)"
bash: line 9: which: command not found
bash: line 11: which: command not found
Please install cURL or wget and run again
```

<!-- Describe technically what your patch does. -->

<!-- Why is this change required? What problem does it solve? -->

<!-- Why is this patch will make a better world? -->

<!-- How does this look? Add a screenshot if you can -->

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.

Note: no docs/tests added, but I checked the boxes because I don't think they are needed.

I tested the modified`./gef.sh` locally.