### PR TITLE
Fix problems due to multiple matches in filename filters

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3549,6 +3549,8 @@ def process_lookup_path(name: str, perm: Permission = Permission.ALL) -> Optiona
         for x in matches:
             warn(f"- '{x}'")
 
+        warn("Returning the first match")
+
     return ret
 
 

--- a/gef.py
+++ b/gef.py
@@ -3528,13 +3528,12 @@ def process_lookup_path(name: str, perm: Permission = Permission.ALL) -> Optiona
         err("Process is not running")
         return None
 
-    matches = set()
-    ret = None
+    matches: Set[str] = set()
+    ret: Optional[Section] = None
     for sect in gef.memory.maps:
-        try:
-            filename = pathlib.Path(sect.path).name
-        except:
-            filename = sect.path
+        # NOTE: There is apparently no way this line raises an exception, but if
+        # it does, add a `try/except` block :)
+        filename = pathlib.Path(sect.path).name
 
         if name in filename and sect.permission & perm:
             if ret is None:
@@ -10817,9 +10816,8 @@ class GefHeapManager(GefManager):
                 dbg("Trying to bruteforce main_arena address")
                 # setup search_range for `main_arena` to `.data` of glibc
                 search_filter = lambda f: "libc" in pathlib.Path(f.filename).name and f.name == ".data"
-                dotdatas = list(filter(search_filter, get_info_files()))
 
-                for dotdata in dotdatas:
+                for dotdata in list(filter(search_filter, get_info_files())):
                     search_range = range(dotdata.zone_start, dotdata.zone_end, alignment)
                     # find first possible candidate
                     for addr in search_range:

--- a/gef.py
+++ b/gef.py
@@ -3528,11 +3528,28 @@ def process_lookup_path(name: str, perm: Permission = Permission.ALL) -> Optiona
         err("Process is not running")
         return None
 
+    matches = set()
+    ret = None
     for sect in gef.memory.maps:
-        if name in sect.path and sect.permission & perm:
-            return sect
+        try:
+            filename = pathlib.Path(sect.path).name
+        except:
+            filename = sect.path
 
-    return None
+        if name in filename and sect.permission & perm:
+            if ret is None:
+                ret = sect
+            matches.add(sect.path)
+
+    matches_count = len(matches)
+
+    if matches_count > 1:
+        warn(f"{matches_count} matches! You should probably refine your search!")
+
+        for x in matches:
+            warn(f"- '{x}'")
+
+    return ret
 
 
 @lru_cache()

--- a/gef.py
+++ b/gef.py
@@ -3528,29 +3528,28 @@ def process_lookup_path(name: str, perm: Permission = Permission.ALL) -> Optiona
         err("Process is not running")
         return None
 
-    matches: Set[str] = set()
-    ret: Optional[Section] = None
+    matches: Dict[str, Section] = dict()
     for sect in gef.memory.maps:
-        # NOTE: There is apparently no way this line raises an exception, but if
-        # it does, add a `try/except` block :)
         filename = pathlib.Path(sect.path).name
 
         if name in filename and sect.permission & perm:
-            if ret is None:
-                ret = sect
-            matches.add(sect.path)
+            if sect.path not in matches.keys():
+                matches[sect.path] = sect
 
     matches_count = len(matches)
+
+    if matches_count == 0:
+        return None
 
     if matches_count > 1:
         warn(f"{matches_count} matches! You should probably refine your search!")
 
-        for x in matches:
+        for x in matches.keys():
             warn(f"- '{x}'")
 
         warn("Returning the first match")
 
-    return ret
+    return list(matches.values())[0]
 
 
 @lru_cache()

--- a/gef.py
+++ b/gef.py
@@ -10814,15 +10814,17 @@ class GefHeapManager(GefManager):
             try:
                 dbg("Trying to bruteforce main_arena address")
                 # setup search_range for `main_arena` to `.data` of glibc
-                search_filter = lambda f: "libc" in f.filename and f.name == ".data"
-                dotdata = list(filter(search_filter, get_info_files()))[0]
-                search_range = range(dotdata.zone_start, dotdata.zone_end, alignment)
-                # find first possible candidate
-                for addr in search_range:
-                    if GlibcArena.verify(addr):
-                        dbg(f"Found candidate at {addr:#x}")
-                        return addr
-                dbg("Bruteforce not successful")
+                search_filter = lambda f: "libc" in pathlib.Path(f.filename).name and f.name == ".data"
+                dotdatas = list(filter(search_filter, get_info_files()))
+
+                for dotdata in dotdatas:
+                    search_range = range(dotdata.zone_start, dotdata.zone_end, alignment)
+                    # find first possible candidate
+                    for addr in search_range:
+                        if GlibcArena.verify(addr):
+                            dbg(f"Found candidate at {addr:#x}")
+                            return addr
+                    dbg("Bruteforce not successful")
             except Exception:
                 pass
 

