### PR TITLE
Correctly parse offset from `info proc mappings` output (#1096)

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -10705,7 +10705,7 @@ class GefMemoryManager(GefManager):
                 break
 
             parts = [x.strip() for x in line.split()]
-            addr_start, addr_end, offset = [int(x, 16) for x in parts[0:3]]
+            addr_start, addr_end, _, offset = [int(x, 16) for x in parts[0:4]]
             if mock_permission:
                 perm = Permission(7)
                 path = " ".join(parts[4:]) if len(parts) >= 4 else ""

--- a/tests/api/gef_memory.py
+++ b/tests/api/gef_memory.py
@@ -75,8 +75,11 @@ class GefMemoryApi(RemoteGefUnitTestGeneric):
                 next(root.eval("gef.memory.parse_gdb_info_proc_maps()") )
 
         else:
-            for section in root.eval("gef.memory.parse_gdb_info_proc_maps()"):
-                assert isinstance(section, Section)
+            sections = list(root.eval("gef.memory.parse_gdb_info_proc_maps()"))
+            with open(f"/proc/{gef.session.pid}/maps") as f:
+                for section, line in zip(sections, f.read().splitlines()):
+                    assert isinstance(section, Section)
+                    assert section.offset == int(line.split()[2], 16)
 
     def test_func_parse_permissions(self):
         root = self._conn.root


### PR DESCRIPTION
## Description
Fix the Offset column in the `vmmap` command by getting the offset from the correct column in `parse_gdb_info_proc_maps`.

Before:
```
gef➤  vmmap
[ Legend:  Code | Heap | Stack ]
Start              End                Offset             Perm Path
0x0000555555554000 0x0000555555558000 0x0000000000004000 r-- /usr/bin/ls
0x0000555555558000 0x000055555556e000 0x0000000000016000 r-x /usr/bin/ls
0x000055555556e000 0x0000555555577000 0x0000000000009000 r-- /usr/bin/ls
0x0000555555577000 0x0000555555579000 0x0000000000002000 r-- /usr/bin/ls
0x0000555555579000 0x000055555557a000 0x0000000000001000 rw- /usr/bin/ls
0x000055555557a000 0x000055555557b000 0x0000000000001000 rw- [heap]
```

After:
```
gef➤  vmmap
[ Legend:  Code | Heap | Stack ]
Start              End                Offset             Perm Path
0x0000555555554000 0x0000555555558000 0x0000000000000000 r-- /usr/bin/ls
0x0000555555558000 0x000055555556e000 0x0000000000004000 r-x /usr/bin/ls
0x000055555556e000 0x0000555555577000 0x000000000001a000 r-- /usr/bin/ls
0x0000555555577000 0x0000555555579000 0x0000000000023000 r-- /usr/bin/ls
0x0000555555579000 0x000055555557a000 0x0000000000025000 rw- /usr/bin/ls
0x000055555557a000 0x000055555557b000 0x0000000000000000 rw- [heap]
```

info proc mappings:
```
gef➤  info proc mappings
process 18800
Mapped address spaces:

          Start Addr           End Addr       Size     Offset  Perms  objfile
      0x555555554000     0x555555558000     0x4000        0x0  r--p   /usr/bin/ls
      0x555555558000     0x55555556e000    0x16000     0x4000  r-xp   /usr/bin/ls
      0x55555556e000     0x555555577000     0x9000    0x1a000  r--p   /usr/bin/ls
      0x555555577000     0x555555579000     0x2000    0x23000  r--p   /usr/bin/ls
      0x555555579000     0x55555557a000     0x1000    0x25000  rw-p   /usr/bin/ls
      0x55555557a000     0x55555557b000     0x1000        0x0  rw-p   [heap]
```

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
