### PR TITLE
workflows: tests: Fix arg to check marks

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,4 +66,4 @@ jobs:
     - name: Run Tests
       run: |
         make -C tests/binaries -j ${{ env.GEF_CI_NB_CPU }}
-        python${{ env.PY_VER }} -m pytest --forked -n ${{ env.GEF_CI_NB_CPU }} -v -k "not benchmark" tests/
+        python${{ env.PY_VER }} -m pytest --forked -n ${{ env.GEF_CI_NB_CPU }} -v -m "not benchmark" tests/


### PR DESCRIPTION
We used `-k "not benchmark"` which would filter out ANY test that contained the word 'benchmark'.

This change fixes that by using the `-m` argument to only filter on marks.