### PR TITLE
add layout mapping API for external plugins

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -121,6 +121,26 @@ def register_external_context_pane(
 *  `condition_callback` (optional): a function that returns a boolean deciding whether this context
  pane should be shown
 
+### Context Layout Mapping API
+
+This API is designed for registering a new layout mapping for a GEF Context View. It specifies the interface for the function register_external_context_layout_mapping which operates similarly to the previously discussed register_external_context_pane. Pane must have been previously established in the layout configuration.
+
+```python
+def register_external_context_layout_mapping(
+    current_pane_name: str,
+    display_pane_function: Callable[[], None],
+    pane_title_function: Callable[[], Optional[str]],
+    condition: Optional[Callable[[], bool]] = None
+) -> None:
+```
+
+Registers a new mapping for an existing pane within the GEF Context View.
+
+*  `current_pane_name`: the name of an already registered pane in the layout
+*  `display_pane_function`: a function that prints content in the pane using `gef_print()`
+*  `pane_title_function`: a function that returns a string to be used as the pane title or None if no title should be displayed
+*  `condition`: (optional) a predicate function that must return True for the pane content and title to be displayed; if it returns False, the pane is skipped
+
 ## API
 
 Some of the most important parts of the API for creating new commands are mentioned (but not limited

--- a/docs/api.md
+++ b/docs/api.md
@@ -123,7 +123,10 @@ def register_external_context_pane(
 
 ### Context Layout Mapping API
 
-This API is designed for registering a new layout mapping for a GEF Context View. It specifies the interface for the function register_external_context_layout_mapping which operates similarly to the previously discussed register_external_context_pane. Pane must have been previously established in the layout configuration.
+This API is designed for registering a new layout mapping for a GEF Context View. It specifies
+the interface for the function register_external_context_layout_mapping which operates similarly
+to the previously discussed register_external_context_pane. Pane must have been previously
+established in the layout configuration.
 
 ```python
 def register_external_context_layout_mapping(
@@ -138,8 +141,10 @@ Registers a new mapping for an existing pane within the GEF Context View.
 
 *  `current_pane_name`: the name of an already registered pane in the layout
 *  `display_pane_function`: a function that prints content in the pane using `gef_print()`
-*  `pane_title_function`: a function that returns a string to be used as the pane title or None if no title should be displayed
-*  `condition`: (optional) a predicate function that must return True for the pane content and title to be displayed; if it returns False, the pane is skipped
+*  `pane_title_function`: a function that returns a string to be used as the pane title or
+None if no title should be displayed
+*  `condition`: (optional) a predicate function that must return True for the pane content
+and title to be displayed; if it returns False, the pane is skipped
 
 ## API
 

--- a/gef.py
+++ b/gef.py
@@ -4550,6 +4550,27 @@ def register_external_context_pane(pane_name: str, display_pane_function: Callab
     gef.gdb.add_context_pane(pane_name, display_pane_function, pane_title_function, condition)
     return
 
+def register_external_context_layout_mapping(current_pane_name: str, display_pane_function: Callable[[], None], pane_title_function: Callable[[], Optional[str]], condition : Optional[Callable[[], bool]] = None) -> None:
+    """
+    Registering function for new GEF Context View.
+    current_pane_name: a previously registered (in "layout") pane name.
+    display_pane_function: a function that uses gef_print() to print strings
+    pane_title_function: a function that returns a string or None, which will be displayed as the title.
+    If None, no title line is displayed.
+    condition: an optional callback: if not None, the callback will be executed first. If it returns true,
+      then only the pane title and content will displayed. Otherwise, it's simply skipped.
+
+    Example usage for a simple text to show when we hit a syscall:
+    def only_syscall(): return gef_current_instruction(gef.arch.pc).is_syscall()
+    def display_pane():
+      gef_print("Wow, I am a context pane!")
+    def pane_title():
+      return "example:pane"
+    register_external_context_pane("example_pane", display_pane, pane_title, only_syscall)
+    """
+    gef.gdb.add_context_layout_mapping(current_pane_name, display_pane_function, pane_title_function, condition)
+    return
+
 
 #
 # Commands
@@ -9836,6 +9857,14 @@ class GefCommand(gdb.Command):
         gdb.execute("gef help")
         return
 
+    def add_context_layout_mapping(self, current_pane_name: str, display_pane_function: Callable, pane_title_function: Callable, condition: Optional[Callable]) -> None:
+        """Add a new context layout mapping."""
+        context = self.commands["context"]
+        assert isinstance(context, ContextCommand)
+
+        # overload the printing of pane title
+        context.layout_mapping[current_pane_name] = (display_pane_function, pane_title_function, condition)
+
     def add_context_pane(self, pane_name: str, display_pane_function: Callable, pane_title_function: Callable, condition: Optional[Callable]) -> None:
         """Add a new context pane to ContextCommand."""
         context = self.commands["context"]
@@ -9845,8 +9874,7 @@ class GefCommand(gdb.Command):
         corrected_settings_name: str = pane_name.replace(" ", "_")
         gef.config["context.layout"] += f" {corrected_settings_name}"
 
-        # overload the printing of pane title
-        context.layout_mapping[corrected_settings_name] = (display_pane_function, pane_title_function, condition)
+        add_context_layout_mapping(corrected_settings_name, display_pane_function, pane_title_function, condition)
 
     def load(self) -> None:
         """Load all the commands and functions defined by GEF into GDB."""

--- a/gef.py
+++ b/gef.py
@@ -4551,23 +4551,6 @@ def register_external_context_pane(pane_name: str, display_pane_function: Callab
     return
 
 def register_external_context_layout_mapping(current_pane_name: str, display_pane_function: Callable[[], None], pane_title_function: Callable[[], Optional[str]], condition : Optional[Callable[[], bool]] = None) -> None:
-    """
-    Registering function for new GEF Context View.
-    current_pane_name: a previously registered (in "layout") pane name.
-    display_pane_function: a function that uses gef_print() to print strings
-    pane_title_function: a function that returns a string or None, which will be displayed as the title.
-    If None, no title line is displayed.
-    condition: an optional callback: if not None, the callback will be executed first. If it returns true,
-      then only the pane title and content will displayed. Otherwise, it's simply skipped.
-
-    Example usage for a simple text to show when we hit a syscall:
-    def only_syscall(): return gef_current_instruction(gef.arch.pc).is_syscall()
-    def display_pane():
-      gef_print("Wow, I am a context pane!")
-    def pane_title():
-      return "example:pane"
-    register_external_context_pane("example_pane", display_pane, pane_title, only_syscall)
-    """
     gef.gdb.add_context_layout_mapping(current_pane_name, display_pane_function, pane_title_function, condition)
     return
 

--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -38,7 +38,9 @@ fi
 git clone --branch ${branch} https://github.com/hugsy/gef-extras.git "${DIR}"
 ver=$(gdb -q -nx -ex 'pi print(f"{sys.version_info.major}.{sys.version_info.minor}", end="")' -ex quit)
 python${ver} -m pip install --requirement "${DIR}"/requirements.txt --upgrade
-gdb -q -ex "gef config gef.extra_plugins_dir '${DIR}/scripts'" \
+gdb -q -ex "pi gef.config['context.layout'] += ' syscall_args'" \
+       -ex "pi gef.config['context.layout'] += ' libc_function_args'" \
+       -ex "gef config gef.extra_plugins_dir '${DIR}/scripts'" \
        -ex "gef config pcustom.struct_path '${DIR}/structs'" \
        -ex "gef config syscall-args.path '${DIR}/syscall-tables'" \
        -ex "gef config context.libc_args True" \


### PR DESCRIPTION
## Description

This fixes all the issues with the context panes and it now works as it did before the plugins were created. 

In the GEF part, it was just a minor refactor and a new external API. 

In the gef-extras part, it was only necessary to call this new function!

I think the proposed solution is simple and it works.

gef-extras code:
- https://github.com/hugsy/gef-extras/pull/111

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [X] My change includes a change to the documentation, if required.
-  [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.
