### PR TITLE
Fix TIOCGWINSZ struct size mismatch

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -3796,7 +3796,7 @@ def get_terminal_size() -> tuple[int, int]:
         import fcntl
         import termios
         try:
-            tty_rows, tty_columns = struct.unpack("hh", fcntl.ioctl(1, termios.TIOCGWINSZ, "1234")) # type: ignore
+            tty_rows, tty_columns, _, _ = struct.unpack("hhhh", fcntl.ioctl(1, termios.TIOCGWINSZ, "12345678")) # type: ignore
             return tty_rows, tty_columns
         except OSError:
             return 600, 100


### PR DESCRIPTION
A buffer the size of `struct winsize` should be passed to the TIOCGWINSZ ioctl. The size of the winsize struct is 8 bytes (see https://man7.org/linux/man-pages/man2/TIOCSWINSZ.2const.html), but a 4-bytes buffer was passed, which caused a BOF.

## Description

The patch fixes a BOF which caused a crash in some newer python environments.

Fixes #1201 

## Checklist

-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
