### PR TITLE
Killing the last inconsistencies through type hints

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3907,7 +3907,7 @@ def gef_convenience(value: Union[str, bytes]) -> str:
     if isinstance(value, str):
         gdb.execute(f"""set {var_name} = "{value}" """)
     elif isinstance(value, bytes):
-        value_as_array = "{" + ", ".join([f"0x{x:#.02x}" for x in value]) + "}"
+        value_as_array = "{" + ", ".join([f"0x{b:02x}" for b in value]) + "}"
         gdb.execute(f"""set {var_name} = {value_as_array} """)
     else:
         raise TypeError

--- a/gef.py
+++ b/gef.py
@@ -116,10 +116,10 @@ except ImportError:
     sys.exit(1)
 
 
-GDB_MIN_VERSION                        = (8, 0)
-PYTHON_MIN_VERSION                     = (3, 6)
-PYTHON_VERSION                         = sys.version_info[0:2]
-GDB_VERSION : Tuple[int, int]           = tuple(map(int, re.search(r"(\d+)[^\d]+(\d+)", gdb.VERSION).groups())) # type:ignore
+GDB_MIN_VERSION: Tuple[int, int]       = (8, 0)
+PYTHON_MIN_VERSION: Tuple[int, int]    = (3, 6)
+PYTHON_VERSION: Tuple[int, int]        = sys.version_info[0:2]
+GDB_VERSION: Tuple[int, int]           = tuple(map(int, re.search(r"(\d+)[^\d]+(\d+)", gdb.VERSION).groups())) # type:ignore
 
 DEFAULT_PAGE_ALIGN_SHIFT               = 12
 DEFAULT_PAGE_SIZE                      = 1 << DEFAULT_PAGE_ALIGN_SHIFT

--- a/tests/commands/gef.py
+++ b/tests/commands/gef.py
@@ -77,7 +77,7 @@ class GefCommand(RemoteGefUnitTestGeneric):
 
         # valid
         pattern = gdb.execute("pattern create -n 4", to_string=True).splitlines()[1]
-        assert len(pattern) == 1024, f"Unexpected pattern {pattern}"
+        assert len(pattern) == 1024, f"Unexpected pattern length {len(pattern)}"
         res = gdb.execute("gef set args $_gef0")
         res = gdb.execute("show args", to_string=True).strip()
         assert (

--- a/tests/commands/gef.py
+++ b/tests/commands/gef.py
@@ -30,7 +30,7 @@ class GefCommand(RemoteGefUnitTestGeneric):
             "gef.follow_child (bool)",
             "gef.readline_compat (bool)",
             "gef.show_deprecation_warnings (bool)",
-            "gef.tempdir (str)",
+            "gef.tempdir (Path)",
             "got.function_not_resolved (str)",
             "got.function_resolved (str)",
         )
@@ -77,7 +77,7 @@ class GefCommand(RemoteGefUnitTestGeneric):
 
         # valid
         pattern = gdb.execute("pattern create -n 4", to_string=True).splitlines()[1]
-        assert len(pattern) == 1024
+        assert len(pattern) == 1024, f"Unexpected pattern {pattern}"
         res = gdb.execute("gef set args $_gef0")
         res = gdb.execute("show args", to_string=True).strip()
         assert (

--- a/tests/commands/pcustom.py
+++ b/tests/commands/pcustom.py
@@ -45,7 +45,7 @@ class PcustomCommand(RemoteGefUnitTestGeneric):
                 #
                 gdb.execute(f"gef config pcustom.struct_path {dirpath}")
                 res = gdb.execute("gef config pcustom.struct_path", to_string=True)
-                self.assertIn(f'pcustom.struct_path (str) = "{dirpath}"', res)
+                self.assertIn(f'pcustom.struct_path (Path) = {dirpath}', res)
 
                 #
                 # List the structures in the files inside dirpath


### PR DESCRIPTION
## Description

This PR  is purely esthetic but fixes a few extra inconsistencies thanks to type hints, using `pylint` and `pylance`.
Both pass now reporting no error, warning or info!

Among other fixes:
 * removed unused vars
 * `f-string`-ify more
 * enforce (using `assert`) expected type to variable when appropriate
 * fixed some bad type names in `gdb.events.*`
 * the config manager allows to receive non basic types
 * applied all the type issues spotted by pylance using the gdb.pyi stub
 * a lot of `staticmethod` have been made non static because we can use `gef.gdb.commands["XXX"]` instead

With this PR :
 * `pylint` on gef and tests/*.py shows a 10/10 score

![image](https://github.com/hugsy/gef/assets/590234/2ac4b0b4-ea95-4a35-a6e0-fd65b8e15b7f)

 * `pylance` shows no error 

![image](https://github.com/hugsy/gef/assets/590234/9a99b7a1-1c04-48b3-ace4-c7e56d8c5d61)

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
