### PR TITLE
only allow big|small as 2nd arg in search-pattern

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -6175,8 +6175,13 @@ class SearchPatternCommand(GenericCommand):
         endian = gef.arch.endianness
 
         if argc >= 2:
-            if argv[1].lower() == "big": endian = Endianness.BIG_ENDIAN
-            elif argv[1].lower() == "little": endian = Endianness.LITTLE_ENDIAN
+            if argv[1].lower() == "big":
+                endian = Endianness.BIG_ENDIAN
+            elif argv[1].lower() == "little":
+                endian = Endianness.LITTLE_ENDIAN
+            else: 
+                self.usage()
+                return
 
         if is_hex(pattern):
             if endian == Endianness.BIG_ENDIAN:


### PR DESCRIPTION
## Description
What patch does: If not required parameters is passed in `search-pattern` it will return the usage information. `search-pattern PATTERN [little|big] [section]`

Previously the options are slightly confusing with two optional arguments and no sanitize checks for `big|endian`
For example 
`search-pattern 0x41414141 heap` would be evalutated to `search-pattern 0x41414141 little`

## Checklist
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
