### PR TITLE
fix/remote-vmmap-updates

### DIFF
--- a/tests/api/gef_memory.py
+++ b/tests/api/gef_memory.py
@@ -145,3 +145,20 @@ class GefMemoryApi(RemoteGefUnitTestGeneric):
             gdb.execute(cmd)
             sections = gef.memory.maps
             assert len(sections) > 0
+
+    def test_func_parse_maps_old_remote_gdbserver(self):
+        gef, gdb = self._gef, self._gdb
+        # When in a gdb remote session objfile handlers should
+        # trigger memory map updates
+        while True:
+            port = random.randint(1025, 65535)
+            if port != self._port:
+                break
+
+        with gdbserver_session(port=port) as _:
+            gdb.execute(f"target remote {GDBSERVER_DEFAULT_HOST}:{port}")
+            initial_cnt = len(gef.memory.maps)
+            gdb.execute(f"break _start")
+            gdb.execute(f"continue")
+            start_cnt = len(gef.memory.maps)
+            assert start_cnt > initial_cnt


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->
Adds objfile handlers to non gef-remote remote sessions.  Handler re-syncs `/proc/maps` when new objects are loaded.

<!-- Why is this change required? What problem does it solve? -->
Currently, if a non-gef gdb remote session is started (such as via pwntools `gdb.debug`), the `vmmap` command does not refresh when new libraries are loaded including libc.  This breaks `vmmap` and other gef functionality that relies upon the newly mapped memory.
<!-- Why is this patch will make a better world? -->

<!-- How does this look? Add a screenshot if you can -->

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
