### PR TITLE
Support breakpoint.locations

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7613,7 +7613,12 @@ class ContextCommand(GenericCommand):
         cur_insn_color = gef.config["theme.disassemble_current_instruction"]
         pc = gef.arch.pc
         breakpoints = gdb.breakpoints() or []
-        bp_locations = [b.location for b in breakpoints if b.location and b.location.startswith("*")]
+        # breakpoint.locations was introduced in gdb 13.1
+        if len(breakpoints) and hasattr(breakpoints[-1], "locations"):
+            bp_locations = [hex(location.address) for b in breakpoints for location in b.locations if location is not None]
+        else:
+            # location relies on the user setting the breakpoints with "b *{hex(address)}"
+            bp_locations = [b.location for b in breakpoints if b.location and b.location.startswith("*")]
 
         frame = gdb.selected_frame()
         arch_name = f"{gef.arch.arch.lower()}:{gef.arch.mode}"


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->
If gdb is recent enough this patch uses `breakpoint.locations` to extract directly the address at which the breakpoints are set instead of parsing the command used by the user.

<!-- Why is this change required? What problem does it solve? -->
As discussed in #1039 the previous implementation only worked if the user sets the breakpoint with a format "b *{hex(address)}"

<!-- Why is this patch will make a better world? -->

<!-- How does this look? Add a screenshot if you can -->

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
