### PR TITLE
[cmd] Add a `arch` command for managing `gef.arch`

### DIFF
--- a/docs/commands/arch.md
+++ b/docs/commands/arch.md
@@ -1,0 +1,12 @@
+## Command `arch`
+
+`arch` manages the loaded architecture.
+
+There are 3 available sub-commands:
+- `list`: List the installed architectures.
+- `get`: This prints the currently loaded architecture, and why it is selected.
+- `set`: You can manually set the loaded architecture by providing its name as an argument, or let
+  gef do magic to detect the architecture by not providing arguments.
+
+![arch](https://imgur.com/a/6JUoOmS)
+

--- a/docs/commands/arch.md
+++ b/docs/commands/arch.md
@@ -14,4 +14,4 @@ There are 3 available sub-commands:
 > automatically. Force-setting the architecture can lead to unexpected behavior if not done correctly.
 
 
-![arch](https://imgur.com/a/6JUoOmS)
+![arch](https://github.com/hugsy/gef/assets/590234/c4481a78-9311-43ba-929f-2817c5c9290e)

--- a/docs/commands/arch.md
+++ b/docs/commands/arch.md
@@ -9,4 +9,3 @@ There are 3 available sub-commands:
   gef do magic to detect the architecture by not providing arguments.
 
 ![arch](https://imgur.com/a/6JUoOmS)
-

--- a/docs/commands/arch.md
+++ b/docs/commands/arch.md
@@ -5,8 +5,8 @@
 There are 3 available sub-commands:
 
 -  `list`: List the installed architectures.
--  `get`: This prints the currently loaded architecture, and why it is selected.
--  `set`: You can manually set the loaded architecture by providing its name as an argument, or let
+-  `get`: Print the currently loaded architecture, and why it is selected.
+-  `set`: Manually set the loaded architecture by providing its name as an argument, or let
   gef do magic to detect the architecture by not providing arguments.
 
 > [!WARNING]

--- a/docs/commands/arch.md
+++ b/docs/commands/arch.md
@@ -10,7 +10,7 @@ There are 3 available sub-commands:
   gef do magic to detect the architecture by not providing arguments.
 
 > [!WARNING]
-> Setting manually should be done as a last resort as GEF expects to find the architecture 
+> Setting manually should be done as a last resort as GEF expects to find the architecture
 > automatically. Force-setting the architecture can lead to unexpected behavior if not done correctly.
 
 

--- a/docs/commands/arch.md
+++ b/docs/commands/arch.md
@@ -9,5 +9,9 @@ There are 3 available sub-commands:
 -  `set`: You can manually set the loaded architecture by providing its name as an argument, or let
   gef do magic to detect the architecture by not providing arguments.
 
+> [!WARNING]
+> Setting manually should be done as a last resort as GEF expects to find the architecture 
+> automatically. Force-setting the architecture can lead to unexpected behavior if not done correctly.
+
 
 ![arch](https://imgur.com/a/6JUoOmS)

--- a/docs/commands/arch.md
+++ b/docs/commands/arch.md
@@ -3,9 +3,11 @@
 `arch` manages the loaded architecture.
 
 There are 3 available sub-commands:
-- `list`: List the installed architectures.
-- `get`: This prints the currently loaded architecture, and why it is selected.
-- `set`: You can manually set the loaded architecture by providing its name as an argument, or let
+
+-  `list`: List the installed architectures.
+-  `get`: This prints the currently loaded architecture, and why it is selected.
+-  `set`: You can manually set the loaded architecture by providing its name as an argument, or let
   gef do magic to detect the architecture by not providing arguments.
+
 
 ![arch](https://imgur.com/a/6JUoOmS)

--- a/gef.py
+++ b/gef.py
@@ -4823,9 +4823,12 @@ class ArchListCommand(GenericCommand):
     def do_invoke(self, args: List[str]) -> None:
         gef_print(Color.greenify("Available architectures:"))
         for arch in sorted(set(__registered_architectures__.values()), key=lambda x: x.arch):
-            if arch != GenericArchitecture:
-                gef_print(' ' + Color.yellowify(str(arch())))
-                for alias in filter(lambda x: isinstance(x, str), arch.aliases):
+            if arch is GenericArchitecture:
+                continue
+
+            gef_print(' ' + Color.yellowify(str(arch())))
+            for alias in arch.aliases:
+                if isinstance(alias, str):
                     gef_print(f"  {alias}")
 
 
@@ -11625,7 +11628,7 @@ class Gef:
     def __init__(self) -> None:
         self.binary: Optional[FileFormat] = None
         self.arch: Architecture = GenericArchitecture() # see PR #516, will be reset by `new_objfile_handler`
-        self.arch_reason: str = "This default architecture"
+        self.arch_reason: str = "This is the default architecture"
         self.config = GefSettingsManager()
         self.ui = GefUiManager()
         self.libc = GefLibcManager()

--- a/gef.py
+++ b/gef.py
@@ -4769,29 +4769,55 @@ class GenericCommand(gdb.Command):
 
 
 @register
-class ArchCommand(GenericCommand):
+class PieCommand(GenericCommand):
     """Manage the current loaded architecture"""
 
     _cmdline_ = "arch"
     _syntax_ = f"{_cmdline_} (list|get|set) ..."
     _example_ = f"{_cmdline_}"
 
+    def __init__(self) -> None:
+        super().__init__(prefix=True)
+        return
+
+    def do_invoke(self, argv: List[str]) -> None:
+        if not argv:
+            self.usage()
+        return
+
+@register
+class ArchGetCommand(GenericCommand):
+    """Get the current loaded architecture"""
+
+    _cmdline_ = "arch get"
+    _syntax_ = f"{_cmdline_}"
+    _example_ = f"{_cmdline_}"
+
     def do_invoke(self, args: List[str]) -> None:
-        if len(args) == 0 or args[0] == 'get':
-            self._get_cmd()
-        elif args[0] == 'set':
-            self._set_cmd(*args[1:])
-        elif args[0] == 'list':
-            self._list_cmd()
+        gef_print(f"{Color.greenify('Arch')}: {gef.arch}")
+        gef_print(f"{Color.greenify('Reason')}: {gef.arch_reason}")
 
-    def _get_cmd(self) -> None:
-        gef_print(f"{Color.greenify("Arch")}: {gef.arch}")
-        gef_print(f"{Color.greenify("Reason")}: {gef.arch_reason}")
 
-    def _set_cmd(self, arch = None, *args) -> None:
-        reset_architecture(arch)
+@register
+class ArchSetCommand(GenericCommand):
+    """Set the current loaded architecture"""
 
-    def _list_cmd(self) -> None:
+    _cmdline_ = "arch set"
+    _syntax_ = f"{_cmdline_} <arch>"
+    _example_ = f"{_cmdline_}"
+
+    def do_invoke(self, args: List[str]) -> None:
+        reset_architecture(args[0] if args else None)
+
+@register
+class ArchListCommand(GenericCommand):
+    """List the available architectures"""
+
+    _cmdline_ = "arch list"
+    _syntax_ = f"{_cmdline_}"
+    _example_ = f"{_cmdline_}"
+
+    def do_invoke(self, args: List[str]) -> None:
         gef_print(Color.greenify("Available architectures:"))
         for arch in __registered_architectures__.keys():
             if type(arch) == str:

--- a/gef.py
+++ b/gef.py
@@ -4824,7 +4824,7 @@ class ArchListCommand(GenericCommand):
         gef_print(Color.greenify("Available architectures:"))
         for arch in sorted(set(__registered_architectures__.values()), key=lambda x: x.arch):
             if arch != GenericArchitecture:
-                gef_print(' ' + Color.yellowify(arch()))
+                gef_print(' ' + Color.yellowify(str(arch())))
                 for alias in filter(lambda x: isinstance(x, str), arch.aliases):
                     gef_print(f"  {alias}")
 

--- a/gef.py
+++ b/gef.py
@@ -3812,6 +3812,8 @@ def reset_architecture(arch: Optional[str] = None) -> None:
             raise OSError(f"CPU type is currently not supported: {gef.binary.e_machine}")
         return
 
+    warn("Did not find any way to guess the correct architecture :(")
+
 
 @lru_cache()
 def cached_lookup_type(_type: str) -> Optional[gdb.Type]:

--- a/gef.py
+++ b/gef.py
@@ -2277,12 +2277,6 @@ def get_zone_base_address(name: str) -> Optional[int]:
 #
 # Architecture classes
 #
-class ArchitectureReason(enum.StrEnum):
-    DEFAULT = "This default architecture"
-    MANUAL = "The architecture has been set manually"
-    GDB = "The architecture has been detected by GDB"
-    ELF = "The architecture has been detected via the ELF headers"
-
 
 @deprecated("Using the decorator `register_architecture` is unecessary")
 def register_architecture(cls: Type["Architecture"]) -> Type["Architecture"]:
@@ -3792,7 +3786,7 @@ def reset_architecture(arch: Optional[str] = None) -> None:
     if arch:
         try:
             gef.arch = arches[arch]()
-            gef.arch_reason = ArchitectureReason.MANUAL
+            gef.arch_reason = "The architecture has been set manually"
         except KeyError:
             raise OSError(f"Specified arch {arch.upper()} is not supported")
         return
@@ -3803,14 +3797,14 @@ def reset_architecture(arch: Optional[str] = None) -> None:
         preciser_arch = next((a for a in arches.values() if a.supports_gdb_arch(gdb_arch)), None)
         if preciser_arch:
             gef.arch = preciser_arch()
-            gef.arch_reason = ArchitectureReason.GDB
+            gef.arch_reason = "The architecture has been detected by GDB"
             return
 
     # last resort, use the info from elf header to find it from the known architectures
     if gef.binary and isinstance(gef.binary, Elf):
         try:
             gef.arch = arches[gef.binary.e_machine]()
-            gef.arch_reason = ArchitectureReason.ELF
+            gef.arch_reason = "The architecture has been detected via the ELF headers"
         except KeyError:
             raise OSError(f"CPU type is currently not supported: {gef.binary.e_machine}")
         return
@@ -11620,7 +11614,7 @@ class Gef:
     def __init__(self) -> None:
         self.binary: Optional[FileFormat] = None
         self.arch: Architecture = GenericArchitecture() # see PR #516, will be reset by `new_objfile_handler`
-        self.arch_reason = ArchitectureReason.DEFAULT
+        self.arch_reason = "This default architecture"
         self.config = GefSettingsManager()
         self.ui = GefUiManager()
         self.libc = GefLibcManager()

--- a/gef.py
+++ b/gef.py
@@ -4800,8 +4800,16 @@ class ArchSetCommand(GenericCommand):
     _syntax_ = f"{_cmdline_} <arch>"
     _example_ = f"{_cmdline_} X86"
 
+    def __init__(self):
+        super().__init__(complete=-1) # -1 is the default for gdb but not for gef.
+                                      # It means we use the complete method for autocompletion.
+
     def do_invoke(self, args: List[str]) -> None:
         reset_architecture(args[0] if args else None)
+
+    def complete(self, text: str, word: str) -> List[str]:
+        return sorted(x for x in __registered_architectures__.keys() if
+                       isinstance(x, str) and x.startswith(text.strip()))
 
 @register
 class ArchListCommand(GenericCommand):

--- a/gef.py
+++ b/gef.py
@@ -4805,7 +4805,7 @@ class ArchSetCommand(GenericCommand):
 
     def complete(self, text: str, word: str) -> List[str]:
         return sorted(x for x in __registered_architectures__.keys() if
-                       isinstance(x, str) and x.startswith(text.strip()))
+                       isinstance(x, str) and x.lower().startswith(text.lower().strip()))
 
 @register
 class ArchListCommand(GenericCommand):
@@ -4818,7 +4818,7 @@ class ArchListCommand(GenericCommand):
     def do_invoke(self, args: List[str]) -> None:
         gef_print(Color.greenify("Available architectures:"))
         for arch in __registered_architectures__.keys():
-            if type(arch) == str:
+            if type(arch) == str and arch != "GenericArchitecture":
                 gef_print(f"- {arch}")
 
 
@@ -11618,7 +11618,7 @@ class Gef:
     def __init__(self) -> None:
         self.binary: Optional[FileFormat] = None
         self.arch: Architecture = GenericArchitecture() # see PR #516, will be reset by `new_objfile_handler`
-        self.arch_reason = "This default architecture"
+        self.arch_reason: str = "This default architecture"
         self.config = GefSettingsManager()
         self.ui = GefUiManager()
         self.libc = GefLibcManager()

--- a/gef.py
+++ b/gef.py
@@ -4763,12 +4763,12 @@ class GenericCommand(gdb.Command):
 
 
 @register
-class PieCommand(GenericCommand):
-    """Manage the current loaded architecture"""
+class ArchCommand(GenericCommand):
+    """Manage the current loaded architecture."""
 
     _cmdline_ = "arch"
     _syntax_ = f"{_cmdline_} (list|get|set) ..."
-    _example_ = f"{_cmdline_}"
+    _example_ = f"{_cmdline_} set X86"
 
     def __init__(self) -> None:
         super().__init__(prefix=True)
@@ -4781,7 +4781,7 @@ class PieCommand(GenericCommand):
 
 @register
 class ArchGetCommand(GenericCommand):
-    """Get the current loaded architecture"""
+    """Get the current loaded architecture."""
 
     _cmdline_ = "arch get"
     _syntax_ = f"{_cmdline_}"
@@ -4794,18 +4794,18 @@ class ArchGetCommand(GenericCommand):
 
 @register
 class ArchSetCommand(GenericCommand):
-    """Set the current loaded architecture"""
+    """Set the current loaded architecture."""
 
     _cmdline_ = "arch set"
     _syntax_ = f"{_cmdline_} <arch>"
-    _example_ = f"{_cmdline_}"
+    _example_ = f"{_cmdline_} X86"
 
     def do_invoke(self, args: List[str]) -> None:
         reset_architecture(args[0] if args else None)
 
 @register
 class ArchListCommand(GenericCommand):
-    """List the available architectures"""
+    """List the available architectures."""
 
     _cmdline_ = "arch list"
     _syntax_ = f"{_cmdline_}"

--- a/gef.py
+++ b/gef.py
@@ -4800,10 +4800,6 @@ class ArchSetCommand(GenericCommand):
     _syntax_ = f"{_cmdline_} <arch>"
     _example_ = f"{_cmdline_} X86"
 
-    def __init__(self):
-        super().__init__(complete=-1) # -1 is the default for gdb but not for gef.
-                                      # It means we use the complete method for autocompletion.
-
     def do_invoke(self, args: List[str]) -> None:
         reset_architecture(args[0] if args else None)
 

--- a/gef.py
+++ b/gef.py
@@ -4822,7 +4822,7 @@ class ArchListCommand(GenericCommand):
 
     def do_invoke(self, args: List[str]) -> None:
         gef_print(Color.greenify("Available architectures:"))
-        for arch in set(__registered_architectures__.values()):
+        for arch in sorted(set(__registered_architectures__.values()), key=lambda x: x.arch):
             if arch != GenericArchitecture:
                 gef_print(' ' + Color.yellowify(arch()))
                 for alias in filter(lambda x: isinstance(x, str), arch.aliases):

--- a/tests/commands/arch.py
+++ b/tests/commands/arch.py
@@ -3,6 +3,7 @@ Arch commands test module
 """
 
 from tests.base import RemoteGefUnitTestGeneric
+import pytest
 
 
 class ArchCommand(RemoteGefUnitTestGeneric):

--- a/tests/commands/arch.py
+++ b/tests/commands/arch.py
@@ -23,15 +23,15 @@ class ArchCommand(RemoteGefUnitTestGeneric):
         gdb = self._gdb
 
         res = gdb.execute("arch get", to_string=True)
-        self.assertIn(" Architecture(Generic, None, LITTLE_ENDIAN)", res)
-        self.assertIn(" This default architecture", res)
+        self.assertIn(" Architecture(X86, 64, LITTLE_ENDIAN)", res)
+        self.assertIn(" The architecture has been detected via the ELF headers", res)
 
     def test_cmd_arch_set(self):
         gdb = self._gdb
 
         res = gdb.execute("arch get", to_string=True)
-        self.assertIn(" Architecture(Generic, None, LITTLE_ENDIAN)", res)
-        self.assertIn(" This default architecture", res)
+        self.assertIn(" Architecture(X86, 64, LITTLE_ENDIAN)", res)
+        self.assertIn(" The architecture has been detected via the ELF headers", res)
 
         gdb.execute("arch set X86")
 

--- a/tests/commands/arch.py
+++ b/tests/commands/arch.py
@@ -2,24 +2,22 @@
 Arch commands test module
 """
 
+import pytest
+
 from tests.base import RemoteGefUnitTestGeneric
 from tests.utils import ARCH
-import pytest
 
 
 class ArchCommand(RemoteGefUnitTestGeneric):
-    """Generic class for command testing, that defines all helpers"""
-
-    def setUp(self) -> None:
-        return super().setUp()
+    """Class for `arch` command testing."""
 
     @pytest.mark.skipif(ARCH != "x86_64", reason=f"Skipped for {ARCH}")
     def test_cmd_arch_get(self):
         gdb = self._gdb
 
         res = gdb.execute("arch get", to_string=True)
-        self.assertIn(" Architecture(X86, 64, LITTLE_ENDIAN)", res)
-        self.assertIn(" The architecture has been detected via the ELF headers", res)
+        assert " Architecture(X86, 64, LITTLE_ENDIAN)" in res
+        assert " The architecture has been detected via the ELF headers" in res
 
     def test_cmd_arch_set(self):
         gdb = self._gdb
@@ -27,21 +25,21 @@ class ArchCommand(RemoteGefUnitTestGeneric):
         gdb.execute("arch set X86")
 
         res = gdb.execute("arch get", to_string=True)
-        self.assertIn(" Architecture(X86, 32, LITTLE_ENDIAN)", res)
-        self.assertIn(" The architecture has been set manually", res)
+        assert " Architecture(X86, 32, LITTLE_ENDIAN)" in res
+        assert " The architecture has been set manually" in res
 
 
         gdb.execute("arch set ppc")
 
         res = gdb.execute("arch get", to_string=True)
-        self.assertIn(" Architecture(PPC, PPC32, LITTLE_ENDIAN)", res)
-        self.assertIn(" The architecture has been set manually", res)
+        assert " Architecture(PPC, PPC32, LITTLE_ENDIAN)" in res
+        assert " The architecture has been set manually" in res
 
     def test_cmd_arch_list(self):
         gdb = self._gdb
 
         res = gdb.execute("arch list", to_string=True)
-        self.assertNotIn("- GenericArchitecture", res)
-        self.assertIn(" Architecture(X86, 64, LITTLE_ENDIAN)", res)
-        self.assertIn("  X86", res)
-        self.assertIn("  X86_64", res)
+        assert "- GenericArchitecture" not in res
+        assert " Architecture(X86, 64, LITTLE_ENDIAN)" in res
+        assert "  X86" in res
+        assert "  X86_64" in res

--- a/tests/commands/arch.py
+++ b/tests/commands/arch.py
@@ -42,5 +42,6 @@ class ArchCommand(RemoteGefUnitTestGeneric):
 
         res = gdb.execute("arch list", to_string=True)
         self.assertNotIn("- GenericArchitecture", res)
-        self.assertIn("- X86", res)
-        self.assertIn("- X86_64", res)
+        self.assertIn(" Architecture(X86, 64, LITTLE_ENDIAN)", res)
+        self.assertIn("  x86", res)
+        self.assertIn("  x86_64", res)

--- a/tests/commands/arch.py
+++ b/tests/commands/arch.py
@@ -3,14 +3,6 @@ Arch commands test module
 """
 
 from tests.base import RemoteGefUnitTestGeneric
-from tests.utils import (
-    ARCH,
-    ERROR_INACTIVE_SESSION_MESSAGE,
-    debug_target,
-    findlines,
-    is_32b,
-    is_64b,
-)
 
 
 class ArchCommand(RemoteGefUnitTestGeneric):
@@ -19,6 +11,7 @@ class ArchCommand(RemoteGefUnitTestGeneric):
     def setUp(self) -> None:
         return super().setUp()
 
+    @pytest.mark.skipif(ARCH != "x86_64", reason=f"Skipped for {ARCH}")
     def test_cmd_arch_get(self):
         gdb = self._gdb
 
@@ -28,10 +21,6 @@ class ArchCommand(RemoteGefUnitTestGeneric):
 
     def test_cmd_arch_set(self):
         gdb = self._gdb
-
-        res = gdb.execute("arch get", to_string=True)
-        self.assertIn(" Architecture(X86, 64, LITTLE_ENDIAN)", res)
-        self.assertIn(" The architecture has been detected via the ELF headers", res)
 
         gdb.execute("arch set X86")
 
@@ -43,6 +32,6 @@ class ArchCommand(RemoteGefUnitTestGeneric):
         gdb = self._gdb
 
         res = gdb.execute("arch list", to_string=True)
-        self.assertIn("- GenericArchitecture", res)
+        self.assertNotIn("- GenericArchitecture", res)
         self.assertIn("- X86", res)
         self.assertIn("- X86_64", res)

--- a/tests/commands/arch.py
+++ b/tests/commands/arch.py
@@ -36,7 +36,7 @@ class ArchCommand(RemoteGefUnitTestGeneric):
         gdb.execute("arch set X86")
 
         res = gdb.execute("arch get", to_string=True)
-        self.assertIn(" Architecture(Generic, None, LITTLE_ENDIAN)", res)
+        self.assertIn(" Architecture(X86, 32, LITTLE_ENDIAN)", res)
         self.assertIn(" The architecture has been set manually", res)
 
     def test_cmd_arch_list(self):

--- a/tests/commands/arch.py
+++ b/tests/commands/arch.py
@@ -1,0 +1,48 @@
+"""
+Arch commands test module
+"""
+
+from tests.base import RemoteGefUnitTestGeneric
+from tests.utils import (
+    ARCH,
+    ERROR_INACTIVE_SESSION_MESSAGE,
+    debug_target,
+    findlines,
+    is_32b,
+    is_64b,
+)
+
+
+class ArchCommand(RemoteGefUnitTestGeneric):
+    """Generic class for command testing, that defines all helpers"""
+
+    def setUp(self) -> None:
+        return super().setUp()
+
+    def test_cmd_arch_get(self):
+        gdb = self._gdb
+
+        res = gdb.execute("arch get", to_string=True)
+        self.assertIn(" Architecture(Generic, None, LITTLE_ENDIAN)", res)
+        self.assertIn(" This default architecture", res)
+
+    def test_cmd_arch_set(self):
+        gdb = self._gdb
+
+        res = gdb.execute("arch get", to_string=True)
+        self.assertIn(" Architecture(Generic, None, LITTLE_ENDIAN)", res)
+        self.assertIn(" This default architecture", res)
+
+        gdb.execute("arch set X86")
+
+        res = gdb.execute("arch get", to_string=True)
+        self.assertIn(" Architecture(Generic, None, LITTLE_ENDIAN)", res)
+        self.assertIn(" The architecture has been set manually", res)
+
+    def test_cmd_arch_list(self):
+        gdb = self._gdb
+
+        res = gdb.execute("arch list", to_string=True)
+        self.assertIn("- GenericArchitecture", res)
+        self.assertIn("- X86", res)
+        self.assertIn("- X86_64", res)

--- a/tests/commands/arch.py
+++ b/tests/commands/arch.py
@@ -3,6 +3,7 @@ Arch commands test module
 """
 
 from tests.base import RemoteGefUnitTestGeneric
+from tests.utils import ARCH
 import pytest
 
 

--- a/tests/commands/arch.py
+++ b/tests/commands/arch.py
@@ -43,5 +43,5 @@ class ArchCommand(RemoteGefUnitTestGeneric):
         res = gdb.execute("arch list", to_string=True)
         self.assertNotIn("- GenericArchitecture", res)
         self.assertIn(" Architecture(X86, 64, LITTLE_ENDIAN)", res)
-        self.assertIn("  x86", res)
-        self.assertIn("  x86_64", res)
+        self.assertIn("  X86", res)
+        self.assertIn("  X86_64", res)

--- a/tests/commands/arch.py
+++ b/tests/commands/arch.py
@@ -30,6 +30,13 @@ class ArchCommand(RemoteGefUnitTestGeneric):
         self.assertIn(" Architecture(X86, 32, LITTLE_ENDIAN)", res)
         self.assertIn(" The architecture has been set manually", res)
 
+
+        gdb.execute("arch set ppc")
+
+        res = gdb.execute("arch get", to_string=True)
+        self.assertIn(" Architecture(PPC, PPC32, LITTLE_ENDIAN)", res)
+        self.assertIn(" The architecture has been set manually", res)
+
     def test_cmd_arch_list(self):
         gdb = self._gdb
 


### PR DESCRIPTION
    Available subcommands:
    - get  -> prints the current arch and the reason
    - set  -> manually set the current arch (or auto-detect if no arg is provided)
    - list -> list available architectures

Implements this: https://github.com/hugsy/gef/issues/1002