--- a/tests/api/misc.py
+++ b/tests/api/misc.py
@@ -65,3 +65,15 @@ class MiscFunctionTest(RemoteGefUnitTestGeneric):
         gdb.execute("gef config gef.propagate_debug_exception True")
         with pytest.raises(Exception):
             gdb.execute("hexdump byte *0")
+
+    def test_func_process_lookup_path(self):
+        root, gdb = self._conn.root, self._gdb
+        gdb.execute("start")
+
+        assert root.eval("process_lookup_path('meh')") is None
+
+        libc = root.eval("process_lookup_path('libc')")
+        assert libc is not None
+        assert "libc" in pathlib.Path(libc.path).name
+
+        assert root.eval("process_lookup_path('stack')") is not None

--- a/tests/binaries/Makefile
+++ b/tests/binaries/Makefile
@@ -27,6 +27,7 @@ all: $(LINKED)
 
 %.out : %.c
 	@echo "[+] Building '$(TMPDIR)/$@'"
+	@mkdir -p $(TMPDIR)
 	@$(CC) $(CFLAGS) $(EXTRA_FLAGS) -o $(TMPDIR)/$@ $? $(LDFLAGS)
 
 %.out : %.cpp
@@ -55,3 +56,6 @@ heap-non-main.out heap-tcache.out heap-multiple-heaps.out: EXTRA_FLAGS := -pthre
 heap-bins.out: EXTRA_FLAGS := -Wno-unused-result
 
 default.out: EXTRA_FLAGS := -fstack-protector-all -fpie -pie
+
+collision.out: TMPDIR := $(TMPDIR)/collision-libc
+

--- a/tests/binaries/Makefile
+++ b/tests/binaries/Makefile
@@ -58,4 +58,3 @@ heap-bins.out: EXTRA_FLAGS := -Wno-unused-result
 default.out: EXTRA_FLAGS := -fstack-protector-all -fpie -pie
 
 collision.out: TMPDIR := $(TMPDIR)/collision-libc
-

