### PR TITLE
Fix: malloc_state padding on 32-bit glibc #1202

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -1388,10 +1388,9 @@ class GlibcArena:
         ]
         if gef and gef.libc.version and gef.libc.version >= (2, 27):
             # https://elixir.bootlin.com/glibc/glibc-2.27/source/malloc/malloc.c#L1684
-            fields += [
-                ("have_fastchunks", ctypes.c_uint32),
-                ("UNUSED_c", ctypes.c_uint32), # padding to align to 0x10
-            ]
+            fields += [("have_fastchunks", ctypes.c_uint32)]
+            if gef.arch.ptrsize == 8:
+                fields += [("UNUSED_c", ctypes.c_uint32)]
         fields += [
             ("fastbinsY", GlibcArena.NFASTBINS * pointer),
             ("top", pointer),


### PR DESCRIPTION
issue #1202 fixed

## Description

This patch fixes the `malloc_state` layout used by `GlibcArena.malloc_state_t()` on 32-bit glibc targets.

For glibc 2.27+, GEF currently adds the `UNUSED_c` padding field unconditionally after `have_fastchunks`. That matches the expected alignment on 64-bit targets, but it is incorrect on 32-bit targets such as ARMv7. As a result, the parsed `malloc_state` layout is shifted by 4 bytes, and later fields such as `top`, `last_remainder`, `next`, `system_mem`, and `max_system_mem` are read from incorrect offsets.

In practice, this breaks heap arena parsing on affected targets. For example, `heap arenas` may show an invalid `next` pointer such as `0x0`, fail to walk the arena list correctly, or display corrupted memory statistics such as an invalid `mempeak` value.

This patch makes the padding conditional on pointer size and only inserts `UNUSED_c` on 64-bit targets. This keeps the existing behavior for 64-bit glibc while restoring the correct `malloc_state` layout on 32-bit glibc.

This change is required to make heap arena parsing work correctly on 32-bit ARM systems affected by #1202.

Reproduction environment reported in the issue:

* Debian bookworm
* glibc 2.36
* ARMv7 (32-bit)
* GDB 13.1

Observed behavior before this change:

* `heap arenas` reports an invalid `next` pointer
* arena traversal is broken
* `mempeak` and related fields may contain corrupted values

Expected behavior after this change:

* `heap arenas` parses `malloc_state` using the correct layout on 32-bit targets
* `next` points to the correct arena
* arena traversal works as expected
* memory-related fields are read from the correct offsets

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
-  [x] I have read and agree to the **CONTRIBUTING** document.
