### PR TITLE
Add a path argument to GotCommand build_line to support hugsy/gef-extras/pull/122

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -9447,7 +9447,7 @@ class GotCommand(GenericCommand):
                                          "Line color of the got command output for unresolved function")
         return
 
-    def build_line(self, name: str, color: str, address_val: int, got_address: int) -> str:
+    def build_line(self, name: str, _path: str, color: str, address_val: int, got_address: int) -> str:
         line = f"[{hex(address_val)}] "
         line += Color.colorify(f"{name} {RIGHT_ARROW} {hex(got_address)}", color)
         return line
@@ -9517,7 +9517,7 @@ class GotCommand(GenericCommand):
             else:
                 color = self["function_resolved"]
 
-            line = self.build_line(name, color, address_val, got_address)
+            line = self.build_line(name, elf_virtual_path, color, address_val, got_address)
             gef_print(line)
         return
 


### PR DESCRIPTION
Add a path argument to GotCommand build_line to support updates in GotAudit.

Related changes in hugsy/gef-extras/pull/122

## Description

In order to reduce false positives in GotAudit, the build_line function requires the path to the file whose symbols are being described.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
