### PR TITLE
Add a `source` post hook

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -11489,5 +11489,12 @@ if __name__ == "__main__":
 
     # restore saved breakpoints (if any)
     bkp_fpath = pathlib.Path(gef.config["gef.autosave_breakpoints_file"]).expanduser().absolute()
-    if bkp_fpath.exists() and bkp_fpath.is_file():
+    if bkp_fpath.is_file():
         gdb.execute(f"source {bkp_fpath}")
+
+    # Add a `source` post hook to force gef recheck the registered plugins and
+    # eventually load the missing one(s)
+    cmd = """define hookpost-source
+        pi gef.gdb.load()
+        end"""
+    gdb.execute(cmd)

--- a/gef.py
+++ b/gef.py
@@ -11492,9 +11492,6 @@ if __name__ == "__main__":
     if bkp_fpath.is_file():
         gdb.execute(f"source {bkp_fpath}")
 
-    # Add a `source` post hook to force gef recheck the registered plugins and
+    # Add a `source` post hook to force gef to recheck the registered plugins and
     # eventually load the missing one(s)
-    cmd = """define hookpost-source
-        pi gef.gdb.load()
-        end"""
-    gdb.execute(cmd)
+    gdb.execute("define hookpost-source\npi gef.gdb.load()\nend")


### PR DESCRIPTION
## Description

Add a post hook to `source` to automatically reload `gef` commands and move `@register`-ed new commands to being active.

TODO: figure out when posthook appeared for compat

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [ ] My code follows the code style of this project.
-  [ ] My change includes a change to the documentation, if required.
-  [ ] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [ ] I have read and agree to the **CONTRIBUTING** document.
