### PR TITLE
Error handling in `GefRemoteSessionManager.sync`

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -11056,7 +11056,12 @@ class GefRemoteSessionManager(GefSessionManager):
             return True
         tgt.parent.mkdir(parents=True, exist_ok=True)
         dbg(f"[remote] downloading '{src}' -> '{tgt}'")
-        gdb.execute(f"remote get '{src}' '{tgt.absolute()}'")
+
+        try:
+            gdb.execute(f"remote get '{src}' '{tgt.absolute()}'")
+        except gdb.error:
+            return False
+
         return tgt.exists()
 
     def connect(self, pid: int) -> bool:

--- a/gef.py
+++ b/gef.py
@@ -11322,6 +11322,7 @@ def target_remote_posthook():
 
     gef.session.remote = GefRemoteSessionManager("", 0)
     if not gef.session.remote.setup():
+        gef.session.reset_remote()
         warn(f"Failed to create a proper environment for {gef.session.remote}")
         return False
 

--- a/gef.py
+++ b/gef.py
@@ -6049,10 +6049,10 @@ class RemoteCommand(GenericCommand):
 
         dbg(f"[remote] initializing remote session with {gef.session.remote.target} under {gef.session.remote.root}")
         if not gef.session.remote.connect(args.pid):
-            gef.session.remote_initializing = False
+            gef.session.reset_remote()
             raise EnvironmentError(f"Cannot connect to remote target {gef.session.remote.target}")
         if not gef.session.remote.setup():
-            gef.session.remote_initializing = False
+            gef.session.reset_remote()
             raise EnvironmentError(f"Failed to create a proper environment for {gef.session.remote.target}")
 
         gdb.execute("context")
@@ -10877,6 +10877,12 @@ class GefSessionManager(GefManager):
         self._maps: Optional[pathlib.Path] = None
         self._root: Optional[pathlib.Path] = None
         return
+
+    def reset_remote(self) -> None:
+        self.remote_initializing = False
+        self.remote = None
+        return
+
 
     def __str__(self) -> str:
         return f"Session({'Local' if self.remote is None else 'Remote'}, pid={self.pid or 'Not running'}, os='{self.os}')"

--- a/gef.py
+++ b/gef.py
@@ -3335,7 +3335,7 @@ class MIPS64(MIPS):
 
     @staticmethod
     def supports_gdb_arch(gdb_arch: str) -> Optional[bool]:
-        return gdb_arch.startswith("mips") and gef.binary.e_class == Elf.Class.ELF_64_BITS
+        return gdb_arch.startswith("mips") and gef.binary and gef.binary.e_class == Elf.Class.ELF_64_BITS
 
 
 def copy_to_clipboard(data: bytes) -> None:
@@ -3722,7 +3722,7 @@ def reset_architecture(arch: Optional[str] = None) -> None:
             return
 
     # last resort, use the info from elf header to find it from the known architectures
-    if gef.binary.e_machine:
+    if gef.binary and gef.binary.e_machine:
         try:
             gef.arch = arches[gef.binary.e_machine]()
         except KeyError:
@@ -7222,7 +7222,7 @@ class EntryPointBreakCommand(GenericCommand):
             return
 
         if not os.access(fpath, os.X_OK):
-            warn(f"The file '{fpath}' is not executable.")
+            warn(f"The file '{fpath}' does not exists or is not executable.")
             return
 
         if is_alive() and not gef.session.qemu_mode:
@@ -11114,8 +11114,9 @@ class GefRemoteSessionManager(GefSessionManager):
         # refresh gef to consider the binary
         reset_all_caches()
 
-        if self.file.exists():
+        if self.lfile.exists():
             gef.binary = Elf(self.lfile)
+
 
         reset_architecture()
         return success

--- a/gef.py
+++ b/gef.py
@@ -3551,6 +3551,10 @@ def continue_handler(_: "gdb.ContinueEvent") -> None:
 
 def hook_stop_handler(_: "gdb.StopEvent") -> None:
     """GDB event handler for stop cases."""
