### PR TITLE
Set Gray color as "Bright Black"

### DIFF
--- a/gef.py
+++ b/gef.py
@@ -577,7 +577,7 @@ class Color:
     # \033      ->  Start an ANSI escape code for displaying colors
     colors = {
         "normal": "\001\033[0m\002",
-        "gray": "\001\033[1;38;5;240m\002",
+        "gray": "\001\033[90m\002",
         "light_gray": "\001\033[0;37m\002",
         "red": "\001\033[31m\002",
         "green": "\001\033[32m\002",


### PR DESCRIPTION
## Description

Set Gray color as "Bright Black", judging from [Gentoo's documentation about colors in terminal emulators](https://wiki.gentoo.org/wiki/Terminal_emulator/Colors#Specifying_colors).

This has the nice effect of enabling custom theming of the gray color by the terminal application (e.g., Konsole), so that the gray remains readable with different themes.

## Contribution

-  [x] I have read and agree to the **CONTRIBUTING** document.

## Licensing

-  [ ] The code of this PR contains LLM-generated code.

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
-  [x] My code follows the code style of this project.
-  [x] My change includes a change to the documentation, if required.
-  [x] If my change adds new code, [adequate tests](docs/testing.md) have been added.
