### PR TITLE
Supporting changes for the "got-audit" command.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -7,6 +7,7 @@ Therefore it requires the following binaries to be present:
 
 *  `file`
 *  `readelf`
+*  `nm`
 *  `ps`
 *  `python3`
 

--- a/gef.py
+++ b/gef.py
@@ -9263,6 +9263,11 @@ class GotCommand(GenericCommand):
                                          "Line color of the got command output for unresolved function")
         return
 
+    def build_line(self, name: str, color: str, address_val: int, got_address: int):
+        line = f"[{hex(address_val)}] "
+        line += Color.colorify(f"{name} {RIGHT_ARROW} {hex(got_address)}", color)
+        return line
+
     @only_if_gdb_running
     def do_invoke(self, argv: List[str]) -> None:
         readelf = gef.session.constants["readelf"]
@@ -9289,7 +9294,7 @@ class GotCommand(GenericCommand):
                 relro_status = "No RelRO"
 
         # retrieve jump slots using readelf
-        lines = gef_execute_external([readelf, "--relocs", elf_file], as_list=True)
+        lines = gef_execute_external([readelf, "--wide", "--relocs", elf_file], as_list=True)
         jmpslots = [line for line in lines if "JUMP" in line]
 
         gef_print(f"\nGOT protection: {relro_status} | GOT functions: {len(jmpslots)}\n ")
@@ -9317,8 +9322,7 @@ class GotCommand(GenericCommand):
             else:
                 color = self["function_resolved"]
 
-            line = f"[{hex(address_val)}] "
-            line += Color.colorify(f"{name} {RIGHT_ARROW} {hex(got_address)}", color)
+            line = self.build_line(name, color, address_val, got_address)
             gef_print(line)
         return
 
@@ -11072,7 +11076,7 @@ class GefSessionManager(GefManager):
         self.aliases: List[GefAlias] = []
         self.modules: List[FileFormat] = []
         self.constants = {} # a dict for runtime constants (like 3rd party file paths)
-        for constant in ("python3", "readelf", "file", "ps"):
+        for constant in ("python3", "readelf", "nm", "file", "ps"):
             self.constants[constant] = which(constant)
         return
 

--- a/gef.py
+++ b/gef.py
@@ -9263,7 +9263,7 @@ class GotCommand(GenericCommand):
                                          "Line color of the got command output for unresolved function")
         return
 
-    def build_line(self, name: str, color: str, address_val: int, got_address: int):
+    def build_line(self, name: str, color: str, address_val: int, got_address: int) -> str:
         line = f"[{hex(address_val)}] "
         line += Color.colorify(f"{name} {RIGHT_ARROW} {hex(got_address)}", color)
         return line


### PR DESCRIPTION
## Description

This change moves the setup of the line describing a GOT entry into a method in order to support the "got-audit" command, which is a subclass of the GotCommand.  It also uses a full-width output from readelf, and gets the path for `nm`, both of which also support the got-audit command as a subclass.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
