### PR TITLE
fix python version parsing

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -11396,7 +11396,7 @@ if __name__ == "__main__":
         pyenv = which("pyenv")
         pyenv_root = gef_pystring(subprocess.check_output([pyenv, "root"]).strip())
         pyenv_version = gef_pystring(subprocess.check_output([pyenv, "version-name"]).strip())
-        site_packages_dir = pathlib.Path(pyenv_root) / f"versions/{pyenv_version}/lib/python{pyenv_version[:3]}/site-packages"
+        site_packages_dir = pathlib.Path(pyenv_root) / f"versions/{pyenv_version}/lib/python{pathlib.Path(pyenv_version).stem}/site-packages"
         assert site_packages_dir.is_dir()
         site.addsitedir(str(site_packages_dir.absolute()))
     except FileNotFoundError:


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->
get python version using the stem function from pathlib instead of list slicing

<!-- Why is this change required? What problem does it solve? -->
with list slicing assertion fails while using pyenv bacuse the path is wrong

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
