### PR TITLE
support 64 bit retval for stub

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -4147,7 +4147,8 @@ class StubBreakpoint(gdb.Breakpoint):
         return
 
     def stop(self) -> bool:
-        gdb.execute(f"return (unsigned int){self.retval:#x}")
+        size = "long" if gef.arch.ptrsize == 8 else "int"
+        gdb.execute(f"return (unsigned {size}){self.retval:#x}")
         ok(f"Ignoring call to '{self.func}' "
            f"(setting return value to {self.retval:#x})")
         return False


### PR DESCRIPTION
## Description

The `return (int) X` command in gdb only sets the 4 lowest bytes of the return register. For example if `rax` was `-1`, a `return int 0` would leave us with `0xffffffff000000` instead of `0x0`.

This patch makes `StubBreakpoint` check for the register size and executes `return (int)` or `return (long)` accordingly.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
