### PR TITLE
[Docs] Fix broken image paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/images/logo.png" alt="logo"/>
+  <img src="docs/assets/images/logo.png" alt="logo"/>
 </p>
 
 <p align="center">
@@ -39,7 +39,7 @@ $ gdb -q
 
 You can immediately see that GEF is correctly installed by launching GDB:
 
-![gef-context](assets/images/gef-context.png)
+![gef-context](docs/assets/images/gef-context.png)
 
 A few of `GEF` features include:
 

--- a/docs/commands/canary.md
+++ b/docs/commands/canary.md
@@ -10,4 +10,4 @@ The command `canary` does not take any arguments.
 gef➤ canary
 ```
 
-![gef-canary](assets/images/gef-canary.png)
+![gef-canary](docs/assets/images/gef-canary.png)

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -10,7 +10,7 @@ To view all settings for all commands loaded:
 gef➤  gef config
 ```
 
-![gef-config](assets/images/gef-config.png)
+![gef-config](docs/assets/images/gef-config.png)
 
 Or to get one setting value:
 

--- a/docs/commands/context.md
+++ b/docs/commands/context.md
@@ -1,6 +1,6 @@
 ## Command `context`
 
-![gef-context](assets/images/gef-context.png)
+![gef-context](docs/assets/images/gef-context.png)
 
 `gef` (not unlike `PEDA` or `fG! famous gdbinit`) provides comprehensive context menu when hitting a
 breakpoint.
@@ -123,7 +123,7 @@ gef➤ gef config context.redirect /dev/pts/0
 ```
 
 Enjoy:
-![gef-context-redirect-section](assets/images/gef-context-redirect-section.png)
+![gef-context-redirect-section](docs/assets/images/gef-context-redirect-section.png)
 
 To go back to normal, remove the value:
 

--- a/docs/commands/edit-flags.md
+++ b/docs/commands/edit-flags.md
@@ -20,4 +20,4 @@ instruction), but we want to have the Carry flag set, simply go with:
 gef➤ flags -ZERO +CARRY
 ```
 
-![flags](assets/images/flags.png)
+![flags](docs/assets/images/flags.png)

--- a/docs/commands/entry-break.md
+++ b/docs/commands/entry-break.md
@@ -12,4 +12,4 @@ It will perform the following actions:
    header, set a breakpoint and run. This case should never fail if the ELF binary has a valid
    structure.
 
-![entry-break-example](assets/images/entry-break-example.png)
+![entry-break-example](docs/assets/images/entry-break-example.png)

--- a/docs/commands/format-string-helper.md
+++ b/docs/commands/format-string-helper.md
@@ -28,4 +28,4 @@ gef➤ r
 If a potentially insecure entry is found, the breakpoint will trigger, stop the process execution,
 display the reason for trigger and the associated context.
 
-![fmtstr-helper-example](assets/images/fmtstr-helper-example.png)
+![fmtstr-helper-example](docs/assets/images/fmtstr-helper-example.png)

--- a/docs/commands/gef-remote.md
+++ b/docs/commands/gef-remote.md
@@ -38,7 +38,7 @@ Process /tmp/default.out created; pid = 258932
 Listening on port 1234
 ```
 
-![gef-remote-1](assets/images/gef-remote-1.png)
+![gef-remote-1](docs/assets/images/gef-remote-1.png)
 
 On the client, when the original `gdb` would use `target remote`, GEF's syntax is roughly similar
 (shown running in debug mode for more verbose output, but you don't have to):
@@ -75,12 +75,12 @@ Reading /lib64/ld-linux-x86-64.so.2 from remote target...
 
 And finally breaking into the program, showing the current context:
 
-![gef-remote](assets/images/gef-remote.png)
+![gef-remote](docs/assets/images/gef-remote.png)
 
 You will also notice the prompt has changed to indicate the debugging mode is now "remote". Besides
 that, all of GEF features are available:
 
-![gef-remote-command](assets/images/gef-remote-command.png)
+![gef-remote-command](docs/assets/images/gef-remote-command.png)
 
 #### `remote-extended`
 

--- a/docs/commands/got.md
+++ b/docs/commands/got.md
@@ -11,7 +11,7 @@ gef➤ got [--all] [filters]
 
 `--all` Print the GOT for all shared objects in addition to the executable file
 
-![gef-got](assets/images/gef-got.png)
+![gef-got](docs/assets/images/gef-got.png)
 
 The applied filter partially matches the name of the functions, so you can do something like this.
 
@@ -21,7 +21,7 @@ gef➤ got print
 gef➤ got read
 ```
 
