### PR TITLE
Fix an incorrect scoped function call (introduced in #1093)

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -9974,7 +9974,7 @@ class GefCommand(gdb.Command):
         corrected_settings_name: str = pane_name.replace(" ", "_")
         gef.config["context.layout"] += f" {corrected_settings_name}"
 
-        add_context_layout_mapping(corrected_settings_name, display_pane_function, pane_title_function, condition)
+        self.add_context_layout_mapping(corrected_settings_name, display_pane_function, pane_title_function, condition)
 
     def load(self) -> None:
         """Load all the commands and functions defined by GEF into GDB."""


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->
In #1093, a call to `add_context_layout_mapping` was added without the `self` scoping, causing a crash when external plugins add a context pane to GEF. I triggered this in the latest version of d2d:

```
Python Exception <class 'NameError'>: name 'add_context_layout_mapping' is not defined
Error occurred in Python: name 'add_context_layout_mapping' is not defined
```

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [X] My code follows the code style of this project.
-  [X] My change includes a change to the documentation, if required.
-  [X] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.

## Other Recommendations
If possible, I'd recommend adding a linter check as a requirement to the CI, so simple bugs like this can be caught :). 
