### PR TITLE
Fix location of syscall-tables for gef-extras installation script

### DIFF
--- a/scripts/gef-extras.sh
+++ b/scripts/gef-extras.sh
@@ -42,7 +42,7 @@ gdb -q -ex "pi gef.config['context.layout'] += ' syscall_args'" \
        -ex "pi gef.config['context.layout'] += ' libc_function_args'" \
        -ex "gef config gef.extra_plugins_dir '${DIR}/scripts'" \
        -ex "gef config pcustom.struct_path '${DIR}/structs'" \
-       -ex "gef config syscall-args.path '${DIR}/syscall-tables'" \
+       -ex "gef config syscall-args.path '${DIR}/scripts/syscall_args/syscall-tables'" \
        -ex "gef config context.libc_args True" \
        -ex "gef config context.libc_args_path '${DIR}/glibc-function-args'" \
        -ex 'gef save' \


### PR DESCRIPTION
## Description

Fix location of syscall-tables for gef-extras installation script.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
