### PR TITLE
gef.sh: warn about XDG init file taking precedence

### DIFF
--- a/scripts/gef.sh
+++ b/scripts/gef.sh
@@ -20,8 +20,10 @@ fi
 
 # Backup gdbinit if any
 if [ -f "${target_init}" ] && [ -s "${target_init}" ]; then
-    cp "${target_init}" "${target_init}.old"
-    echo "[*] Existing gdbinit saved as ${target_init}.old"
+    timestamp=$(date +%Y%m%d_%H%M%S)
+    backup_file="${target_init}_${timestamp}.old"
+    cp "${target_init}" "${backup_file}"
+    echo "[*] Existing gdbinit saved as ${backup_file}"
 else
     touch "${target_init}"
 fi


### PR DESCRIPTION
## description

On some systems, GDB may read the XDG init file (`~/.config/gdb/gdbinit`) instead of `~/.gdbinit`.
In that case, the installer updates `~/.gdbinit` correctly, but GEF still won’t auto-load on `gdb` startup, which is confusing for users.

This PR adds a minimal post-install hint: if `~/.config/gdb/gdbinit` exists, print a note telling users to add `source ~/.gef-<tag>.py` to that file if GEF doesn't auto-load.

## References
> On non-Apple hosts the locations searched are:
> 
> $XDG_CONFIG_HOME/gdb/gdbinit
> $HOME/.config/gdb/gdbinit
> $HOME/.gdbinit
> While on Apple hosts the locations searched are:
>
> $HOME/Library/Preferences/gdb/gdbinit
> $HOME/.gdbinit

https://sourceware.org/gdb/current/onlinedocs/gdb.html/Initialization-Files.html#Home-directory-initialization-files