### PR TITLE
Verify `gdb.parameter("debug-file"directory")` returns a string

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -11858,6 +11858,8 @@ if __name__ == "__main__":
         default_dbgsym_path = "/usr/lib/debug"
         param_name = "debug-file-directory"
         dbgsym_paths = gdb.parameter(param_name)
+        if not isinstance(dbgsym_paths, str):
+            raise TypeError
         if default_dbgsym_path not in dbgsym_paths:
             newpath = f"{dbgsym_paths}:" if dbgsym_paths else ""
             newpath += default_dbgsym_path


### PR DESCRIPTION
## Description

This PR fixes  a missing type check introduced by #1173 when getting result from `gdb.parameter` while setting ` debug-file-directory` 

## Checklist

-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
