### PR TITLE
Evaluate arguments passed to `vmmap`

### DIFF
--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -15,3 +15,7 @@ determine which section it belongs to.
 ![vmmap-grep](https://i.imgur.com/ZFF4QVf.png)
 
 ![vmmap-address](https://i.imgur.com/hfcs1jH.png)
+
+The address can be also be given in the form of a register or variable.
+
+![vmmap-register](https://i.imgur.com/RlZA6NU.png)

--- a/gef.py
+++ b/gef.py
@@ -8711,6 +8711,10 @@ class VMMapCommand(GenericCommand):
                 addr = int(argv[0], 0)
                 if addr >= entry.page_start and addr < entry.page_end:
                     self.print_entry(entry)
+            else:
+                addr = safe_parse_and_eval(argv[0])
+                if addr is not None and addr >= entry.page_start and addr < entry.page_end:
+                    self.print_entry(entry)
         return
 
     def print_entry(self, entry: Section) -> None:

--- a/tests/commands/vmmap.py
+++ b/tests/commands/vmmap.py
@@ -21,3 +21,6 @@ class VmmapCommand(RemoteGefUnitTestGeneric):
 
         res = gdb.execute("vmmap stack", to_string=True)
         self.assertGreater(len(res.splitlines()), 1)
+
+        res = gdb.execute("vmmap $rip", to_string=True)
+        self.assertEqual(len(res.splitlines()), 2)


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->

Attempts to parse and eval an argument passed to `vmmap`.

<!-- Why is this change required? What problem does it solve? -->

This makes `vmmap $rip`, for example, work.

<!-- Why is this patch will make a better world? -->

This is useful as it is easier to look up the memory section a pointer contained in a register/variable points to. It's also more consistent with commands like `dereference`

<!-- How does this look? Add a screenshot if you can -->
![image](https://github.com/hugsy/gef/assets/13556931/4e88ebf8-e7d6-425d-9099-f78debc20bfc)

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.
