### PR TITLE
fix enum.Flag empty check

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -678,13 +678,13 @@ class Section:
         return
 
     def is_readable(self) -> bool:
-        return (self.permission & Permission.READ) != 0
+        return bool(self.permission & Permission.READ)
 
     def is_writable(self) -> bool:
-        return (self.permission & Permission.WRITE) != 0
+        return bool(self.permission & Permission.WRITE)
 
     def is_executable(self) -> bool:
-        return (self.permission & Permission.EXECUTE) != 0
+        return bool(self.permission & Permission.EXECUTE)
 
     @property
     def size(self) -> int:


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->
Fix the permission checks in `Section` by using [enum.Flag.\_\_bool\_\_](https://docs.python.org/3/library/enum.html#enum.Flag). For `enum.Flag`, != 0 always returns `True`, as the test below.
```python
import enum

class Permission(enum.Flag):
    NONE = 0
    EXECUTE = 1
    WRITE = 2
    READ = 4
    ALL = 7

p = Permission(0)
print(p, p != 0)  # Permission.NONE True
```

The fixed functions are rarely called. I found this when porting `Section` to [llef](https://github.com/foundryzero/llef). I also have checked all  `!= 0` and found no similar error.

<!-- Why is this change required? What problem does it solve? -->

<!-- Why is this patch will make a better world? -->

<!-- How does this look? Add a screenshot if you can -->

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