-![gef-got-one-filter](assets/images/gef-got-one-filter.png)
+![gef-got-one-filter](docs/assets/images/gef-got-one-filter.png)
 
 Example of multiple partial filters:
 
@@ -29,7 +29,7 @@ Example of multiple partial filters:
 gef➤ got str get
 ```
 
-![gef-got-multi-filter](assets/images/gef-got-multi-filter.png)
+![gef-got-multi-filter](docs/assets/images/gef-got-multi-filter.png)
 
 ```text
 gef➤ got --all str get

--- a/docs/commands/heap-analysis-helper.md
+++ b/docs/commands/heap-analysis-helper.md
@@ -33,12 +33,12 @@ The following settings are accepted:
 -  `check_null_free`: to break execution when a free(NULL) is encountered (disabled by default);
 -  `check_double_free`: to break execution when a double free is encountered;
 
-![double-free](assets/images/double-free.png)
+![double-free](docs/assets/images/double-free.png)
 
 -  `check_weird_free`: to execution when `free()` is called against a non-tracked pointer;
 -  `check_uaf`: to break execution when a possible Use-after-Free condition is found.
 
-![uaf](assets/images/uaf.png)
+![uaf](docs/assets/images/uaf.png)
 
 Just like the format string vulnerability helper, the `heap-analysis-helper` can fail to detect
 complex heap scenarios and/or provide some false positive alerts. Each finding must of course be
@@ -57,7 +57,7 @@ gef➤  gef config heap-analysis-helper.check_uaf False
 Then `gef` will not notify you of any inconsistency detected, but simply display a clear message
 when a chunk is allocated/freed.
 
-![heap-track](assets/images/heap-track.png)
+![heap-track](docs/assets/images/heap-track.png)
 
 To get information regarding the currently tracked chunks, use the `show` subcommand:
 
@@ -65,4 +65,4 @@ To get information regarding the currently tracked chunks, use the `show` subcom
 gef➤  heap-analysis-helper show
 ```
 
-![heap-analysis-helper-show](assets/images/heap-analysis-helper-show.png)
+![heap-analysis-helper-show](docs/assets/images/heap-analysis-helper-show.png)

--- a/docs/commands/heap.md
+++ b/docs/commands/heap.md
@@ -46,7 +46,7 @@ Displays all the chunks from the `heap` section of the current arena.
 gef➤ heap chunks
 ```
 
-![heap-chunks](assets/images/heap-chunks.png)
+![heap-chunks](docs/assets/images/heap-chunks.png)
 
 To select from which arena to display chunks either use the `heap set-arena` command or provide the
 base address of the other arena like this:
@@ -55,7 +55,7 @@ base address of the other arena like this:
 gef➤ heap chunks [arena_address]
 ```
 
-![heap-chunks-arena](assets/images/heap-chunks-arena.png)
+![heap-chunks-arena](docs/assets/images/heap-chunks-arena.png)
 
 In order to display the chunks of all the available arenas at once use
 
@@ -63,7 +63,7 @@ In order to display the chunks of all the available arenas at once use
 gef➤ heap chunks -a
 ```
 
-![heap-chunks-all](assets/images/heap-chunks-all.png)
+![heap-chunks-all](docs/assets/images/heap-chunks-all.png)
 
 Because usually the heap chunks are aligned to a certain number of bytes in memory GEF automatically
 re-aligns the chunks data start addresses to match Glibc's behavior. To be able to view unaligned
@@ -76,7 +76,7 @@ To get a higher level overview of the chunks you can use the `--summary` flag to
 gef➤ heap chunks --summary
 ```
 
-![heap-chunks-summary](assets/images/heap-chunks-summary.png)
+![heap-chunks-summary](docs/assets/images/heap-chunks-summary.png)
 
 Sometimes, multiple types of objects could have the same size, hence it might not be enough only
 knowing the chunk size when debugging issues like memory leaks. GEF supports using the vtable to
@@ -87,7 +87,7 @@ with the `--summary` flag.
 gef➤ heap chunks --summary --resolve
 ```
 
