### PR TITLE
Fix heap bins tcache from accessing invalid addresses on glibc 2.42

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6981,6 +6981,11 @@ class GlibcHeapTcachebinsCommand(GenericCommand):
             count = u16(gef.memory.read(tcache_base + tcache_count_size*i, 2))
 
         chunk = dereference(tcache_base + tcache_count_size*self.TCACHE_MAX_BINS + i*gef.arch.ptrsize)
+
+        # Real heap chunk pointers are always ptrsize-aligned, so we check
+        # the alignment to prevent following invalid addresses.
+        if chunk and (int(chunk) & (gef.arch.ptrsize - 1)):
+            return None, count
         chunk = GlibcTcacheChunk(int(chunk)) if chunk else None
         return chunk, count
 


### PR DESCRIPTION
## Description

Fix for heap bins tcache accessing invalid addresses on glibc 2.42.
Also adding a sanity check to ensure only properly aligned tcache entry pointers are traversed.

With the current implementation, when parsing tcache bins, corrupted values in the entry array (e.g. 0x7000…) can be misinterpreted as valid pointers. This causes gdb to dereference invalid memory and the command fails.

The fix adds a simple ptrsize-alignment check before constructing a GlibcTcacheChunk. 
Since real heap chunk pointers are always ptrsize-aligned, this prevents mis-parsing and avoids invalid memory accesses without affecting normal behavior.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
