### PR TITLE
[libc] Fix `find_libc_version` for checking each readable maps

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -11505,7 +11505,7 @@ class GefLibcManager(GefManager):
     @lru_cache()
     def find_libc_version() -> Tuple[int, int]:
         """Attempt to determine the libc version. This operation can be long."""
-        libc_sections = (m for m in gef.memory.maps if "libc" in m.path and m.permission == Permission.READ)
+        libc_sections = (m for m in gef.memory.maps if "libc" in m.path and m.permission & Permission.READ)
         for section in libc_sections:
             # Try to determine from the filepath
             match = re.search(GefLibcManager.PATTERN_LIBC_VERSION_FILENAME, section.path)


### PR DESCRIPTION
On a 2.30 libc, the string `glibc 2.30` was on a `r-x` page instead of a `r--` page.
Checking all readable pages would not affect performances too much since it is unlikely to have lots of libc maps, and this function is not called often.