### PR TITLE
Always print top chunk when run `heap chunks -a`

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6718,6 +6718,7 @@ class GlibcHeapChunksCommand(GenericCommand):
         nb = self["peek_nb_byte"]
         chunk_iterator = GlibcChunk(start, from_base=True, allow_unaligned=ctx.allow_unaligned)
         heap_summary = GlibcHeapArenaSummary(resolve_type=ctx.resolve_type)
+        top_printed = False
         for chunk in chunk_iterator:
             heap_corrupted = chunk.base_address > end
             should_process = self.should_process_chunk(chunk, ctx)
@@ -6726,6 +6727,8 @@ class GlibcHeapChunksCommand(GenericCommand):
                 if should_process:
                     gef_print(
                         f"{chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
+
+                top_printed = True
                 break
 
             if heap_corrupted:
@@ -6748,6 +6751,9 @@ class GlibcHeapChunksCommand(GenericCommand):
 
             ctx.remaining_chunk_count -= 1
 
+        if not top_printed and ctx.print_arena:
+            top_chunk =  GlibcChunk(arena.top, from_base=True, allow_unaligned=ctx.allow_unaligned)
+            gef_print(f"{top_chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
         if ctx.summary:
             heap_summary.print()
 

--- a/gef.py
+++ b/gef.py
@@ -6696,7 +6696,7 @@ class GlibcHeapChunksCommand(GenericCommand):
             arena = GlibcArena(f"*{arena_addr:#x}")
             self.dump_chunks_arena(arena, ctx)
         except gdb.error as e:
-            err(f"Invalid arena: {e} \nArena Address: {args.arena_address}")
+            err(f"Invalid arena: {e}\nArena Address: {args.arena_address}")
             return
 
     def dump_chunks_arena(self, arena: GlibcArena, ctx: GlibcHeapWalkContext) -> None:

--- a/gef.py
+++ b/gef.py
@@ -6690,11 +6690,13 @@ class GlibcHeapChunksCommand(GenericCommand):
                 if not args.all:
                     return
         try:
+            if not args.arena_address or args.arena_address == "":
+                return
             arena_addr = parse_address(args.arena_address)
             arena = GlibcArena(f"*{arena_addr:#x}")
             self.dump_chunks_arena(arena, ctx)
-        except gdb.error:
-            err("Invalid arena")
+        except gdb.error as e:
+            err("Invalid arena: {} \nArena Address: {}".format(e, args.arena_address))
             return
 
     def dump_chunks_arena(self, arena: GlibcArena, ctx: GlibcHeapWalkContext) -> None:

--- a/gef.py
+++ b/gef.py
@@ -6696,7 +6696,7 @@ class GlibcHeapChunksCommand(GenericCommand):
             arena = GlibcArena(f"*{arena_addr:#x}")
             self.dump_chunks_arena(arena, ctx)
         except gdb.error as e:
-            err("Invalid arena: {} \nArena Address: {}".format(e, args.arena_address))
+            err(f"Invalid arena: {e} \nArena Address: {args.arena_address}")
             return
 
     def dump_chunks_arena(self, arena: GlibcArena, ctx: GlibcHeapWalkContext) -> None:

--- a/gef.py
+++ b/gef.py
@@ -6729,7 +6729,6 @@ class GlibcHeapChunksCommand(GenericCommand):
                 if should_process:
                     gef_print(
                         f"{chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
-
                 top_printed = True
                 break
 

--- a/gef.py
+++ b/gef.py
@@ -6755,6 +6755,7 @@ class GlibcHeapChunksCommand(GenericCommand):
         if not top_printed and ctx.print_arena:
             top_chunk =  GlibcChunk(arena.top, from_base=True, allow_unaligned=ctx.allow_unaligned)
             gef_print(f"{top_chunk!s} {LEFT_ARROW} {Color.greenify('top chunk')}")
+
         if ctx.summary:
             heap_summary.print()
 

--- a/gef.py
+++ b/gef.py
@@ -6690,7 +6690,7 @@ class GlibcHeapChunksCommand(GenericCommand):
                 if not args.all:
                     return
         try:
-            if not args.arena_address or args.arena_address == "":
+            if not args.arena_address:
                 return
             arena_addr = parse_address(args.arena_address)
             arena = GlibcArena(f"*{arena_addr:#x}")


### PR DESCRIPTION
## Description

Test case: https://github.com/shellphish/how2heap/blob/master/glibc_2.39/house_of_tangerine.c

Top chunk cannot be printed after it's size changed, pero top chunk always access by `arena.top`, it should always been printed ever with a malform size.


## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
