### PR TITLE
[cmd] Add support for flags specifying filters type in vmmap, and allow multiple filters

### DIFF
--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -13,9 +13,9 @@ and `heap` sections set as Read/Write/Execute.
 to determine which section it belongs to:
 
 -  `-a` / `--addr`:
-  -  filter by address -> parses the next argument as an integer or asks gdb to interpret the value
+  +  filter by address -> parses the next argument as an integer or asks gdb to interpret the value
 -  `-n` / `--name`:
-  -  filter based on section name
+  +  filter based on section name
 -  If nothing is specified, it prints a warning and guesses the type
 
 ![vmmap-grep](https://github.com/hugsy/gef/assets/11377623/a3dbaa3e-88b0-407f-a0dd-07e65c4a3f73)

--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -13,9 +13,9 @@ and `heap` sections set as Read/Write/Execute.
 to determine which section it belongs to:
 
 -  `-a` / `--addr`:
-   -  filter by address -> parses the next argument as an integer or asks gdb to interpret the value
+  -  filter by address -> parses the next argument as an integer or asks gdb to interpret the value
 -  `-n` / `--name`:
-   -  filter based on section name
+  -  filter based on section name
 -  If nothing is specified, it prints a warning and guesses the type
 
 ![vmmap-grep](https://github.com/hugsy/gef/assets/11377623/a3dbaa3e-88b0-407f-a0dd-07e65c4a3f73)

--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -12,11 +12,11 @@ and `heap` sections set as Read/Write/Execute.
 `vmmap` can accept multiple arguments, either patterns to match again mapping names, or addresses
 to determine which section it belongs to:
 
--  `-a` / `--addr`:
-  +  filter by address -> parses the next argument as an integer or asks gdb to interpret the value
--  `-n` / `--name`:
-  +  filter based on section name
--  If nothing is specified, it prints a warning and guesses the type
+1.  `-a` / `--addr`:
+    -  filter by address -> parses the next argument as an integer or asks gdb to interpret the value
+2.  `-n` / `--name`:
+    -  filter based on section name
+3.  If nothing is specified, it prints a warning and guesses the type
 
 ![vmmap-grep](https://github.com/hugsy/gef/assets/11377623/a3dbaa3e-88b0-407f-a0dd-07e65c4a3f73)
 

--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -9,8 +9,14 @@ differs from one architecture to another (this is one of the main reasons I star
 place). For example, you can learn that ELF running on SPARC architectures always have their `.data`
 and `heap` sections set as Read/Write/Execute.
 
-`vmmap` accepts one argument, either a pattern to match again mapping names, or an address to
-determine which section it belongs to.
+`vmmap` can accept multiple arguments, either patterns to match again mapping names, or addresses
+to determine which section it belongs to:
+
+-  `-a` / `--addr`:
+   -  filter by address -> parses the next argument as an integer or asks gdb to interpret the value
+-  `-n` / `--name`:
+   -  filter based on section name
+-  If nothing is specified, it prints a warning and guesses the type
 
 ![vmmap-grep](https://github.com/hugsy/gef/assets/11377623/a3dbaa3e-88b0-407f-a0dd-07e65c4a3f73)
 

--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -12,10 +12,14 @@ and `heap` sections set as Read/Write/Execute.
 `vmmap` accepts one argument, either a pattern to match again mapping names, or an address to
 determine which section it belongs to.
 
-![vmmap-grep](https://i.imgur.com/ZFF4QVf.png)
+![vmmap-grep](https://github.com/hugsy/gef/assets/11377623/a3dbaa3e-88b0-407f-a0dd-07e65c4a3f73)
 
-![vmmap-address](https://i.imgur.com/hfcs1jH.png)
+![vmmap-address](https://github.com/hugsy/gef/assets/11377623/4dffe491-f927-4f03-b842-4d941140e66c)
 
 The address can be also be given in the form of a register or variable.
 
-![vmmap-register](https://i.imgur.com/RlZA6NU.png)
+![vmmap-register](https://github.com/hugsy/gef/assets/11377623/aed7ecdc-7ad9-4ba5-ae03-329e66432731)
+
+And you can do all of them in one command :)
+
+![vmmap-all-in-one](https://github.com/hugsy/gef/assets/11377623/b043f61b-48b3-4316-9f84-eb83822149ac)

--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -26,6 +26,6 @@ The address can be also be given in the form of a register or variable.
 
 ![vmmap-register](https://github.com/hugsy/gef/assets/11377623/aed7ecdc-7ad9-4ba5-ae03-329e66432731)
 
-And you can do all of them in one command :)
+And you can do all of them in one command 🙂
 
 ![vmmap-all-in-one](https://github.com/hugsy/gef/assets/11377623/b043f61b-48b3-4316-9f84-eb83822149ac)

--- a/gef.py
+++ b/gef.py
@@ -8899,14 +8899,6 @@ class VMMapCommand(GenericCommand):
             err("No address mapping information found")
             return
 
-        # Parse args:
-        #  - `-a` / `--addr`:
-        #    - filter by address -> parses the next arg as an int or asks gdb
-        #    the value
-        #  - `-n` / `--name`:
-        #    - filter based on section name
-        #  - If nothing is specified, print a warning and guess the type
-        current_type = 0 # 0:None, 1:Address, 2:Name
 
         addrs = {}
         names = []

--- a/gef.py
+++ b/gef.py
@@ -8941,7 +8941,7 @@ class VMMapCommand(GenericCommand):
             if len(names) + len(addrs) == 0:
                 self.print_entry(entry)
 
-            elif any(filters):
+            elif filters:
                 if filter_content != last_printed_filter:
                     gef_print() # skip a line between different filters
                     gef_print(Color.greenify(filter_content))

--- a/gef.py
+++ b/gef.py
@@ -8905,7 +8905,7 @@ class VMMapCommand(GenericCommand):
         names: List[str] = [x for x in args.name]
 
         for arg in args.unknown_types:
-            if arg is '':
+            if not arg:
                 continue
 
             if self.is_integer(arg):

--- a/gef.py
+++ b/gef.py
@@ -8938,7 +8938,7 @@ class VMMapCommand(GenericCommand):
                 if entry.page_start <= addr < entry.page_end]
             filter_content = f"[{' & '.join([*names_filter, *addrs_filter])}]"
 
-            if len(names) + len(addrs) == 0:
+            if not names and not addrs:
                 self.print_entry(entry)
 
             elif names_filter or addrs_filter:

--- a/gef.py
+++ b/gef.py
@@ -8906,8 +8906,8 @@ class VMMapCommand(GenericCommand):
 
         current_type: ArgType = ArgType.NONE
 
-        addrs = {}
-        names = []
+        addrs: Dict[str, int] = {}
+        names: List[str] = []
 
         for arg in argv:
             if arg in ("-a", "--addr"):

--- a/gef.py
+++ b/gef.py
@@ -8936,7 +8936,7 @@ class VMMapCommand(GenericCommand):
             names_filter = [f"name = '{x}'" for x in names if x in entry.path]
             addrs_filter = [f"addr = {self.format_addr_filter(arg, addr)}" for arg, addr in addrs.items()
                 if entry.page_start <= addr < entry.page_end]
-            filter_content = f"[{' & '.join([*names filter, *addrs_filter])}]"
+            filter_content = f"[{' & '.join([*names_filter, *addrs_filter])}]"
 
             if len(names) + len(addrs) == 0:
                 self.print_entry(entry)

--- a/gef.py
+++ b/gef.py
@@ -8936,8 +8936,7 @@ class VMMapCommand(GenericCommand):
             names_filter = [f"name = '{x}'" for x in names if x in entry.path]
             addrs_filter = [f"addr = {self.format_addr_filter(arg, addr)}" for arg, addr in addrs.items()
                 if entry.page_start <= addr < entry.page_end]
-            filters = names_filter + addrs_filter
-            filter_content = f"[{' & '.join(filters)}]"
+            filter_content = f"[{' & '.join([*names filter, *addrs_filter])}]"
 
             if len(names) + len(addrs) == 0:
                 self.print_entry(entry)

--- a/gef.py
+++ b/gef.py
@@ -8900,9 +8900,9 @@ class VMMapCommand(GenericCommand):
             return
 
         class ArgType(enum.Enum):
-            NONE    : enum.auto()
-            ADDRESS : enum.auto()
-            NAME    : enum.auto()
+            NONE    = enum.auto()
+            ADDRESS = enum.auto()
+            NAME    = enum.auto()
 
         current_type: ArgType = ArgType.NONE
 

--- a/gef.py
+++ b/gef.py
@@ -8941,7 +8941,7 @@ class VMMapCommand(GenericCommand):
             if len(names) + len(addrs) == 0:
                 self.print_entry(entry)
 
-            elif filters:
+            elif names_filter or addrs_filter:
                 if filter_content != last_printed_filter:
                     gef_print() # skip a line between different filters
                     gef_print(Color.greenify(filter_content))

--- a/gef.py
+++ b/gef.py
@@ -8893,7 +8893,7 @@ class VMMapCommand(GenericCommand):
     _example_ = f"{_cmdline_} libc"
 
     @only_if_gdb_running
-    @parse_arguments({'unknown_types': ['']}, {('--addr', '-a'): [''], ('--name', '-n'): ['']})
+    @parse_arguments({"unknown_types": [""]}, {("--addr", "-a"): [""], ("--name", "-n"): [""]})
     def do_invoke(self, _: List[str], **kwargs: Any) -> None:
         args : argparse.Namespace = kwargs["arguments"]
         vmmap = gef.memory.maps

--- a/gef.py
+++ b/gef.py
@@ -8963,8 +8963,8 @@ class VMMapCommand(GenericCommand):
 
         for entry in vmmap:
             names_filter = [f"name = '{x}'" for x in names if x in entry.path]
-            addrs_filter = [f"addr = " + self.format_addr_filter(arg, addr) for arg, addr in addrs.items()
-                if addr >= entry.page_start and addr < entry.page_end]
+            addrs_filter = [f"addr = {self.format_addr_filter(arg, addr)}" for arg, addr in addrs.items()
+                if entry.page_start <= addr < entry.page_end]
             filters = names_filter + addrs_filter
             filter_content = f"[{' & '.join(filters)}]"
 
@@ -8981,10 +8981,8 @@ class VMMapCommand(GenericCommand):
         gef_print()
         return
 
-    def format_addr_filter(self, arg, addr):
-        if self.is_integer(arg):
-            return f"`{arg}`"
-        return f"`{arg}` ({addr:#x})"
+    def format_addr_filter(self, arg: str, addr: int):
+        return f"`{arg}`" if self.is_integer(arg) else f"`{arg}` ({addr:#x})"
 
     def print_entry(self, entry: Section) -> None:
         line_color = ""

--- a/gef.py
+++ b/gef.py
@@ -8899,19 +8899,25 @@ class VMMapCommand(GenericCommand):
             err("No address mapping information found")
             return
 
+        class ArgType(enum.Enum):
+            NONE    : enum.auto()
+            ADDRESS : enum.auto()
+            NAME    : enum.auto()
+
+        current_type: ArgType = ArgType.NONE
 
         addrs = {}
         names = []
 
         for arg in argv:
             if arg in ("-a", "--addr"):
-                current_type = 1
+                current_type = ArgType.ADDRESS
                 continue
             if arg in ("-n", "--name"):
-                current_type = 2
+                current_type = ArgType.NAME
                 continue
 
-            if current_type == 1: # Address
+            if current_type is ArgType.ADDRESS:
                 if self.is_integer(arg):
                     addr = int(arg, 0)
                 else:
@@ -8922,10 +8928,10 @@ class VMMapCommand(GenericCommand):
                 else:
                     addrs[arg] = int(addr)
 
-            elif current_type == 2:
+            elif current_type is ArgType.NAME:
                 names.append(arg)
 
-            elif current_type == 0:
+            elif current_type is ArgType.NONE:
                 if self.is_integer(arg):
                     addr = int(arg, 0)
                 else:
@@ -8940,9 +8946,9 @@ class VMMapCommand(GenericCommand):
                 warn("You can use --name or --addr before the filter value for specifying its type manually.")
                 gef_print()
 
-            current_type = 0
+            current_type = ArgType.NONE
 
-        if current_type:
+        if current_type is not ArgType.NONE:
             warn("The last filter seems to have no value associated, we ignore it .. :/")
 
         if not gef.config["gef.disable_color"]:

--- a/tests/commands/vmmap.py
+++ b/tests/commands/vmmap.py
@@ -23,4 +23,4 @@ class VmmapCommand(RemoteGefUnitTestGeneric):
         self.assertGreater(len(res.splitlines()), 1)
 
         res = gdb.execute("vmmap $pc", to_string=True)
-        self.assertEqual(len(res.splitlines()), 2)
+        self.assertEqual(len(res.splitlines()), 8)

--- a/tests/commands/vmmap.py
+++ b/tests/commands/vmmap.py
@@ -17,7 +17,7 @@ class VmmapCommand(RemoteGefUnitTestGeneric):
         )
         gdb.execute("start")
         res = gdb.execute("vmmap", to_string=True)
-        self.assertEqual(len(res.splitlines()), 23)
+        self.assertGreater(len(res.splitlines()), 1)
 
         res = gdb.execute("vmmap stack", to_string=True)
         assert "`stack` has no type specified. We guessed it was a name filter." in res

--- a/tests/commands/vmmap.py
+++ b/tests/commands/vmmap.py
@@ -17,10 +17,34 @@ class VmmapCommand(RemoteGefUnitTestGeneric):
         )
         gdb.execute("start")
         res = gdb.execute("vmmap", to_string=True)
-        self.assertGreater(len(res.splitlines()), 1)
+        self.assertEqual(len(res.splitlines()), 23)
 
         res = gdb.execute("vmmap stack", to_string=True)
-        self.assertGreater(len(res.splitlines()), 1)
+        assert "`stack` has no type specified. We guessed it was a name filter." in res
+        self.assertEqual(len(res.splitlines()), 9)
 
         res = gdb.execute("vmmap $pc", to_string=True)
+        assert "`$pc` has no type specified. We guessed it was an address filter." in res
         self.assertEqual(len(res.splitlines()), 8)
+
+    def test_cmd_vmmap_addr(self):
+        gef, gdb = self._gef, self._gdb
+        gdb.execute("start")
+
+        pc = gef.arch.register("pc")
+
+        res = gdb.execute(f"vmmap -a {pc:#x}", to_string=True)
+        self.assertEqual(len(res.splitlines()), 5)
+
+        res = gdb.execute("vmmap --addr $pc", to_string=True)
+        self.assertEqual(len(res.splitlines()), 5)
+
+    def test_cmd_vmmap_name(self):
+        gdb = self._gdb
+        gdb.execute("start")
+
+        res = gdb.execute("vmmap -n stack", to_string=True)
+        self.assertEqual(len(res.splitlines()), 5)
+
+        res = gdb.execute("vmmap --name stack", to_string=True)
+        self.assertEqual(len(res.splitlines()), 5)


### PR DESCRIPTION
Parse args:
 - `-a` / `--addr`:
   - filter by address -> parses the next arg as an int or asks gdb the value
 - `-n` / `--name`:
   - filter based on section name
 - If nothing is specified, print a warning and guess the type (previous behavior)