-![heap-chunks-summary-resolve](assets/images/heap-chunks-summary-resolve.png)
+![heap-chunks-summary-resolve](docs/assets/images/heap-chunks-summary-resolve.png)
 
 Heap chunk command also supports filtering chunks by their size. To do so, simply provide the
 `--min-size` or `--max-size` argument:
@@ -96,7 +96,7 @@ Heap chunk command also supports filtering chunks by their size. To do so, simpl
 gef➤ heap chunks --min-size 16 --max-size 32
 ```
 
-![heap-chunks-size-filter](assets/images/heap-chunks-size-filter.png)
+![heap-chunks-size-filter](docs/assets/images/heap-chunks-size-filter.png)
 
 The range is inclusive, so the above command will display all chunks with size >=16 and <=32.
 
@@ -107,7 +107,7 @@ of the chunks in the output:
 gef➤ heap chunks --count 1
 ```
 
-![heap-chunks-size-filter](assets/images/heap-chunks-size-filter.png)
+![heap-chunks-size-filter](docs/assets/images/heap-chunks-size-filter.png)
 
 ### `heap chunk` command
 
@@ -118,7 +118,7 @@ the user memory pointer of the chunk to show the information related to a specif
 gef➤ heap chunk [address]
 ```
 
-![heap-chunk](assets/images/heap-chunk.png)
+![heap-chunk](docs/assets/images/heap-chunk.png)
 
 Because usually the heap chunks are aligned to a certain number of bytes in memory GEF automatically
 re-aligns the chunks data start addresses to match Glibc's behavior. To be able to view unaligned
@@ -145,7 +145,7 @@ Multi-threaded programs have different arenas, and the knowledge of the `main_ar
 `gef` therefore provides the `arena` sub-commands to help you list all the arenas allocated in your
 program **at the moment you call the command**.
 
-![heap-arenas](assets/images/heap-arenas.png)
+![heap-arenas](docs/assets/images/heap-arenas.png)
 
 ### `heap set-arena` command
 

--- a/docs/commands/memory.md
+++ b/docs/commands/memory.md
@@ -3,7 +3,7 @@
 As long as the 'memory' section is enabled in your context layout (which it is by default), you can
 register addresses, lengths, and grouping size.
 
