### PR TITLE
Fix name_break for current location and add tests

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -7584,13 +7584,20 @@ class NamedBreakpointCommand(GenericCommand):
         super().__init__()
         return
 
-    @parse_arguments({"name": "", "address": "*$pc"}, {})
+    @parse_arguments({"name": "", "address": ""}, {})
     def do_invoke(self, _: list[str], **kwargs: Any) -> None:
         args : argparse.Namespace = kwargs["arguments"]
         if not args.name:
             err("Missing name for breakpoint")
             self.usage()
             return
+
+        if not args.address:
+            if not is_alive():
+                err("No debugging session active")
+                return
+
+            args.address = "*{}".format(hex(int(gdb.parse_and_eval("*$pc").address)))
 
         NamedBreakpoint(args.address, args.name)
         return

--- a/tests/commands/name_break.py
+++ b/tests/commands/name_break.py
@@ -9,12 +9,70 @@ from tests.base import RemoteGefUnitTestGeneric
 class NameBreakCommand(RemoteGefUnitTestGeneric):
     """`name-break` command test module"""
 
-    def test_cmd_name_break(self):
+    def test_cmd_name_break_no_args(self):
         gdb = self._gdb
-        gdb.execute("start")
-        res = gdb.execute("nb foobar *main+10", to_string=True)
-        res = gdb.execute("nb foobar *0xcafebabe", to_string=True)
-        self.assertIn("at 0xcafebabe", res)
+        res = gdb.execute("nb", to_string=True)
+        self.assertIn("Missing name", res)
 
-        res = gdb.execute("start")
-        gdb.execute("nb foobar", to_string=True)
+    def test_cmd_name_break_no_session(self):
+        gdb = self._gdb
+        res = gdb.execute("nb foobar", to_string=True)
+        self.assertIn("No debugging session active", res)
+
+    def test_cmd_name_break_address(self):
+        gdb = self._gdb
+
+        # get address of main
+        gdb.execute("b main")
+        gdb.execute("run")
+
+        main_address = gdb.execute("p/x $pc", to_string=True).strip().split()[-1]
+
+        gdb.execute("delete")
+        gdb.execute("stop")
+
+        # set named breakpoint at main address
+        res = gdb.execute(f"nb foobar *{main_address}", to_string=True)
+        self.assertIn(f"at {main_address}", res)
+
+        gdb.execute("run")
+
+        # verify correct address is hit
+        current_address = gdb.execute("p/x $pc", to_string=True).strip().split()[-1]
+        self.assertEqual(main_address, current_address, f"Expected breakpoint at {main_address}, got {current_address}")
+
+    def test_cmd_name_break_symbol_offset(self):
+        gdb = self._gdb
+
+        # get address of main+8
+        gdb.execute("start")
+
+        main_offset_address = gdb.execute("p/x *main+8", to_string=True).strip().split()[-1]
+
+        # set named breakpoint at main+8 address
+        res = gdb.execute(f"nb foobar *main+8", to_string=True)
+
+        self.assertIn(f"at {main_offset_address}", res)
+
+    def test_cmd_name_break_current_location(self):
+        gdb = self._gdb
+
+        # run until main
+        gdb.execute("b main")
+        gdb.execute("run")
+
+        main_address = gdb.execute("p/x $pc", to_string=True).strip().split()[-1]
+
+        # remove gdb breakpoint and set a named breakpoint at current location
+        gdb.execute("delete")
+
+        res = gdb.execute("nb foobar", to_string=True)
+
+        self.assertIn(f"at {main_address}", res)
+
+        # restart the process and ensure correct breakpoint is hit
+        gdb.execute("run")
+
+        current_address = gdb.execute("p/x $pc", to_string=True).strip().split()[-1]
+
+        self.assertEqual(main_address, current_address, f"Expected breakpoint at {main_address}, got {current_address}")


### PR DESCRIPTION
## Description

Fix for using `name-break` without specifying an address (which should just set the breakpoint at current `pc`). 
Also adding more thorough tests to check the different usages work.

With the current implementation, when setting a named breakpoint without specifying a location, the location will be set to `*$pc`. When reattaching to a process, the location of breakpoints gets re-evaluated, which results in all named breakpoints being changed to the current `pc` when attaching.

The fix will evaluate the location on set now, when no address argument is given and set the breakpoint with a specific address.

## Checklist

-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
