### PR TITLE
Changed gef.py, now support x86_64_elf_gdb

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -927,7 +927,7 @@ class Elf(FileFormat):
                 return False
 
             abspath = str(self.path.absolute())
-            readelf = gef.session.constants["readelf"]
+            readelf = gef.session.constants["x86_64-elf-readelf"]
             self.__checksec["Canary"] = __check_security_property("-rs", abspath, r"__stack_chk_fail") is True
             has_gnu_stack = __check_security_property("-W -l", abspath, r"GNU_STACK") is True
             if has_gnu_stack:
@@ -9187,7 +9187,7 @@ class GotCommand(GenericCommand):
 
     @only_if_gdb_running
     def do_invoke(self, argv: List[str]) -> None:
-        readelf = gef.session.constants["readelf"]
+        readelf = gef.session.constants["x86_64-elf-readelf"]
 
         elf_file = str(gef.session.file)
         elf_virtual_path = str(gef.session.file)
@@ -10939,7 +10939,7 @@ class GefSessionManager(GefManager):
         self.aliases: List[GefAlias] = []
         self.modules: List[FileFormat] = []
         self.constants = {} # a dict for runtime constants (like 3rd party file paths)
-        for constant in ("python3", "readelf", "file", "ps"):
+        for constant in ("python3", "x86_64-elf-readelf", "file", "ps"):
             self.constants[constant] = which(constant)
         return
 


### PR DESCRIPTION
## Description

This patch modifies the gef.py file to introduce compatibility with x86_64-elf-readelf. This change allows gef to be used in environments that do not run on the x86_64 architecture(Apple Silicon, AArch64....), broadening its applicability and utility across different computing environments.


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
