### PR TITLE
Fix recursive loop on architectures where `flags` register is a dynamic value

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3841,7 +3841,7 @@ def parse_address(address: str) -> int:
     """Parse an address and return it as an Integer."""
     if is_hex(address):
         return int(address, 16)
-    return to_unsigned_long(gdb.parse_and_eval(address))
+    return int(gdb.parse_and_eval(address))
 
 
 def is_in_x86_kernel(address: int) -> bool:

--- a/tests/commands/entry_break.py
+++ b/tests/commands/entry_break.py
@@ -15,11 +15,7 @@ class EntryBreakCommand(RemoteGefUnitTestGeneric):
         # run once (ok)
         lines = (gdb.execute("entry-break", to_string=True) or "").strip().splitlines()
 
-        #
-        #
-        # "[+] Breaking at Breaking at entry-point" might be the 1st or 2nd line (depending on whether we target
-        # a PIC binary) start with
-        #
+        # expect the entry point string pattern
         assert len(lines) >= 2
         assert any(line.startswith("[+] Breaking at entry-point") for line in lines)
 

--- a/tests/commands/entry_break.py
+++ b/tests/commands/entry_break.py
@@ -13,9 +13,17 @@ class EntryBreakCommand(RemoteGefUnitTestGeneric):
         gdb = self._gdb
 
         # run once (ok)
-        res = gdb.execute("entry-break", to_string=True).strip()
-        assert res.startswith("[+] Breaking at")
+        lines = (gdb.execute("entry-break", to_string=True) or "").strip().splitlines()
+
+        #
+        #
+        # "[+] Breaking at Breaking at entry-point" might be the 1st or 2nd line (depending on whether we target
+        # a PIC binary) start with
+        #
+        assert len(lines) >= 2
+        assert lines[0].startswith("[+] Breaking at entry-point") or \
+              lines[1].startswith("[+] Breaking at entry-point")
 
         # re-run while session running (nok)
-        res = gdb.execute("entry-break", to_string=True).strip()
+        res = (gdb.execute("entry-break", to_string=True).strip() or "").strip()
         assert "gdb is already running" in res

--- a/tests/commands/entry_break.py
+++ b/tests/commands/entry_break.py
@@ -21,9 +21,8 @@ class EntryBreakCommand(RemoteGefUnitTestGeneric):
         # a PIC binary) start with
         #
         assert len(lines) >= 2
-        assert lines[0].startswith("[+] Breaking at entry-point") or \
-              lines[1].startswith("[+] Breaking at entry-point")
+        assert any(line.startswith("[+] Breaking at entry-point") for line in lines)
 
         # re-run while session running (nok)
-        res = (gdb.execute("entry-break", to_string=True).strip() or "").strip()
+        res = (gdb.execute("entry-break", to_string=True) or "").strip()
         assert "gdb is already running" in res

--- a/tests/commands/highlight.py
+++ b/tests/commands/highlight.py
@@ -13,9 +13,10 @@ class HighlightCommand(RemoteGefUnitTestGeneric):
     def test_cmd_highlight(self):
         gdb = self._gdb
 
+        gdb.execute("start")
+
         gdb.execute("gef config context.layout stack")
         gdb.execute("gef config gef.disable_color 0")
-        gdb.execute("start")
 
         for cmd in [
             "highlight add 41414141 yellow",
@@ -23,12 +24,11 @@ class HighlightCommand(RemoteGefUnitTestGeneric):
             "highlight add 43434343 green",
             "highlight add 44444444 pink",
             'patch string $sp "AAAABBBBCCCCDDDD"',
-            "hexdump qword $sp -s 2",
         ]:
             gdb.execute(cmd)
 
-        res = gdb.execute("context", to_string=True)
-        self.assertIn(f"{Color.YELLOW.value}41414141{Color.NORMAL.value}", res)
-        self.assertIn(f"{Color.BLUE.value}42424242{Color.NORMAL.value}", res)
-        self.assertIn(f"{Color.GREEN.value}43434343{Color.NORMAL.value}", res)
-        self.assertIn(f"{Color.PINK.value}44444444{Color.NORMAL.value}", res)
+        res: str = (gdb.execute("hexdump qword $sp -s 2", to_string=True) or "").strip()
+        assert f"{Color.YELLOW.value}41414141{Color.NORMAL.value}" in res
+        assert f"{Color.BLUE.value}42424242{Color.NORMAL.value}" in res
+        assert f"{Color.GREEN.value}43434343{Color.NORMAL.value}" in res
+        assert f"{Color.PINK.value}44444444{Color.NORMAL.value}" in res


### PR DESCRIPTION
## Description

Quick fix for a nasty bug I discovered last night:

For (at least) ARM and ARM64`$arch.ptrsize` is calculated dynamically from CSPR flags, and invokes `parse_address`. However, `parse_address` requires `ptrsize` to be set to determine the alignment. 
So we end up in an infinite loop. Which breaks almost everything.

Example on ARM64

```console
↳ File "/home/hugsy/code/gef/gef.py", line 3844, in parse_address()
    →     return to_unsigned_long(gdb.parse_and_eval(address))
↳ File "/home/hugsy/code/gef/gef.py", line 2351, in __get_register_for_selected_frame()
    →     return parse_address(regname)
↳ File "/home/hugsy/code/gef/gef.py", line 2345, in __get_register()
    →     return self.__get_register_for_selected_frame(regname, int(key))
↳ File "/home/hugsy/code/gef/gef.py", line 2363, in register()
    →     return self.__get_register(name)
↳ File "/home/hugsy/code/gef/gef.py", line 2584, in cpsr()
    →     return gef.arch.register(self.flag_register)
↳ File "/home/hugsy/code/gef/gef.py", line 2745, in is_aarch32()
    →     return (self.cpsr & (1 << 4) != 0) and (self.cpsr & (1 << 5) == 0)
↳ File "/home/hugsy/code/gef/gef.py", line 2756, in ptrsize()
    →     if self.is_aarch32():
↳ File "/home/hugsy/code/gef/gef.py", line 3411, in to_unsigned_long()
    →     mask = (1 << (gef.arch.ptrsize*8)) - 1
[...]
```

Repro: open any binary with gef on arm64, run `start` 

Fix: Simply replacing `to_unsigned_long` with `int` is perfectly fine for this situation, which is what the PR does.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
