### PR TITLE
Use shutil when looking for executables on the host system

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1936,13 +1936,11 @@ def gef_pybytes(x: str) -> bytes:
 @lru_cache()
 def which(program: str) -> pathlib.Path:
     """Locate a command on the filesystem."""
-    for path in os.environ["PATH"].split(os.pathsep):
-        dirname = pathlib.Path(path)
-        fpath = dirname / program
-        if os.access(fpath, os.X_OK):
-            return fpath
-
-    raise FileNotFoundError(f"Missing file `{program}`")
+    path = shutil.which(program)
+    if path:
+        return pathlib.Path(path)
+    else:
+        raise FileNotFoundError(f"Missing file `{program}`")
 
 
 def style_byte(b: int, color: bool = True) -> str:

--- a/gef.py
+++ b/gef.py
@@ -1936,10 +1936,10 @@ def gef_pybytes(x: str) -> bytes:
 @lru_cache()
 def which(program: str) -> pathlib.Path:
     """Locate a command on the filesystem."""
-    try:
-        return pathlib.Path(shutil.which(program))
-    except TypeError:
+    res = shutil.which(program)
+    if not res:
         raise FileNotFoundError(f"Missing file `{program}`")
+    return pathlib.Path(res)
 
 
 def style_byte(b: int, color: bool = True) -> str:

--- a/gef.py
+++ b/gef.py
@@ -1936,10 +1936,9 @@ def gef_pybytes(x: str) -> bytes:
 @lru_cache()
 def which(program: str) -> pathlib.Path:
     """Locate a command on the filesystem."""
-    path = shutil.which(program)
-    if path:
-        return pathlib.Path(path)
-    else:
+    try:
+        return pathlib.Path(shutil.which(program))
+    except TypeError:
         raise FileNotFoundError(f"Missing file `{program}`")
 
 


### PR DESCRIPTION
## Description

The implementation of the `which` function only checks for the executable flag on paths, which means it can return a directory (at least on POSIX), causing weird permission errors down the line. It should instead defer to `shutil.which`; that function contains a platform-agnostic implementation that should hopefully match the behavior of the GNU `which` utility.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
