### PR TITLE
fixed color swap between heap/stack

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -8950,8 +8950,8 @@ class VMMapCommand(GenericCommand):
 
     def show_legend(self) -> None:
         code_title = Color.colorify("Code", gef.config["theme.address_code"])
-        stack_title = Color.colorify("Heap", gef.config["theme.address_stack"])
-        heap_title = Color.colorify("Stack", gef.config["theme.address_heap"])
+        stack_title = Color.colorify("Stack", gef.config["theme.address_stack"])
+        heap_title = Color.colorify("Heap", gef.config["theme.address_heap"])
         gef_print(f"[ Legend:  {code_title} | {stack_title} | {heap_title} ]")
         return
 


### PR DESCRIPTION
## Description

There is a bug in how stack/heap addresses colors are shown in gdb using the `vmmap` command. This patch fixes it:

### Before:

![image](https://github.com/user-attachments/assets/68561278-99dc-44c2-95e5-6200f15d6f93)

### After:

![image](https://github.com/user-attachments/assets/b606b273-ff1d-4735-a320-00c2367d2b2a)

## Checklist

-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
