### PR TITLE
Setup fallback 'debug-file-directory'

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -11862,8 +11862,8 @@ if __name__ == "__main__":
             newpath = f"{dbgsym_paths}:" if dbgsym_paths else ""
             newpath += default_dbgsym_path
             gdb.execute(f"set {param_name} {newpath}")
-    except gdb.error:
-        pass
+    except gdb.error as e:
+        warn(f"Failed to set {param_name}, reason: {str(e)}")
 
     # load GEF, set up the managers and load the plugins, functions,
     gef = Gef()

--- a/gef.py
+++ b/gef.py
@@ -11853,6 +11853,18 @@ if __name__ == "__main__":
         except gdb.error:
             pass
 
+    # set fallback 'debug-file-directory' for gdbs that installed outside `/usr`.
+    try:
+        default_dbgsym_path = "/usr/lib/debug"
+        param_name = "debug-file-directory"
+        dbgsym_paths = gdb.parameter(param_name)
+        if default_dbgsym_path not in dbgsym_paths:
+            newpath = f"{dbgsym_paths}:" if dbgsym_paths else ""
+            newpath += default_dbgsym_path
+            gdb.execute(f"set {param_name} {newpath}")
+    except gdb.error:
+        pass
+
     # load GEF, set up the managers and load the plugins, functions,
     gef = Gef()
     reset()


### PR DESCRIPTION
## Description

<!-- Describe technically what your patch does. -->
This PR adds fallback path `/usr/lib/debug` to `debug-file-directory` config.
Closes #1169.

<!-- Why is this change required? What problem does it solve? -->
Some gdbs installed outside `/usr` (like nix or in user homedir) will not search
for dbgsyms in `/usr/lib/debug`. However `/us/lib/debug` is where most distros
package debuginfo symbols to.

<!-- Why is this patch will make a better world? -->

<!-- How does this look? Add a screenshot if you can -->
### Before
```console
> /run/workspace/bin/gdb -q -x .gef.py -ex 'show debug-file-directory' -ex 'quit'
The directory where separate debug symbols are searched for is "/nix/store/k51rfv38p65jbhw906vpl85yg1vd7xqn-gdb-15.2/lib/debug".
```
### After 
```console
> /run/workspace/bin/gdb -q -x .gef.py -ex 'show debug-file-directory' -ex 'quit'
The directory where separate debug symbols are searched for is "/nix/store/k51rfv38p65jbhw906vpl85yg1vd7xqn-gdb-15.2/lib/debug:/usr/lib/debug".

```

<!-- Annotate your PR with label proper labels (architecture impacted, type of improvement,
etc.) ->

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [ ] My change includes a change to the documentation, if required.
-  [ ] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [X] I have read and agree to the **CONTRIBUTING** document.
