### PR TITLE
[cmd] Allow for filtering about maps permissions in `vmmap`

### DIFF
--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -9,8 +9,8 @@ differs from one architecture to another (this is one of the main reasons I star
 place). For example, you can learn that ELF running on SPARC architectures always have their `.data`
 and `heap` sections set as Read/Write/Execute.
 
-`vmmap` accepts one argument, either a pattern to match again mapping names, or an address to
-determine which section it belongs to.
+`vmmap` accepts one argument, either a pattern to match again mapping names, an address to determine
+which section it belongs to, or the permissions of the sections to match.
 
 ![vmmap-grep](https://i.imgur.com/ZFF4QVf.png)
 

--- a/gef.py
+++ b/gef.py
@@ -8791,6 +8791,12 @@ class VMMapCommand(GenericCommand):
                 addr = int(argv[0], 0)
                 if addr >= entry.page_start and addr < entry.page_end:
                     self.print_entry(entry)
+            elif argv[0][0] in 'r-' and \
+                    argv[0][1] in 'w-' and \
+                    argv[0][2] in 'x-':
+                perms = Permission.from_process_maps(argv[0])
+                if entry.permission == perms:
+                    self.print_entry(entry)
             else:
                 addr = safe_parse_and_eval(argv[0])
                 if addr is not None and addr >= entry.page_start and addr < entry.page_end:


### PR DESCRIPTION
This CL allows for searching sections by their permissions. For instance, you could search for all rwx sections by typing `vmmap rwx`.