### PR TITLE
Restore support for Python3.6 on LTS 18.04

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -84,7 +84,7 @@ from functools import lru_cache
 from io import StringIO, TextIOWrapper
 from types import ModuleType
 from typing import (Any, ByteString, Callable, Dict, Generator, Iterable,
-                    Iterator, List, NoReturn, Optional, OrderedDict, Sequence, Set, Tuple, Type, TypeVar,
+                    Iterator, List, NoReturn, Optional, Sequence, Set, Tuple, Type, TypeVar,
                     Union, cast)
 from urllib.request import urlopen
 
@@ -6466,7 +6466,6 @@ class GlibcHeapChunksCommand(GenericCommand):
                     return
         try:
             arena_addr = parse_address(args.arena_address)
-            print(f"{arena_addr=:#x}")
             arena = GlibcArena(f"*{arena_addr:#x}")
             self.dump_chunks_arena(arena, ctx)
         except gdb.error:
@@ -9678,8 +9677,8 @@ class GefCommand(gdb.Command):
         gef.config["gef.main_arena_offset"] = GefSetting("", str, "Offset from libc base address to main_arena symbol (int or hex). Set to empty string to disable.")
         gef.config["gef.propagate_debug_exception"] = GefSetting(False, bool, "If true, when debug mode is enabled, Python exceptions will be propagated all the way.")
 
-        self.commands : OrderedDict[str, GenericCommand] = collections.OrderedDict()
-        self.functions : OrderedDict[str, GenericFunction] = collections.OrderedDict()
+        self.commands : Dict[str, GenericCommand] = collections.OrderedDict()
+        self.functions : Dict[str, GenericFunction] = collections.OrderedDict()
         self.missing: Dict[str, Exception] = {}
         return
 
@@ -10121,13 +10120,13 @@ class GefMissingCommand(gdb.Command):
 
     def invoke(self, args: Any, from_tty: bool) -> None:
         self.dont_repeat()
-        missing_commands = gef.gdb.missing
+        missing_commands: Dict[str, Exception] = gef.gdb.missing
         if not missing_commands:
             ok("No missing command")
             return
 
-        for missing_command, reason in missing_commands.items():
-            warn(f"Command `{missing_command}` is missing, reason {RIGHT_ARROW} {reason}")
+        for cmd, reason in missing_commands.items():
+            warn(f"Missing `{cmd}`, reason: {str(reason)}")
         return
 
 


### PR DESCRIPTION
## Description

Removed one debug print, and replaced `typing.OrderedDict` with `typing.Dict` (brings little and breaks compat)

## Checklist

-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
