### PR TITLE
Fix python unicode encoding problem when install gef in non-ascii  locale

### DIFF
--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -13,8 +13,8 @@ if [ -f "${HOME}/.gdbinit" ]; then
     mv "${HOME}/.gdbinit" "${HOME}/.gdbinit.old"
 fi
 
-tag=$(python3 -c 'import urllib.request as r,json as j; x=j.loads(r.urlopen("https://api.github.com/repos/hugsy/gef/tags").read()); print(x[0]["name"])')
-python3 -c "import urllib.request as r; x=r.urlopen('https://github.com/hugsy/gef/raw/${tag}/gef.py').read(); print(x.decode('utf-8'))" > ${HOME}/.gef-${tag}.py
+tag=$(python3 -X utf8 -c 'import urllib.request as r,json as j; x=j.loads(r.urlopen("https://api.github.com/repos/hugsy/gef/tags").read()); print(x[0]["name"])')
+python3 -X utf8 -c "import urllib.request as r; x=r.urlopen('https://github.com/hugsy/gef/raw/${tag}/gef.py').read(); print(x.decode('utf-8'))" > ${HOME}/.gef-${tag}.py
 
 if [ -f "${HOME}/.gef-${tag}.py" ]; then
     echo "source ~/.gef-${tag}.py" > ~/.gdbinit


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->
To make python  using UTF-8 when outputting to the pipe
<!-- Why is this change required? What problem does it solve? -->
Some users in Asian regions using non-ASCII languages may encounter issues when installing GEF with mys2 on Windows. The error message might be: "UnicodeEncodeError: 'gbk' codec can't encode character '\u21b3' in position 5137: illegal multibyte sequence." The reason is that Python is not using UTF-8 when outputting to the pipe, so the -x parameter needs to be added.
<!-- Why is this patch will make a better world? -->
Make installation easier
<!-- How does this look? Add a screenshot if you can -->
![image](https://github.com/user-attachments/assets/80254b9d-803d-494a-b10c-35875c9f1c06)

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