-![memory watch](assets/images/memory watch.png)
+![memory watch](docs/assets/images/memory watch.png)
 
 _Note_: this command **should NOT** be mistaken with the [GDB `watch`
 command](https://sourceware.org/gdb/current/onlinedocs/gdb/Set-Watchpoints.html) meant to set
@@ -38,7 +38,7 @@ gef ➤ memory watch $_got()+0x18 5
 
 Which, when the `context` is displayed, will show something like:
 
-![gef-context-memory](assets/images/gef-context-memory.png)
+![gef-context-memory](docs/assets/images/gef-context-memory.png)
 
 ### Removing a watch
 

--- a/docs/commands/pcustom.md
+++ b/docs/commands/pcustom.md
@@ -110,7 +110,7 @@ gef➤  dt person_t
 By providing an address or a GDB symbol, `gef` will apply this user-defined structure to the
 specified address:
 
-![gef-pcustom-with-address](assets/images/gef-pcustom-with-address.png)
+![gef-pcustom-with-address](docs/assets/images/gef-pcustom-with-address.png)
 
 This means that we can now create very easily new user-defined structures
 
@@ -120,7 +120,7 @@ For a full demo, watch the following tutorial:
 
 Additionally, if you have successfully configured your IDA settings, you can also directly import
 the structure(s) that was(were) reverse-engineered in IDA directly in your GDB session:
-![ida-structure-examples](assets/images/ida-structure-examples.png) - (see `gef-extras/ida-rpyc`,
+![ida-structure-examples](docs/assets/images/ida-structure-examples.png) - (see `gef-extras/ida-rpyc`,
 which is the new improved version of `ida-interact`)
 
 #### Dynamic `ctypes.Structure`-like classes

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -29,4 +29,4 @@ gef➤  scan stack libc
 To check mappings without a path associated, an address range (start-end) can be used. Note that
 ranges don't include whitespaces.
 
-![scan-address](assets/images/scan-address.png)
+![scan-address](docs/assets/images/scan-address.png)

--- a/docs/commands/search-pattern.md
+++ b/docs/commands/search-pattern.md
@@ -7,7 +7,7 @@ memory layout. The command `search-pattern`, alias `grep`, aims to be straight-f
 gef➤  search-pattern MyPattern
 ```
 
-![grep](assets/images/grep.png)
+![grep](docs/assets/images/grep.png)
 
 It will provide an easily understandable to spot occurrences of the specified pattern, including the
 section it/they was/were found, and the permission associated to that section.
@@ -19,7 +19,7 @@ starts with `0x` and is a valid hex address. For example:
 gef➤  search-pattern 0x4005f6
 ```
 
-![grep-address](assets/images/grep-address.png)
+![grep-address](docs/assets/images/grep-address.png)
 
 The `search-pattern` command can also be used as a way to search for cross-references to an address.
 For this reason, the alias `xref` also points to the command `search-pattern`.  Therefore the

--- a/docs/commands/stub.md
+++ b/docs/commands/stub.md
@@ -23,8 +23,8 @@ Patching `fork()` calls:
 
 *  Without stub:
 
-![fork execution](assets/images/fork execution.png)
+![fork execution](docs/assets/images/fork execution.png)
 
 *  With stub:
 
-![stubbed fork](assets/images/stubbed fork.png)
+![stubbed fork](docs/assets/images/stubbed fork.png)

--- a/docs/commands/tmux-setup.md
+++ b/docs/commands/tmux-setup.md
@@ -10,7 +10,7 @@ Those commands will check whether GDB is being spawn from inside a `tmux` (resp.
 and if so, will split the pane vertically, and configure the context to be redirected to the new
 pane, looking something like:
 
-![gef-tmux-setup](assets/images/gef-tmux-setup.png)
+![gef-tmux-setup](docs/assets/images/gef-tmux-setup.png)
 
 To set it up, simply enter
 

--- a/docs/commands/trace-run.md
+++ b/docs/commands/trace-run.md
@@ -11,9 +11,9 @@ until the value provided as argument.
 gef> trace-run <address_of_last_instruction_to_trace>
 ```
 
-![trace-run-1](assets/images/trace-run-1.png)
+![trace-run-1](docs/assets/images/trace-run-1.png)
 
 By using the script `ida_color_gdb_trace.py` on the text file generated, it will color the path
 taken:
 
-![trace-run-2](assets/images/trace-run-2.png)
+![trace-run-2](docs/assets/images/trace-run-2.png)

--- a/docs/commands/vmmap.md
+++ b/docs/commands/vmmap.md
@@ -2,7 +2,7 @@
 
 `vmmap` displays the target process's entire memory space mapping.
 
-![vmmap](assets/images/vmmap.png)
+![vmmap](docs/assets/images/vmmap.png)
 
 Interestingly, it helps finding secret gems: as an aware reader might have seen, memory mapping
 differs from one architecture to another (this is one of the main reasons I started `GEF` in a first

--- a/docs/commands/xfiles.md
+++ b/docs/commands/xfiles.md
@@ -4,4 +4,4 @@
 filter by pattern given in argument. For example, if you only want to show the code sections (i.e.
 `.text`):
 
-![xfiles-example](assets/images/xfiles-example.png)
+![xfiles-example](docs/assets/images/xfiles-example.png)

--- a/docs/commands/xinfo.md
+++ b/docs/commands/xinfo.md
@@ -2,7 +2,7 @@
 
 `xinfo` displays all the information known to `gef` about the specific address given as argument:
 
-![xinfo-example](assets/images/xinfo-example.png)
+![xinfo-example](docs/assets/images/xinfo-example.png)
 
 **Important note** : For performance reasons, `gef` caches certain results. `gef` will try to
 automatically refresh its own cache to avoid relying on obsolete information of the debugged

--- a/docs/config.md
+++ b/docs/config.md
@@ -19,7 +19,7 @@ Once in GEF, the configuration settings can be set/unset/modified by the
 [command `gef config`](/docs/commands/config.md). Without argument the command
 will simply dump all known settings:
 
-![gef-config](assets/images/gef-config.png)
+![gef-config](docs/assets/images/gef-config.png)
 
 To update, follow the syntax
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -87,7 +87,7 @@ Some interesting plugins highly recommended too:
 -  [!exploitable](https://github.com/jfoote/exploitable/)
 -  [Voltron](https://github.com/snare/voltron)
 
-![voltron](assets/images/voltron.png)
+![voltron](docs/assets/images/voltron.png)
 Src: [@rick2600: terminator + gdb + gef + voltron cc: @snare @_hugsy_](https://twitter.com/rick2600/status/775926070566490113)
 
 ## I want to contribute, where should I head first?
@@ -107,7 +107,7 @@ unexpected behavior.
 In most locations, Python exceptions will be properly intercepted. If not, `gef` wraps all commands
 with a generic exception handler, to disturb as little as possible your debugging session. If it
 happens, you'll only get to see a message like this:
-![gef-exception](assets/images/gef-exception.png)
+![gef-exception](docs/assets/images/gef-exception.png)
 
 By switching to debug mode, `gef` will give much more information:
 
@@ -115,7 +115,7 @@ By switching to debug mode, `gef` will give much more information:
 gef➤  gef config gef.debug 1
 ```
 
-![gef-debug](assets/images/gef-debug.png)
+![gef-debug](docs/assets/images/gef-debug.png)
 
 If you think fixing it is in your skills, then send a [Pull
 Request](https://github.com/hugsy/gef/pulls) with your patched version, explaining your bug, and

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ process of dynamic analysis and exploit development.
 It requires Python 3, but [`gef-legacy`](https://github.com/hugsy/gef-legacy) can be used if Python
 2 support is needed.
 
-![gef-context](assets/images/gef-context.png)
+![gef-context](docs/assets/images/gef-context.png)
 
 ## GDB Made Easy
 

--- a/docs/obsolete/docs/index.md
+++ b/docs/obsolete/docs/index.md
@@ -5,4 +5,4 @@
 
 ---
 
-![redirect](assets/images/redirect.png)
+![redirect](docs/assets/images/redirect.png)

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -25,51 +25,51 @@ Currently `GEF` supports the following architectures:
 To this day, GDB doesn't come with a hexdump-like view. Well `GEF` fixes that for you via the
 `hexdump` command:
 
-![hexdump](assets/images/hexdump.png)
+![hexdump](docs/assets/images/hexdump.png)
 
 ### Dereferencing data or registers
 
 No more endless manual pointer dereferencing `x/x` style. Just use `dereference` for that. Or for a
 comprehensive view of the registers, `registers` might become your best friend:
 
-![mipsel-deref-regs](assets/images/mipsel-deref-regs.png)
+![mipsel-deref-regs](docs/assets/images/mipsel-deref-regs.png)
 
 ### Heap analysis
 
 #### Detailed view of Glibc Chunks
 
-![x86-heap-chunks](assets/images/x86-heap-chunks.png)
+![x86-heap-chunks](docs/assets/images/x86-heap-chunks.png)
 
 #### Automatic detection of UaF during runtime
 
-![x86-heap-helper-uaf](assets/images/x86-heap-helper-uaf.png)
+![x86-heap-helper-uaf](docs/assets/images/x86-heap-helper-uaf.png)
 
 ### Display ELF information
 
 #### ELF structure
 
-![elf-info](assets/images/elf-info.png)
+![elf-info](docs/assets/images/elf-info.png)
 
 #### Security settings
 
-![elf-checksec](assets/images/elf-checksec.png)
+![elf-checksec](docs/assets/images/elf-checksec.png)
 
 ### Automatic vulnerable string detection
 
-![aarch64-fmtstr](assets/images/aarch64-fmtstr.png)
+![aarch64-fmtstr](docs/assets/images/aarch64-fmtstr.png)
 
 ### Code emulation with Unicorn-Engine (x86-64)
 
-![emu](assets/images/emu.png)
+![emu](docs/assets/images/emu.png)
 
 ### Comprehensive address space layout display
 
-![vmmap](assets/images/vmmap.png)
+![vmmap](docs/assets/images/vmmap.png)
 
 ### Defining arbitrary custom structures
 
-![sparc-arb-struct](assets/images/sparc-arb-struct.png)
+![sparc-arb-struct](docs/assets/images/sparc-arb-struct.png)
 
 ### Highlight custom strings
 
-![highlight-command](assets/images/highlight-command.png)
+![highlight-command](docs/assets/images/highlight-command.png)


### PR DESCRIPTION
## Description

Fixes #1210 by moving image path to `docs/assets/images/` (instead of `assets/images/`)

## Checklist

-  [ ] My code follows the code style of this project.
-  [ ] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [ ] I have read and agree to the **CONTRIBUTING** document.