--- a/tests/binaries/collision.c
+++ b/tests/binaries/collision.c
@@ -1,0 +1,16 @@
+/**
+ * collision.c
+ * -*- mode: c -*-
+ * -*- coding: utf-8 -*-
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+
+int main(int argc, char** argv, char** envp)
+{
+        printf("Hello World!\n");
+        return EXIT_SUCCESS;
+}

--- a/tests/regressions/filename_collision_lookup.py
+++ b/tests/regressions/filename_collision_lookup.py
@@ -20,10 +20,6 @@ class RegressionFilenameCollisionLookup(RemoteGefUnitTestGeneric):
         program = root.eval("process_lookup_path('collision')")
         libc = root.eval("process_lookup_path('libc')")
 
-        print(program)
-        print(libc)
-
         assert program is not None
         assert libc is not None
-        # TODO: Check if we can compare sections directly
-        assert program.page_start != libc.page_start
+        assert program != libc

--- a/tests/regressions/filename_collision_lookup.py
+++ b/tests/regressions/filename_collision_lookup.py
@@ -7,6 +7,8 @@ from tests.utils import debug_target
 class RegressionFilenameCollisionLookup(RemoteGefUnitTestGeneric):
     """Tests for regression about collisions in filenames while using
     `process_lookup_path`
+
+    PR: https://github.com/hugsy/gef/pull/1083
     """
 
     def setUp(self) -> None:

--- a/tests/regressions/filename_collision_lookup.py
+++ b/tests/regressions/filename_collision_lookup.py
@@ -1,0 +1,29 @@
+import pytest
+
+from tests.base import RemoteGefUnitTestGeneric
+from tests.utils import debug_target
+
+
+class RegressionFilenameCollisionLookup(RemoteGefUnitTestGeneric):
+    """Tests for regression about collisions in filenames while using
+    `process_lookup_path`
+    """
+
+    def setUp(self) -> None:
+        self._target = debug_target("collision-libc/collision")
+        return super().setUp()
+
+    def test_process_lookup_path_use_only_filename(self):
+        root, gdb = self._conn.root, self._gdb
+
+        gdb.execute("start")
+        program = root.eval("process_lookup_path('collision')")
+        libc = root.eval("process_lookup_path('libc')")
+
+        print(program)
+        print(libc)
+
+        assert program is not None
+        assert libc is not None
+        # TODO: Check if we can compare sections directly
+        assert program.page_start != libc.page_start


### PR DESCRIPTION
## Expected behavior

- Find the `main_arena` even if there is "libc" in the path of files that aren't libc.
- Warn the user when there are multiple matches when using `$_base("xxx")`
- Search for "xxx" in the filename instead of the entire path when possible when using `$_base("xxx")`

## Current behavior

```
(remote) gef➤  vmmap
[ Legend:  Code | Heap | Stack ]
Start              End                Offset             Perm Path
0x000061077d582000 0x000061077d583000 0x0000000000001000 r-- /home/user/ctf-fcsc/file-checker-src/public/file-checker_remotelibc
0x000061077d583000 0x000061077d584000 0x0000000000001000 r-x /home/user/ctf-fcsc/file-checker-src/public/file-checker_remotelibc
0x000061077d584000 0x000061077d585000 0x0000000000001000 r-- /home/user/ctf-fcsc/file-checker-src/public/file-checker_remotelibc
0x000061077d585000 0x000061077d586000 0x0000000000001000 r-- /home/user/ctf-fcsc/file-checker-src/public/file-checker_remotelibc
0x000061077d586000 0x000061077d587000 0x0000000000001000 rw- /home/user/ctf-fcsc/file-checker-src/public/file-checker_remotelibc
0x000061077d587000 0x000061077d589000 0x0000000000002000 rw- /home/user/ctf-fcsc/file-checker-src/public/file-checker_remotelibc
0x0000715ebf600000 0x0000715ebf628000 0x0000000000028000 r-- /home/user/.cache/.pwntools-cache-3.11/libcdb_libs/8f2af70b7deed50338b9186c7dd60cef3826e18f/libc.so.6
0x0000715ebf628000 0x0000715ebf7b0000 0x0000000000188000 r-x /home/user/.cache/.pwntools-cache-3.11/libcdb_libs/8f2af70b7deed50338b9186c7dd60cef3826e18f/libc.so.6
0x0000715ebf7b0000 0x0000715ebf7ff000 0x000000000004f000 r-- /home/user/.cache/.pwntools-cache-3.11/libcdb_libs/8f2af70b7deed50338b9186c7dd60cef3826e18f/libc.so.6
0x0000715ebf7ff000 0x0000715ebf803000 0x0000000000004000 r-- /home/user/.cache/.pwntools-cache-3.11/libcdb_libs/8f2af70b7deed50338b9186c7dd60cef3826e18f/libc.so.6
0x0000715ebf803000 0x0000715ebf805000 0x0000000000002000 rw- /home/user/.cache/.pwntools-cache-3.11/libcdb_libs/8f2af70b7deed50338b9186c7dd60cef3826e18f/libc.so.6
0x0000715ebf805000 0x0000715ebf812000 0x000000000000d000 rw-
0x0000715ebf8fa000 0x0000715ebf8ff000 0x0000000000005000 rw-
0x0000715ebf8ff000 0x0000715ebf900000 0x0000000000001000 r-- /home/user/.cache/.pwntools-cache-3.11/libcdb_libs/8f2af70b7deed50338b9186c7dd60cef3826e18f/ld-linux-x86-64.so.2
0x0000715ebf900000 0x0000715ebf92b000 0x000000000002b000 r-x /home/user/.cache/.pwntools-cache-3.11/libcdb_libs/8f2af70b7deed50338b9186c7dd60cef3826e18f/ld-linux-x86-64.so.2
0x0000715ebf92b000 0x0000715ebf935000 0x000000000000a000 r-- /home/user/.cache/.pwntools-cache-3.11/libcdb_libs/8f2af70b7deed50338b9186c7dd60cef3826e18f/ld-linux-x86-64.so.2
0x0000715ebf935000 0x0000715ebf937000 0x0000000000002000 r-- /home/user/.cache/.pwntools-cache-3.11/libcdb_libs/8f2af70b7deed50338b9186c7dd60cef3826e18f/ld-linux-x86-64.so.2
0x0000715ebf937000 0x0000715ebf939000 0x0000000000002000 rw- /home/user/.cache/.pwntools-cache-3.11/libcdb_libs/8f2af70b7deed50338b9186c7dd60cef3826e18f/ld-linux-x86-64.so.2
0x00007fffda699000 0x00007fffda6ba000 0x0000000000021000 rw- [stack]
0x00007fffda711000 0x00007fffda715000 0x0000000000004000 r-- [vvar]
0x00007fffda715000 0x00007fffda717000 0x0000000000002000 r-x [vdso]
(remote) gef➤  print $_base("libc")
$1 = 0x61077d582000
(remote) gef➤  heap chunks
[!] Invalid arena
```
