### PR TITLE
Use the correct type for function passed to pthread_create.

### DIFF
--- a/tests/binaries/heap-multiple-heaps.c
+++ b/tests/binaries/heap-multiple-heaps.c
@@ -21,7 +21,7 @@
 /* The expected distance is the chunk size plus room for the metadata. */
 #define EXPECTED_CHUNK_DISTANCE     LESS_THAN_MMAP_THRESHOLD + 24
 
-void *thread()
+void *thread(void *arg)
 {
         void *pointers[NUM_ALLOCS];
         for (int i = 0; i < NUM_ALLOCS; i++) {

--- a/tests/binaries/heap-non-main.c
+++ b/tests/binaries/heap-non-main.c
@@ -8,7 +8,7 @@
 #include <pthread.h>
 #include "utils.h"
 
-void *thread()
+void *thread(void *arg)
 {
         void* p1 = malloc(0x18);
         void* p2 = malloc(0x18);


### PR DESCRIPTION
## Description

This patch modifies the `thread` function in two test files, so that it matches the expected prototype for an argument to pthread_create.  This fixes a build failure with gcc 15:

```
heap-non-main.c: In function ‘main’:
heap-non-main.c:27:40: error: passing argument 3 of ‘pthread_create’ from incompatible pointer type [-Wincompatible-pointer-types]
   27 |         pthread_create(&thread1, NULL, thread, NULL);
      |                                        ^~~~~~
      |                                        |
      |                                        void * (*)(void)
In file included from heap-non-main.c:8:
/usr/include/pthread.h:204:36: note: expected ‘void * (*)(void *)’ but argument is of type ‘void * (*)(void)’
  204 |                            void *(*__start_routine) (void *),
      |                            ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
heap-non-main.c:11:7: note: ‘thread’ declared here
   11 | void *thread()
      |       ^~~~~~
```

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
