### PR TITLE
[internal] Add a way to append values to optional arguments in `parse_arguments` decorator

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -493,7 +493,7 @@ def parse_arguments(required_arguments: Dict[Union[str, Tuple[str, str]], Any],
                     continue
                 elif argtype in (list, tuple):
                     parser.add_argument(*argname, type=type(argvalue[0]),
-                                        default=[], action='append')
+                                        default=[], action="append")
                     continue
                 parser.add_argument(*argname, type=argtype, default=argvalue)
 

--- a/gef.py
+++ b/gef.py
@@ -491,6 +491,10 @@ def parse_arguments(required_arguments: Dict[Union[str, Tuple[str, str]], Any],
                 elif argtype is bool:
                     parser.add_argument(*argname, action="store_false" if argvalue else "store_true")
                     continue
+                elif argtype in (list, tuple):
+                    parser.add_argument(*argname, type=type(argvalue[0]),
+                                        default=[], action='append')
+                    continue
                 parser.add_argument(*argname, type=argtype, default=argvalue)
 
             parsed_args = parser.parse_args(*(args[1:]))


### PR DESCRIPTION
Add support for the `append` action for ArgumentParser in the `parse_arguments` decorator on optional arguments.

This makes us able to support this:

```
command --arg 1 --arg 2 --arg 3
```

And get `[1, 2, 3]` as the `arg` value.

This CL is required to make changes to https://github.com/hugsy/gef/pull/1120 before merging.