### PR TITLE
Prevent duplicate panes in `context.layout`

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -10038,13 +10038,13 @@ class GefCommand(gdb.Command):
 
     def add_context_pane(self, pane_name: str, display_pane_function: Callable, pane_title_function: Callable, condition: Optional[Callable]) -> None:
         """Add a new context pane to ContextCommand."""
-        context = self.commands["context"]
-        assert isinstance(context, ContextCommand)
-
         # assure users can toggle the new context
         corrected_settings_name: str = pane_name.replace(" ", "_")
-        gef.config["context.layout"] += f" {corrected_settings_name}"
+        if corrected_settings_name in gef.config["context.layout"]:
+            warn(f"Duplicate name for `{pane_name}` (`{corrected_settings_name}`), skipping")
+            return
 
+        gef.config["context.layout"] += f" {corrected_settings_name}"
         self.add_context_layout_mapping(corrected_settings_name, display_pane_function, pane_title_function, condition)
 
     def load(self) -> None:

--- a/tests/commands/context.py
+++ b/tests/commands/context.py
@@ -13,4 +13,25 @@ class ContextCommand(RemoteGefUnitTestGeneric):
     cmd = "context"
 
 
-    # See https://github.com/hugsy/gef/projects/10
+    # TODO See https://github.com/hugsy/gef/projects/10
+
+    def test_duplicate_pane_name(self):
+        # Make sure we cannot have 2 context panes with an identical identifier
+        # See #1145 , #1153
+        gdb = self._gdb
+        gef = self._gef
+
+        new_pane_id = "new_pane1"
+        current_layout = gef.config["context.layout"]
+        assert not current_layout.endswith(new_pane_id)
+
+        res = gdb.execute(f"pi register_external_context_pane('{new_pane_id}', print, print, None)", to_string=True)
+        assert "Python Exception" not in res
+        new_layout = gef.config["context.layout"]
+        assert new_layout.endswith(new_pane_id)
+
+        res = gdb.execute(f"pi register_external_context_pane('{new_pane_id}', print, print, None)", to_string=True)
+        assert "Python Exception" not in res
+        new_layout2 = gef.config["context.layout"]
+        assert new_layout == new_layout2
+        assert f"Duplicate name for `{new_pane_id}`" in res


### PR DESCRIPTION
## Description

Make sure panes added in `context.layout` have a unique name

Fixes #1145


