### PR TITLE
memory: Allow info proc mapping on older gdb

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -10590,9 +10590,6 @@ class GefMemoryManager(GefManager):
     @classmethod
     def parse_gdb_info_proc_maps(cls) -> Generator[Section, None, None]:
         """Get the memory mapping from GDB's command `maintenance info sections` (limited info)."""
-        if GDB_VERSION < (11, 0):
-            raise AttributeError("Disregarding old format")
-
         output = (gdb.execute("info proc mappings", to_string=True) or "")
         if not output:
             raise AttributeError

--- a/tests/api/gef_memory.py
+++ b/tests/api/gef_memory.py
@@ -69,14 +69,8 @@ class GefMemoryApi(RemoteGefUnitTestGeneric):
 
         Section = root.eval("Section")
 
-        if self.gdb_version < (11, 0):
-            # expect an exception
-            with pytest.raises(AttributeError):
-                next(root.eval("gef.memory.parse_gdb_info_proc_maps()") )
-
-        else:
-            for section in root.eval("gef.memory.parse_gdb_info_proc_maps()"):
-                assert isinstance(section, Section)
+        for section in root.eval("gef.memory.parse_gdb_info_proc_maps()"):
+            assert isinstance(section, Section)
 
     def test_func_parse_permissions(self):
         root = self._conn.root


### PR DESCRIPTION
This works now that we assume rwx if the Perms column is missing