+    if gef.session.remote:
+        gef.session.remote.maps.unlink()
+        gef.session.remote.sync(f"/proc/{gef.session.remote.pid}/maps")
+
     reset_all_caches()
     gdb.execute("context")
     return

--- a/gef.py
+++ b/gef.py
@@ -11104,7 +11104,6 @@ class GefRemoteSessionManager(GefSessionManager):
         # refresh gef to consider the binary
         reset_all_caches()
 
-        print(self.file)
         if self.file.exists():
             gef.binary = Elf(self.lfile)
 

--- a/gef.py
+++ b/gef.py
@@ -11092,10 +11092,12 @@ class GefRemoteSessionManager(GefSessionManager):
         # setup remote adequately depending on remote or qemu mode
         if self.in_qemu_user():
             dbg(f"Setting up as qemu session, target={self.__qemu}")
-            self.__setup_qemu()
+            if not self.__setup_qemu():
+                return False
         else:
             dbg(f"Setting up as remote session")
-            self.__setup_remote()
+            if not self.__setup_remote():
+                return False
 
         # refresh gef to consider the binary
         reset_all_caches()

--- a/gef.py
+++ b/gef.py
@@ -11117,7 +11117,6 @@ class GefRemoteSessionManager(GefSessionManager):
         if self.lfile.exists():
             gef.binary = Elf(self.lfile)
 
-
         reset_architecture()
         return success
 
@@ -11168,7 +11167,7 @@ class GefRemoteSessionManager(GefSessionManager):
             warn(f"'{fpath}' could not be fetched on the remote system.")
             success = False
 
-            # makeup a fake mem mapping in case we failed to retrieve it
+            # make up a fake mem mapping in case we failed to retrieve it
             maps = self.root / fpath
             with maps.open("w") as fd:
                 fname = self.file.absolute()
@@ -11180,7 +11179,7 @@ class GefRemoteSessionManager(GefSessionManager):
             warn(f"'{fpath}' could not be fetched on the remote system.")
             success = False
 
-            # makeup a fake mem mapping in case we failed to retrieve it
+            # make up a fake environ in case we failed to retrieve it
             environ = self.root / fpath
             with environ.open("wb") as fd:
                 fd.write(b"PATH=/bin\x00HOME=/tmp\x00")
@@ -11190,9 +11189,8 @@ class GefRemoteSessionManager(GefSessionManager):
             warn(f"'{fpath}' could not be fetched on the remote system.")
             success = False
 
-            # makeup a fake mem mapping in case we failed to retrieve it
-            cmdline = self.root / fpath
-            with cmdline.open("w") as fd:
+            # make up a fake cmdline in case we failed to retrieve it
+            with (self.root / fpath).open("w") as fd:
                 fd.write("")
 
         return success


### PR DESCRIPTION
## Description

`def sync(self, src: str, dst: Optional[str] = None) -> bool:` should not raise an error when failing to download a file, but return false instead.

Then, error handling should be managed better in functions that call this `sync` function

This issue was found while reproducing #1044 

### Before

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/dave/gef.py", line 11283, in target_remote_posthook
    if not gef.session.remote.setup():
  File "/dave/gef.py", line 11093, in setup
    self.__setup_remote()
  File "/dave/gef.py", line 11138, in __setup_remote
    if not self.sync(fpath, str(self.file)):
  File "/dave/gef.py", line 11059, in sync
    gdb.execute(f"remote get '{src}' '{tgt.absolute()}'")
gdb.error: Remote I/O error: No such file or directory
Error while executing Python code.
```

### After

```
[!] '/proc/36123/exe' could not be fetched on the remote system.
[!] Failed to create a proper environment for RemoteSession(target=':0', local='/tmp/tmp6gn18rer', pid=36123, qemu_user=False)
```

## Checklist

-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
