### PR TITLE
correct parsing in gdb_get_location_from_symbol

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -2021,8 +2021,8 @@ def gdb_get_location_from_symbol(address: int) -> Optional[Tuple[str, int]]:
     # gdb outputs symbols with format: "<symbol_name> + <offset> in section <section_name> of <file>",
     # here, we are only interested in symbol name and offset.
     i = sym.find(" in section ")
-    sym = sym[:i].split("+")
-    name, offset = sym[0].strip(), 0
+    sym = sym[:i].split(" + ")
+    name, offset = sym[0], 0
     if len(sym) == 2 and sym[1].isdigit():
         offset = int(sym[1])
     return name, offset

--- a/tests/commands/xinfo.py
+++ b/tests/commands/xinfo.py
@@ -20,8 +20,8 @@ class XinfoCommand(GefUnitTestGeneric):
         self.assertTrue(len(res.splitlines()) >= 7)
 
     def test_cmd_xinfo_on_class(self):
-        cmd = "xinfo $pc"
+        cmd = "xinfo $pc+4"
         target = debug_target("class")
-        res = gdb_run_silent_cmd(cmd, target=target, before=["b B<TraitA, TraitB>::Run()"])
+        res = gdb_run_silent_cmd(cmd, target=target, before=["b *'B<TraitA, TraitB>::Run'"])
         self.assertNoException(res)
-        self.assertIn("Symbol: B<TraitA, TraitB>::Run", res)
+        self.assertIn("Symbol: B<TraitA, TraitB>::Run()+4", res)


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->

<!-- Why is this change required? What problem does it solve? -->
As stated in the comments `info symbol` returns "`<symbol_name> + <offset>`" with spaces around the `+`. The current split leaves a space in front of the offset which makes .isdigit() return False.

@r12f, do you think we still need the `.strip()` for `sym[0]` ?

<!-- Why is this patch will make a better world? -->

<!-- How does this look? Add a screenshot if you can -->

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
