### PR TITLE
[Release 2024.06] Fixes

### DIFF
--- a/tests/api/gef_memory.py
+++ b/tests/api/gef_memory.py
@@ -9,6 +9,7 @@ import pytest
 from tests.base import RemoteGefUnitTestGeneric
 
 from tests.utils import (
+    ARCH,
     debug_target,
     gdbserver_session,
     qemuuser_session,
@@ -135,6 +136,7 @@ class GefMemoryApi(RemoteGefUnitTestGeneric):
             sections = gef.memory.maps
             assert len(sections) > 0
 
+    @pytest.mark.skipif(ARCH not in ("x86_64",), reason=f"Skipped for {ARCH}")
     def test_func_parse_maps_remote_qemu(self):
         gdb, gef = self._gdb, self._gef
         # When in a gef-remote qemu-user session `parse_gdb_info_proc_maps`

--- a/tests/api/gef_session.py
+++ b/tests/api/gef_session.py
@@ -6,10 +6,12 @@ import os
 import pathlib
 import random
 import re
+import pytest
 
 from tests.base import RemoteGefUnitTestGeneric
 
 from tests.utils import (
+    ARCH,
     debug_target,
     gdbserver_session,
     qemuuser_session,
@@ -72,6 +74,7 @@ class GefSessionApi(RemoteGefUnitTestGeneric):
                 expected.st_ino == result.st_ino
             )
 
+    @pytest.mark.skipif(ARCH not in ("x86_64",), reason=f"Skipped for {ARCH}")
     def test_root_dir_qemu(self):
         gdb, gef = self._gdb, self._gef
 

--- a/tests/commands/canary.py
+++ b/tests/commands/canary.py
@@ -13,7 +13,6 @@ class CanaryCommand(RemoteGefUnitTestGeneric):
         self._target = debug_target("canary")
         return super().setUp()
 
-
     def test_cmd_canary(self):
         assert ERROR_INACTIVE_SESSION_MESSAGE == self._gdb.execute("canary", to_string=True)
         self._gdb.execute("start")
@@ -21,14 +20,14 @@ class CanaryCommand(RemoteGefUnitTestGeneric):
         assert "The canary of process" in res
         assert self._gef.session.canary[0] == self._gef.session.original_canary[0]
 
-
     def test_overwrite_canary(self):
         gdb, gef = self._gdb, self._gef
 
         gdb.execute("start")
+        _, canary_address = gef.session.canary
         if is_64b():
-            gef.memory.write(gef.arch.canary_address(), p64(0xdeadbeef))
+            gef.memory.write(canary_address, p64(0xDEADBEEF))
         else:
-            gef.memory.write(gef.arch.canary_address(), p32(0xdeadbeef))
-        res = u32(gef.memory.read(gef.arch.canary_address(), gef.arch.ptrsize))
+            gef.memory.write(canary_address, p32(0xDEADBEEF))
+        res = u32(gef.memory.read(canary_address, gef.arch.ptrsize))
         assert 0xdeadbeef == res

--- a/tests/commands/gef_remote.py
+++ b/tests/commands/gef_remote.py
@@ -8,6 +8,7 @@ import pytest
 
 from tests.base import RemoteGefUnitTestGeneric
 from tests.utils import (
+    ARCH,
     debug_target,
     gdbserver_session,
     qemuuser_session,
@@ -39,6 +40,7 @@ class GefRemoteCommand(RemoteGefUnitTestGeneric):
             assert res.endswith(f"pid={gef.session.pid}, mode={gdbserver_mode})")
 
     @pytest.mark.slow
+    @pytest.mark.skipif(ARCH not in ("x86_64",), reason=f"Skipped for {ARCH}")
     def test_cmd_gef_remote_qemu_user(self):
         gdb = self._gdb
         gef = self._gef

--- a/tests/commands/scan.py
+++ b/tests/commands/scan.py
@@ -11,7 +11,7 @@ class ScanCommand(RemoteGefUnitTestGeneric):
     """`scan` command test module"""
 
     def setUp(self) -> None:
-        self._target = debug_target("checksec-no-pie")
+        self._target = debug_target("default")
         return super().setUp()
 
     def test_cmd_scan(self):

--- a/tests/commands/vmmap.py
+++ b/tests/commands/vmmap.py
@@ -22,5 +22,5 @@ class VmmapCommand(RemoteGefUnitTestGeneric):
         res = gdb.execute("vmmap stack", to_string=True)
         self.assertGreater(len(res.splitlines()), 1)
 
-        res = gdb.execute("vmmap $rip", to_string=True)
+        res = gdb.execute("vmmap $pc", to_string=True)
         self.assertEqual(len(res.splitlines()), 2)


### PR DESCRIPTION
Restores tests on non-x86 (tested arm, arm64 and mips64)

Mostly very minor fixes, only unit tests related.
Qemu tests are temporarily disabled when remoting because they all assume host & target are Intel (not blocking, but must be reworked later). 

![image](https://github.com/hugsy/gef/assets/590234/b22f8a1f-9dc7-42e7-ae14-2f44f780598a)
